### PR TITLE
Fix the incorrect tasks file path

### DIFF
--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -38,7 +38,7 @@
   when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat']
 
 # Add online repo for CentOS, OracleLinux, Ubuntu, Debian and Photon
-- include_tasks: ../utils/add_online_repo.yml
+- include_tasks: ../utils/add_official_online_repo.yml
   when: guest_os_ansible_distribution in ['CentOS', 'OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
 
 - block:


### PR DESCRIPTION
The correct utils task file should be add_official_online_repo.yml.

```
VM information:
+-----------------------------------------------------+
| VM Name             | qiz-214-photon-3.0-bug-verify |
+-----------------------------------------------------+
| VM IP               | 10.117.16.102                 |
+-----------------------------------------------------+
| Guest OS Type       | VMware Photon OS 3.0 x86_64   |
+-----------------------------------------------------+
| VM Tools            | 11.2.5.26209 (build-17337674) |
+-----------------------------------------------------+
| Cloud-Init          | 19.4                          |
+-----------------------------------------------------+
| Guest ID            | vmwarePhoton64Guest           |
+-----------------------------------------------------+
| Hardware Version    | vmx-13                        |
+-----------------------------------------------------+


Test Results (Total: 4, Failed: 1, No Run: 0, Elapsed Time: 00:54:58):
+------------------------------------------------+
| Name                    |   Status | Exec Time |
+------------------------------------------------+
| gosc_perl_dhcp          |   Passed | 00:12:29  |
| gosc_perl_staticip      |   Passed | 00:10:13  |
| gosc_cloudinit_dhcp     | * Failed | 00:12:51  |
| gosc_cloudinit_staticip |   Passed | 00:11:57  |
+------------------------------------------------+
```