### PR TITLE
[Bug][Windows] Modify the timeout value for Windows installation

### DIFF
--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -96,10 +96,10 @@
         - include_tasks: ../../common/vm_wait_network_connected.yml
         - include_tasks: ../../common/vm_get_ip.yml
           vars:
-            vm_get_ip_timeout: 600
+            vm_get_ip_timeout: 1800
         - include_tasks: ../utils/win_check_winrm.yml
           vars:
-            win_check_winrm_timeout: 600
+            win_check_winrm_timeout: 1800
         - name: Wait another 1 minute after OS becomes connectable
           pause:
             minutes: 1


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>

In some slow environment, the Windows OS installation process takes longer than 600s to get the IP address, so here modify this value to 1800s to fit some specific environment or situations.