### PR TITLE
add autoinstall for ubuntu 21.04

### DIFF
--- a/linux/deploy_vm/ubuntu/reconfigure_ubuntu_iso_vm.yml
+++ b/linux/deploy_vm/ubuntu/reconfigure_ubuntu_iso_vm.yml
@@ -18,6 +18,12 @@
     dest: ubuntu_install_method.yml
     mode: '0644'
 
+- name: Read ubuntu install method file
+  command: cat ubuntu_install_method.yml
+  register: file_result_ubuntu_install_method
+
+- debug: var=file_result_ubuntu_install_method
+
 - name: Include vars from files
   include_vars: ubuntu_install_method.yml
 

--- a/linux/deploy_vm/ubuntu/reconfigure_ubuntu_iso_vm.yml
+++ b/linux/deploy_vm/ubuntu/reconfigure_ubuntu_iso_vm.yml
@@ -22,7 +22,8 @@
   command: cat ubuntu_install_method.yml
   register: file_result_ubuntu_install_method
 
-- debug: var=file_result_ubuntu_install_method
+- name: "Get content of file ubuntu_install_method.yml"
+  debug: var=file_result_ubuntu_install_method
 
 - name: Include vars from files
   include_vars: ubuntu_install_method.yml

--- a/linux/deploy_vm/ubuntu/ubuntu_install_method.j2
+++ b/linux/deploy_vm/ubuntu/ubuntu_install_method.j2
@@ -1,8 +1,18 @@
-{% for item in ubuntu_install_method_setting -%}
-    {% for os_item in item.os_version.split("/") -%}
-        {% if ubuntu_os_image.find(os_item) != -1 %}
-ubuntu_install_method: "{{ item.install_method }}"
-ubuntu_install_file: "{{ item.install_file }}"
-        {% endif %}
-    {%- endfor %}
+{% set ubuntu_install_method_idx=[] %}
+{% for idx in range(0, ubuntu_install_method_setting|length) -%}
+{% for os_item in ubuntu_install_method_setting[idx].os_version.split("/") -%}
+{% if ubuntu_os_image.find(os_item) != -1 %}
+{{ ubuntu_install_method_idx.append(idx) }}
+{% endif %}
 {%- endfor %}
+{%- endfor %}
+{% if ubuntu_install_method_idx|length > 0 %}
+ubuntu_install_method_idx: "{{ ubuntu_install_method_idx[0] }}"
+ubuntu_install_method: "{{ ubuntu_install_method_setting[ubuntu_install_method_idx[0]].install_method }}"
+ubuntu_install_file: "{{ ubuntu_install_method_setting[ubuntu_install_method_idx[0]].install_file }}"
+{% else %}
+ubuntu_install_method_idx: "-1"
+ubuntu_install_method: "{{ ubuntu_install_method_setting[-1].install_method }}"
+ubuntu_install_file: "{{ ubuntu_install_method_setting[-1].install_file }}"
+{% endif %}
+

--- a/linux/deploy_vm/ubuntu/vars_ubuntu_install.yml
+++ b/linux/deploy_vm/ubuntu/vars_ubuntu_install.yml
@@ -1,9 +1,13 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ubuntu_install_method_setting:
-  - os_version: "20.04/20.10"
+  - os_version: "20.04/20.10/21.04"
     install_method: "cloud-init"
     install_file: "ubuntu-iso-user-data.j2"
   - os_version: "18.04"
     install_method: "simulation"
     install_file: "ubuntu_autoinstall.yml"
+  - os_version: "*"
+    install_method: "cloud-init"
+    install_file: "ubuntu-iso-user-data.j2"
+


### PR DESCRIPTION
add autoinstall for ubuntu 21.04

test items:
1) check autoinstall for ubuntu 20.10 live server and ubuntu 21.04 live server
2) check the default auto install


test result:
1) set cloud-init as autoinstall method for ubuntu 21.04:
    
![image](https://user-images.githubusercontent.com/41054978/118449346-a54ea600-b725-11eb-8f21-fbac43980b63.png)

2) set default autoinstall method for ubuntu 21.04:
![image](https://user-images.githubusercontent.com/41054978/118450510-dbd8f080-b726-11eb-9b21-df9e5b02946e.png)
