### PR TITLE
Set ansible_remote_tmp using environment variable when transfer files to ESXi host

### DIFF
--- a/common/add_host_in_memory_inventory.yml
+++ b/common/add_host_in_memory_inventory.yml
@@ -13,7 +13,8 @@
 #   add_host_in_memory_inventory_become_mth (optional),
 #   add_host_in_memory_inventory_become_usr (optional),
 #   add_host_in_memory_inventory_become_pwd (optional),
-#   add_host_in_memory_inventory_ssh_pipeline (optional)
+#   add_host_in_memory_inventory_ssh_pipeline (optional),
+#   add_host_in_memory_inventory_remote_tmp (optional)
 #
 - name: Required host IP address is not given
   fail:
@@ -36,6 +37,7 @@
     ansible_become_user: "{{ add_host_in_memory_inventory_become_usr | default(omit) }}"
     ansible_become_password: "{{ add_host_in_memory_inventory_become_pwd | default(omit) }}"
     ansible_ssh_pipelining: "{{ add_host_in_memory_inventory_ssh_pipeline | default(False) }}"
+    ansible_remote_tmp: "{{ add_host_in_memory_inventory_remote_tmp | default(omit) }}"
   register: add_host_result
 - name: Display the add host result
   debug: var=add_host_result

--- a/common/transfer_file_remote.yml
+++ b/common/transfer_file_remote.yml
@@ -20,8 +20,6 @@
     group: "{{ transfer_file_remote_gp | default(omit) }}"
     mode: "{{ transfer_file_remote_mode | default('0666') }}"
     force: False
-  environment:
-    ANSIBLE_REMOTE_TMP: "{{ remote_tmp_folder | default(omit) }}"
   register: transfer_file_remote_result
   delegate_to: "{{ transfer_file_remote_server }}"
 

--- a/common/transfer_file_remote.yml
+++ b/common/transfer_file_remote.yml
@@ -22,6 +22,8 @@
     force: False
   register: transfer_file_remote_result
   delegate_to: "{{ transfer_file_remote_server }}"
+  environment:
+    ANSIBLE_REMOTE_TMP: "{{ vm_path }}"
 
 - name: Display the result of file transfer
   debug: var=transfer_file_remote_result

--- a/common/transfer_file_remote.yml
+++ b/common/transfer_file_remote.yml
@@ -20,6 +20,8 @@
     group: "{{ transfer_file_remote_gp | default(omit) }}"
     mode: "{{ transfer_file_remote_mode | default('0666') }}"
     force: False
+  environment:
+    ANSIBLE_REMOTE_TMP: "{{ remote_tmp_folder | default(omit) }}"
   register: transfer_file_remote_result
   delegate_to: "{{ transfer_file_remote_server }}"
 

--- a/common/transfer_file_remote.yml
+++ b/common/transfer_file_remote.yml
@@ -22,8 +22,6 @@
     force: False
   register: transfer_file_remote_result
   delegate_to: "{{ transfer_file_remote_server }}"
-  environment:
-    ANSIBLE_REMOTE_TMP: "{{ vm_path }}"
 
 - name: Display the result of file transfer
   debug: var=transfer_file_remote_result

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -58,7 +58,7 @@
     - name: Set fact of the VM files parent path
       set_fact:
         vm_path: "/vmfs/volumes/{{ datastore }}"
-    - name: For test: display the VM files parent path
+    - name: For test display the VM files parent path
       debug: var=vm_path
 
     # Get vCenter and ESXi version info

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -53,6 +53,13 @@
           - vm_exists
         fail_msg: "VM '{{ vm_name }}' doesn't exist. Please set new_vm to True to deploy the VM or provide an existing VM name."
       when: new_vm is undefined or not new_vm | bool
+    
+    # For test
+    - name: Set fact of the VM files parent path
+      set_fact:
+        vm_path: "/vmfs/volumes/{{ datastore }}"
+    - name: For test: display the VM files parent path
+      debug: var=vm_path
 
     # Get vCenter and ESXi version info
     - include_tasks: ../common/vcenter_get_version_build.yml

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -54,12 +54,21 @@
         fail_msg: "VM '{{ vm_name }}' doesn't exist. Please set new_vm to True to deploy the VM or provide an existing VM name."
       when: new_vm is undefined or not new_vm | bool
     
-    # For test
+    # Set VM datastore path directly when creating a new VM
     - name: Set fact of the VM files parent path
       set_fact:
-        vm_path: "/vmfs/volumes/{{ datastore }}"
-    - name: For test display the VM files parent path
-      debug: var=vm_path
+        vm_datastore_path: "/vmfs/volumes/{{ datastore }}"
+      when: new_vm is defined and new_vm | bool
+    # Get VM datatore path when testing on existing VM
+    - block:
+        - include_tasks: ../common/vm_get_guest_facts.yml
+        - name: Set fact of the VM files parent path
+          set_fact:
+            vm_datastore_path: "/vmfs/volumes/{{ vm_guest_facts.instance.hw_datastores[0] }}"
+      when: vm_exists is defined and vm_exists
+
+    - name: Display the datatore path of VM files
+      debug: var=vm_datastore_path
 
     # Get vCenter and ESXi version info
     - include_tasks: ../common/vcenter_get_version_build.yml
@@ -75,6 +84,7 @@
         add_host_in_memory_inventory_pwd: "{{ esxi_password }}"
         add_host_in_memory_inventory_python: "/bin/python"
         add_host_in_memory_inventory_ssh_pipeline: "{{ esxi_ssh_pipeline_enable | default(False) }}"
+        add_host_in_memory_inventory_remote_tmp: "{{ vm_datastore_path }}"
 
     # Enable guest IP hack on ESXi host to get VM IP address when
     # there is no VMware tools installed or VMware tools is not up

--- a/linux/deploy_vm/amazonlinux/reconfigure_amazonlinux_vm.yml
+++ b/linux/deploy_vm/amazonlinux/reconfigure_amazonlinux_vm.yml
@@ -37,7 +37,7 @@
 # Get VM path on ESXi datastore
 - include_tasks: ../../../common/vm_get_config.yml
   vars:
-      property_list: ['config.files.logDirectory']
+    property_list: ['config.files.logDirectory']
 
 - name: "Set VM file path"
   set_fact:

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -8,7 +8,6 @@
 - name: "Set fact of unattend install ISO file name and remote datastore path"
   set_fact:
     unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ iso_timestamp }}.iso"
-# remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: "Set fact of the temp path of generated unattend install ISO file"
   set_fact:
@@ -57,7 +56,7 @@
 
 - name: Set fact of the dest path of unattend install iso on ESXi host
   set_fact:
-    transferred_unattend_iso: "{{ vm_path }}/{{ unattend_iso_file_name }}"
+    transferred_unattend_iso: "{{ vm_datastore_path }}/{{ unattend_iso_file_name }}"
 - name: Print debug message
   debug:
     msg: "Will transfer unattend install iso to: {{ transferred_unattend_iso }}"
@@ -68,7 +67,6 @@
     transfer_file_remote_src: "{{ generated_unattend_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-# ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -66,6 +66,7 @@
     transfer_file_remote_src: "{{ generated_unattend_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
+    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -5,9 +5,11 @@
   set_fact:
     iso_timestamp: "{{ lookup('pipe','date +%s') }}"
 
-- name: "Set fact of the unattend install ISO file name"
+- name: "Set fact of unattend install ISO file name and remote datastore path"
   set_fact:
     unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ iso_timestamp }}.iso"
+    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
+
 - name: "Set fact of the temp path of generated unattend install ISO file"
   set_fact:
     generated_unattend_iso: "/tmp/{{ unattend_iso_file_name }}"
@@ -55,7 +57,7 @@
 
 - name: Set fact of the dest path of unattend install iso on ESXi host
   set_fact:
-    transferred_unattend_iso: "/vmfs/volumes/{{ datastore }}/{{ unattend_iso_file_name }}"
+    transferred_unattend_iso: "{{ remote_datastore_path }}/{{ unattend_iso_file_name }}"
 - name: Print debug message
   debug:
     msg: "Will transfer unattend install iso to: {{ transferred_unattend_iso }}"
@@ -66,7 +68,7 @@
     transfer_file_remote_src: "{{ generated_unattend_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
+    ansible_remote_tmp: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -8,7 +8,7 @@
 - name: "Set fact of unattend install ISO file name and remote datastore path"
   set_fact:
     unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ iso_timestamp }}.iso"
-    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
+# remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: "Set fact of the temp path of generated unattend install ISO file"
   set_fact:
@@ -57,7 +57,7 @@
 
 - name: Set fact of the dest path of unattend install iso on ESXi host
   set_fact:
-    transferred_unattend_iso: "{{ remote_datastore_path }}/{{ unattend_iso_file_name }}"
+    transferred_unattend_iso: "{{ vm_path }}/{{ unattend_iso_file_name }}"
 - name: Print debug message
   debug:
     msg: "Will transfer unattend install iso to: {{ transferred_unattend_iso }}"
@@ -68,7 +68,7 @@
     transfer_file_remote_src: "{{ generated_unattend_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "{{ remote_datastore_path }}"
+# ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/linux/deploy_vm/download_iso_and_transfer.yml
+++ b/linux/deploy_vm/download_iso_and_transfer.yml
@@ -7,7 +7,7 @@
 - name: Set fact of OS installation ISO file name and remote datastore path
   set_fact:
     os_installation_iso_file: "{{ os_installation_iso_url.split('/')[-1] }}"
-    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
+# remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 - name: Display the OS installation ISO file name
   debug: var=os_installation_iso_file
 
@@ -29,7 +29,7 @@
 
 - name: Set fact of the dest path of OS installation ISO file on ESXi host
   set_fact:
-    transferred_install_iso: "{{ remote_datastore_path }}/{{ os_installation_iso_file }}"
+    transferred_install_iso: "{{ vm_path }}/{{ os_installation_iso_file }}"
 - name: Print the dest path of OS installation ISO file on ESXi host
   debug: var=transferred_install_iso
 
@@ -39,7 +39,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ os_installation_iso_file }}"
     transfer_file_remote_dest: "{{ transferred_install_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "{{ remote_datastore_path }}"
+# ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Set fact of the transferred ISO file datastore path
   set_fact:

--- a/linux/deploy_vm/download_iso_and_transfer.yml
+++ b/linux/deploy_vm/download_iso_and_transfer.yml
@@ -7,7 +7,6 @@
 - name: Set fact of OS installation ISO file name and remote datastore path
   set_fact:
     os_installation_iso_file: "{{ os_installation_iso_url.split('/')[-1] }}"
-# remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 - name: Display the OS installation ISO file name
   debug: var=os_installation_iso_file
 
@@ -29,7 +28,7 @@
 
 - name: Set fact of the dest path of OS installation ISO file on ESXi host
   set_fact:
-    transferred_install_iso: "{{ vm_path }}/{{ os_installation_iso_file }}"
+    transferred_install_iso: "{{ vm_datatore_path }}/{{ os_installation_iso_file }}"
 - name: Print the dest path of OS installation ISO file on ESXi host
   debug: var=transferred_install_iso
 
@@ -39,7 +38,6 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ os_installation_iso_file }}"
     transfer_file_remote_dest: "{{ transferred_install_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-# ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Set fact of the transferred ISO file datastore path
   set_fact:

--- a/linux/deploy_vm/download_iso_and_transfer.yml
+++ b/linux/deploy_vm/download_iso_and_transfer.yml
@@ -4,9 +4,10 @@
 # This task will download OS installation ISO file from given URL
 # locally, and transfer to ESXi host datastore for guest OS installation.
 #
-- name: Set fact of the OS installation ISO file name
+- name: Set fact of OS installation ISO file name and remote datastore path
   set_fact:
     os_installation_iso_file: "{{ os_installation_iso_url.split('/')[-1] }}"
+    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 - name: Display the OS installation ISO file name
   debug: var=os_installation_iso_file
 
@@ -28,7 +29,7 @@
 
 - name: Set fact of the dest path of OS installation ISO file on ESXi host
   set_fact:
-    transferred_install_iso: "/vmfs/volumes/{{ datastore }}/{{ os_installation_iso_file }}"
+    transferred_install_iso: "{{ remote_datastore_path }}/{{ os_installation_iso_file }}"
 - name: Print the dest path of OS installation ISO file on ESXi host
   debug: var=transferred_install_iso
 
@@ -38,7 +39,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ os_installation_iso_file }}"
     transfer_file_remote_dest: "{{ transferred_install_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
+    ansible_remote_tmp: "{{ remote_datastore_path }}"
 
 - name: Set fact of the transferred ISO file datastore path
   set_fact:

--- a/linux/deploy_vm/download_iso_and_transfer.yml
+++ b/linux/deploy_vm/download_iso_and_transfer.yml
@@ -28,7 +28,7 @@
 
 - name: Set fact of the dest path of OS installation ISO file on ESXi host
   set_fact:
-    transferred_install_iso: "{{ vm_datatore_path }}/{{ os_installation_iso_file }}"
+    transferred_install_iso: "{{ vm_datastore_path }}/{{ os_installation_iso_file }}"
 - name: Print the dest path of OS installation ISO file on ESXi host
   debug: var=transferred_install_iso
 

--- a/linux/deploy_vm/download_iso_and_transfer.yml
+++ b/linux/deploy_vm/download_iso_and_transfer.yml
@@ -38,7 +38,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ os_installation_iso_file }}"
     transfer_file_remote_dest: "{{ transferred_install_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "/vmfs/volumes/{{ datastore }}"
+    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
 
 - name: Set fact of the transferred ISO file datastore path
   set_fact:

--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -12,7 +12,6 @@
 - name: Set fact of unattend install ISO file name and remote datastore path
   set_fact:
     unattend_install_iso: "{{ guest_id }}-{{ firmware }}-{{ boot_disk_controller }}-{{ iso_timestamp }}.iso"
-    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: "Set fact of the absolute path of unattend install config file"
   set_fact:
@@ -78,7 +77,7 @@
 
 - name: Set fact of the dest path of unattend install ISO on ESXi host
   set_fact:
-    transferred_unattend_iso: "{{ remote_datastore_path }}/{{ unattend_install_iso }}"
+    transferred_unattend_iso: "{{ vm_datastore_path }}/{{ unattend_install_iso }}"
 - debug:
     msg: "Will transfer unattend install ISO to: {{ transferred_unattend_iso }}"
 
@@ -88,7 +87,6 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ unattend_install_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -9,9 +9,10 @@
 - name: Set fact of the timestamp suffix of ISO file name
   set_fact:
     iso_timestamp: "{{ lookup('pipe','date +%s') }}"
-- name: Set fact of the unattend install ISO file name
+- name: Set fact of unattend install ISO file name and remote datastore path
   set_fact:
     unattend_install_iso: "{{ guest_id }}-{{ firmware }}-{{ boot_disk_controller }}-{{ iso_timestamp }}.iso"
+    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: "Set fact of the absolute path of unattend install config file"
   set_fact:
@@ -77,7 +78,7 @@
 
 - name: Set fact of the dest path of unattend install ISO on ESXi host
   set_fact:
-    transferred_unattend_iso: "/vmfs/volumes/{{ datastore }}/{{ unattend_install_iso }}"
+    transferred_unattend_iso: "{{ remote_datastore_path }}/{{ unattend_install_iso }}"
 - debug:
     msg: "Will transfer unattend install ISO to: {{ transferred_unattend_iso }}"
 
@@ -87,7 +88,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ unattend_install_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
+    ansible_remote_tmp: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -87,6 +87,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ unattend_install_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
+    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -88,7 +88,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ unattend_install_iso }}"
     transfer_file_remote_dest: "{{ transferred_unattend_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "{{ remote_datastore_path }}"
+    ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Produce unattended ISO path
   set_fact:

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -5,7 +5,6 @@
 - name: Set fact of VMware tools ISO file name and remote datastore path
   set_fact:
     win_vmtools_iso_download: "{{ vmtools_url_path.split('/')[-1] }}"
-    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: Download VMware tools
   get_url:
@@ -20,7 +19,7 @@
 
 - name: Set fact of the dest path of VMware tools ISO on ESXi host
   set_fact:
-    transferred_vmtools_iso: "{{ remote_datastore_path }}/{{ win_vmtools_iso_download }}"
+    transferred_vmtools_iso: "{{ vm_datastore_path }}/{{ win_vmtools_iso_download }}"
 - debug:
     msg: "Will transfer VMware tools install ISO to: {{ transferred_vmtools_iso }}"
 
@@ -30,7 +29,6 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ win_vmtools_iso_download }}"
     transfer_file_remote_dest: "{{ transferred_vmtools_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Set fact of the VMware tools ISO path on ESXi host
   set_fact:

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Download VMware tools from specified URL and transfer to ESXi host datastore
-- name: Set fact of the VMware tools ISO file name
+- name: Set fact of VMware tools ISO file name and remote datastore path
   set_fact:
     win_vmtools_iso_download: "{{ vmtools_url_path.split('/')[-1] }}"
+    remote_datastore_path: "/vmfs/volumes/{{ datastore }}"
 
 - name: Download VMware tools
   get_url:
@@ -19,7 +20,7 @@
 
 - name: Set fact of the dest path of VMware tools ISO on ESXi host
   set_fact:
-    transferred_vmtools_iso: "/vmfs/volumes/{{ datastore }}/{{ win_vmtools_iso_download }}"
+    transferred_vmtools_iso: "{{ remote_datastore_path }}/{{ win_vmtools_iso_download }}"
 - debug:
     msg: "Will transfer VMware tools install ISO to: {{ transferred_vmtools_iso }}"
 
@@ -29,7 +30,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ win_vmtools_iso_download }}"
     transfer_file_remote_dest: "{{ transferred_vmtools_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
+    ansible_remote_tmp: "{{ remote_datastore_path }}"
 
 - name: Set fact of the VMware tools ISO path on ESXi host
   set_fact:

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -29,7 +29,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ win_vmtools_iso_download }}"
     transfer_file_remote_dest: "{{ transferred_vmtools_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "/vmfs/volumes/{{ datastore }}"
+    remote_tmp_folder: "/vmfs/volumes/{{ datastore }}"
 
 - name: Set fact of the VMware tools ISO path on ESXi host
   set_fact:

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -30,7 +30,7 @@
     transfer_file_remote_src: "{{ main_playbook_path }}/cache/{{ win_vmtools_iso_download }}"
     transfer_file_remote_dest: "{{ transferred_vmtools_iso }}"
     transfer_file_remote_server: "{{ esxi_hostname }}"
-    ansible_remote_tmp: "{{ remote_datastore_path }}"
+    ansible_remote_tmp_env: "{{ remote_datastore_path }}"
 
 - name: Set fact of the VMware tools ISO path on ESXi host
   set_fact:


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Fixes: #10

When transfer file to ESXi host, we set "ANSIBLE_REMOTE_TMP" environment variable to "/vmfs/volumes/{{ datastore }}" in common task: transfer_file_remote.yml