### PR TITLE
[New feature][Windows] Add enable test signing task for Windows VMware tools install

### DIFF
--- a/windows/wintools_complete_install_verify/enable_test_signing.yml
+++ b/windows/wintools_complete_install_verify/enable_test_signing.yml
@@ -1,0 +1,13 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Enable test signing in Windows guest OS for testing on VMware tools
+# containing not MS WHQL signed drivers
+- include_tasks: ../utils/win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: "bcdedit.exe -set TESTSIGNING ON"
+
+- include_tasks: ../utils/win_shutdown_restart.yml
+  vars:
+    set_win_power_state: "restart"
+- include_tasks: ../utils/win_check_winbsod.yml

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -40,6 +40,9 @@
                 - not vmtools_esxi_bundled
                 - vmtools_url_path is defined
                 - vmtools_url_path
+
+            - include_tasks: enable_test_signing.yml
+              when: is_development_tools is defined and is_development_tools | bool
             # Mount VMware tools ISO file to VM
             - include_tasks: vm_mount_vmtools_iso.yml
             # Execute VMware tools installation


### PR DESCRIPTION
Fixes #8 
When testing on the under development VMware tools, which may contain the un-WHQL signed driver, enable test signing in Windows guest OS before install this VMware tools.