### PR TITLE
Fix flatcar guest name issue

### DIFF
--- a/linux/check_os_fullname/amazonlinux_fullname_map.yml
+++ b/linux/check_os_fullname/amazonlinux_fullname_map.yml
@@ -26,15 +26,17 @@
     - name: "Set guest_fullname variable for Amazon Linux on ESXi <= 6.5.0"
       set_fact:
         guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
-      when:
-        - (esxi_version_num | int <= 650) or ((esxi_version_num | int == 670) and (esxi_update_version | int == 0))
+      when: >
+        (esxi_version is version('6.5.0', '<=')) or
+        (esxi_version is version('6.7.0', '==') and (esxi_update_version | int == 0))
 
     # Map Amazon Linux when ESXi > 6.7.0 GA
     - name: "Set guest_fullname variable for Amazon Linux on ESXi >= 6.7.0"
       set_fact:
         guest_fullname: "Amazon Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-      when:
-        - (esxi_version_num | int > 670) or ((esxi_version_num | int == 670) and (esxi_update_version | int > 0))
+      when: >
+        (esxi_version is version('6.7.0', '>')) or
+        (esxi_version is version('6.7.0', '==') and (esxi_update_version | int > 0))
   when:
     - short_name is undefined or not short_name
 

--- a/linux/check_os_fullname/centos_fullname_map.yml
+++ b/linux/check_os_fullname/centos_fullname_map.yml
@@ -5,7 +5,7 @@
 - name: Set guest_fullname variable for CentOS on ESXi < 6.5.0
   set_fact:
     guest_fullname: "CentOS 4/5 or later {{ bitness }}"
-  when: esxi_version_num | int < 650
+  when: esxi_version is version('6.5.0', '<')
 
 # Map CentOS-5 and earlier when ESXi >= 6.5.0
 - name: Set guest_fullname variable for CentOS on ESXi >= 6.5.0
@@ -13,7 +13,7 @@
     guest_fullname: "CentOS {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int <= 5
-    - esxi_version_num | int >= 650
+    - esxi_version is version('6.5.0', '>=')
 
 # Map CentOS-6, CentOS-7 when ESXi = 6.5.0
 - name: Set guest_fullname variable for CentOS on ESXi = 6.5.0
@@ -21,7 +21,7 @@
     guest_fullname: "CentOS {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int == 6 or guest_os_ansible_distribution_major_ver | int == 7
-    - esxi_version_num | int == 650
+    - esxi_version is version('6.5.0', '==')
 
 # Map CentOS-8 and later when ESXi = 6.5.0
 - name: Set guest_fullname variable for CentOS on ESXi = 6.5.0
@@ -29,7 +29,7 @@
     guest_fullname: "CentOS 7 {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int >= 8
-    - esxi_version_num | int == 650
+    - esxi_version is version('6.5.0', '==')
 
 # Map CentOS-6 and later when ESXi >= 6.7.0
 - name: Set guest_fullname variable for CentOS on ESXi >= 6.7.0
@@ -37,4 +37,4 @@
     guest_fullname: "CentOS {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int >= 6
-    - esxi_version_num | int >= 670
+    - esxi_version is version('6.7.0', '>=')

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -19,13 +19,7 @@
         # Run this test when VMware tools is running
         - block:
             - include_tasks: ../../common/esxi_get_version_build.yml
-              when: >
-                esxi_version is undefined or esxi_version == 'N/A' or
-                esxi_update_version is undefined or esxi_update_version == 'N/A'
-
-            - name: Set fact of ESXi version
-              set_fact:
-                esxi_version_num: "{{ esxi_version | regex_replace('\\.','') }}"
+              when: esxi_version is undefined or esxi_update_version is undefined
 
             - name: Get OS fullname in guest OS
               debug:

--- a/linux/check_os_fullname/debian_fullname_map.yml
+++ b/linux/check_os_fullname/debian_fullname_map.yml
@@ -5,7 +5,7 @@
 - name: "Set guest_fullname variable for Debian on ESXi >= 6.5.0"
   set_fact:
     guest_fullname: "Debian GNU/Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-  when: esxi_version_num | int >= 650
+  when: esxi_version is version('6.5.0', '>=')
 
 # Map Debian-9 and later when ESXi < 6.5.0
 - name: "Set guest_fullname variable for Debian on ESXi < 6.5.0"
@@ -13,7 +13,7 @@
     guest_fullname: "Debian GNU/Linux 8 {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int >= 9
-    - esxi_version_num | int < 650
+    - esxi_version is version('6.5.0', '<')
 
 # Map Debian-8 and earlier when ESXi < 6.5.0
 - name: "Set guest_fullname variable for Debian on ESXi < 6.5.0"
@@ -21,4 +21,4 @@
     guest_fullname: "Debian GNU/Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int < 9
-    - esxi_version_num | int < 650
+    - esxi_version is version('6.5.0', '<')

--- a/linux/check_os_fullname/oraclelinux_fullname_map.yml
+++ b/linux/check_os_fullname/oraclelinux_fullname_map.yml
@@ -1,10 +1,10 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Map Oracle linux 8 and later when ESXi >= 6.7.0
+# Map Oracle linux 6 and later when ESXi >= 6.7.0
 - name: "Set guest_fullname variable for Oracle Linux on ESXi >= 6.7.0"
   set_fact:
     guest_fullname: "Oracle Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int >= 6
-    - esxi_version_num | int  >= 670
+    - esxi_version is version('6.7.0', '>=')

--- a/linux/check_os_fullname/photon_fullname_map.yml
+++ b/linux/check_os_fullname/photon_fullname_map.yml
@@ -5,10 +5,10 @@
 - name: "Set guest_fullname variable for Photon on ESXi >= 6.5.0"
   set_fact:
     guest_fullname: "VMware Photon OS {{ bitness }}"
-  when: esxi_version_num | int >= 650
+  when: esxi_version is version('6.5.0', '>=')
 
 # Map Photon OS when HW < 13
 - name: "Set guest_fullname variable for Photon on ESXi < 6.5.0"
   set_fact:
     guest_fullname: "Other 3.x or later Linux {{ bitness }}"
-  when: esxi_version_num | int < 650
+  when: esxi_version is version('6.5.0', '<')

--- a/linux/check_os_fullname/rhel_fullname_map.yml
+++ b/linux/check_os_fullname/rhel_fullname_map.yml
@@ -5,7 +5,7 @@
 - name: "Set guest_fullname variable for RHEL on ESXi >= 6.7.0"
   set_fact:
     guest_fullname: "Red Hat Enterprise Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-  when: esxi_version_num | int >= 670
+  when: esxi_version is version('6.7.0', '>=')
 
 # Map RHEL-8 when ESXi <= 6.5.0
 - name: "Set guest_fullname variable for RHEL-8 on ESXi <= 6.5.0"
@@ -13,7 +13,7 @@
     guest_fullname: "Red Hat Enterprise Linux 7 {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int == 8
-    - esxi_version_num | int <= 650
+    - esxi_version is version('6.5.0', '<=')
 
 # Map RHEL-7 and earlier when ESXi <= 6.5.0
 - name: "Set guest_fullname variable for RHEL-7 and earlier on ESXi <= 6.5.0"
@@ -21,4 +21,4 @@
     guest_fullname: "Red Hat Enterprise Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int <= 7
-    - esxi_version_num | int <= 650
+    - esxi_version is version('6.5.0', '<=')

--- a/linux/check_os_fullname/sles_fullname_map.yml
+++ b/linux/check_os_fullname/sles_fullname_map.yml
@@ -5,7 +5,7 @@
 - name: Set guest_fullname variable for SLES on ESXi >= 6.7.0
   set_fact:
     guest_fullname: "SUSE Linux Enterprise {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-  when: esxi_version_num | int  >= 670
+  when: esxi_version is version('6.7.0', '>=')
 
 # Map SLES-12 and earlier when ESXi <= 6.5.0
 - name: Set guest_fullname variable for SLES-12 and earlier on ESXi <= 6.5.0
@@ -13,7 +13,7 @@
     guest_fullname: "SUSE Linux Enterprise {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int <= 12
-    - esxi_version_num | int  <= 650
+    - esxi_version is version('6.5.0', '<=')
 
 # Map SLES-15 when ESXi <= 6.5.0
 - name: Set guest_fullname variable for SLES-15 on ESXi <= 6.5.0
@@ -21,4 +21,4 @@
     guest_fullname: "SUSE Linux Enterprise 12 {{ bitness }}"
   when:
     - guest_os_ansible_distribution_major_ver | int == 15
-    - esxi_version_num | int  <= 650
+    - esxi_version is version('6.5.0', '<=')

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -4,6 +4,16 @@
 # Wait VMware tools to report Guest OS fullname
 - include_tasks: ../../common/vm_wait_guest_fullname.yml
 
+# If the guest os full name has detailed OS info, test passed
+- block:
+    - include_tasks: ../../common/print_test_result.yml
+      vars:
+        test_result: "Passed"
+    - meta: end_play
+  when:
+    - guest_os_ansible_distribution == "Flatcar"
+    - "'Flatcar' in vm_guest_facts.instance.hw_guest_full_name"
+
 - block:
     - name: "Assert Guest OS fullname is either {{ guest_fullname[0] }} or {{ guest_fullname[1] }}"
       assert:

--- a/linux/deploy_vm/amazonlinux/reconfigure_amazonlinux_vm.yml
+++ b/linux/deploy_vm/amazonlinux/reconfigure_amazonlinux_vm.yml
@@ -10,20 +10,14 @@
 - include_tasks: ../../../common/esxi_get_version_build.yml
   when: esxi_version is undefined or esxi_version == 'N/A'
 
-- name: "Set fact of the ESXi version"
-  set_fact:
-    esxi_version_num: "{{ esxi_version | regex_replace('\\.','') | int }}"
-
 # Amazon Linux OVA is using other3xlinux64 as guest id
-# amazonlinux2_64 is added in 6.7U1 (HWv14)
-# amazonlinux3_64 is added in 7.0U1 (HWv18)
 - include_tasks: ../../../common/vm_set_guest_id.yml
   vars:
     vm_guest_id: "{{ guest_id }}"
   when:
     - guest_id == 'amazonlinux2_64Guest'
     - ova_hw_guest_id != guest_id
-    - esxi_version_num | int > 670 or (esxi_version_num | int == 670 and esxi_update_version | int > 0)
+    - ((esxi_version is version('6.7.0', '>')) or (esxi_version is version('6.7.0', '==') and esxi_update_version | int > 0))
     - vm_hw_version | int >= 14
 
 - include_tasks: ../../../common/vm_set_guest_id.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -132,6 +132,11 @@
         - include_tasks: ../../common/vm_set_power_state.yml
           vars:
             vm_power_state_set: 'powered-on'
+
+        - name: "Set current power state"
+          set_fact:
+            current_power_state: "{{ vm_power_state_get }}"
+
         - include_tasks: ../../common/vm_wait_guest_fullname.yml
 
         # Try to get the OS type from guest id
@@ -189,17 +194,17 @@
           when:
             - vm_guest_facts.instance.guest_tools_version | int >= 11264
             - ova_guest_os_type == 'unknown'
+      when: ova_guest_os_type == 'unknown'
 
-        # Revert to snapshot "FreshDeployedFromOVA" or "AfterUpgradeHwv" to
-        # proceed the following tasks so that VM's reconfiguration can be
-        # performed at the first time boot.
-        - include_tasks: ../../common/vm_revert_snapshot.yml
-          vars:
-            snapshot_name: "{{ base_snapshot_for_reconfig }}"
+    # Revert to snapshot "FreshDeployedFromOVA" or "AfterUpgradeHwv" to
+    # proceed the following tasks so that VM's reconfiguration can be
+    # performed at the first time boot.
+    - include_tasks: ../../common/vm_revert_snapshot.yml
+      vars:
+        snapshot_name: "{{ base_snapshot_for_reconfig }}"
       when:
-        - "'ubuntu' not in ova_hw_guest_id"
-        - "'amazonlinux' not in ova_hw_guest_id"
-        - "'vmwarePhoton' not in ova_hw_guest_id"
+        - current_power_state is defined
+        - current_power_state == "poweredOn"
 
     # Configure username/password, ssh public key, sshd, etc in guest
     # Reconfig Amazon Linux VM

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -147,6 +147,20 @@
             - vm_guest_facts.instance is defined
             - vm_guest_facts.instance.hw_guest_id is defined
 
+        # Try to get the OS type from guest full name
+        - name: "Get guest OS type for VM '{{ vm_name }}' based on guest full name"
+          set_fact:
+            ova_guest_os_type: |-
+              {%- if 'ubuntu' in vm_guest_facts.instance.hw_guest_full_name | lower -%}ubuntu
+              {%- elif 'amazon linux' in vm_guest_facts.instance.hw_guest_full_name | lower -%}amazonlinux
+              {%- elif 'vmware photon' in vm_guest_facts.instance.hw_guest_full_name | lower -%}photon
+              {%- elif 'flatcar' in vm_guest_facts.instance.hw_guest_full_name | lower -%}flatcar
+              {%- else -%}unknown{%- endif -%}
+          when:
+            - ova_guest_os_type == 'unknown'
+            - vm_guest_facts.instance is defined
+            - vm_guest_facts.instance.hw_guest_full_name is defined
+
         # If ova_guest_os_type is still not determined by guest id,
         # retrieve guest OS detailed data from vmx file
         # guestOS.detailed.data or guestInfo.detailed.data is supported by VMTools >= 11.0.0


### PR DESCRIPTION
On 67GA, flatcar VM's guest full name is like 'Linux 5.10.38-flatcar Flatcar Container Linux by Kinvolk 2765.2.5 Oklo Flatcar Container Linux by Kinvolk 2765.2.5 (Oklo)', and there is no guest os detail info in vm extra config. This fix resolved the issue.