### PR TITLE
Wait VM snapshot renaming completed

### DIFF
--- a/common/vm_rename_snapshot.yml
+++ b/common/vm_rename_snapshot.yml
@@ -30,16 +30,6 @@
     - include_tasks: vm_wait_expected_snapshot.yml
       vars:
         expected_snapshot_name: "{{ new_snapshot_name }}"
-
-    - name: "Check snapshot rename result"
-      assert:
-        that:
-          - vm_snapshot_facts is defined
-          - vm_snapshot_facts.guest_snapshots is defined
-          - vm_snapshot_facts.guest_snapshots.snapshots is defined
-          - vm_snapshot_facts.guest_snapshots.snapshots | selectattr('name', 'equalto', current_snapshot_name) | length == 0
-          - vm_snapshot_facts.guest_snapshots.snapshots | selectattr('name', 'equalto', new_snapshot_name) | length == 1
-        fail_msg: "Failed to rename snapshot '{{ current_snapshot_name }}' to '{{ new_snapshot_name }}'"
   when:
     - current_snapshot_name is defined and current_snapshot_name
     - new_snapshot_name is defined and new_snapshot_name

--- a/common/vm_rename_snapshot.yml
+++ b/common/vm_rename_snapshot.yml
@@ -26,7 +26,11 @@
       debug: var=task_result
       when: enable_debug is defined and enable_debug
 
-    - include_tasks: vm_get_snapshot_facts.yml
+    # Wait for renaming task completed
+    - include_tasks: vm_wait_expected_snapshot.yml
+      vars:
+        expected_snapshot_name: "{{ new_snapshot_name }}"
+
     - name: "Check snapshot rename result"
       assert:
         that:

--- a/common/vm_wait_expected_snapshot.yml
+++ b/common/vm_wait_expected_snapshot.yml
@@ -17,7 +17,11 @@
     folder: "{{ vm_folder }}"
     name: "{{ vm_name }}"
   register: vm_snapshot_facts
-  until: vm_snapshot_facts.guest_snapshots.current_snapshot.name == expected_snapshot_name
+  until:
+    - vm_snapshot_facts is defined
+    - vm_snapshot_facts.guest_snapshots is defined
+    - vm_snapshot_facts.guest_snapshots.current_snapshot is defined
+    - vm_snapshot_facts.guest_snapshots.current_snapshot.name == expected_snapshot_name
   retries: "{{ (expected_snapshot_wait_time | default(30) | int / 3) | int }}"
   delay: 3
 


### PR DESCRIPTION
Snapshot renaming task takes some time, we need to wait it completed and then assert the task success.
```
Testbed information:
+----------------------------------------------+
| Product | Version | Build   | Hostname or IP |
+----------------------------------------------+
| vCenter | 6.7.0   | 8170161 | 10.191.162.225 |
+----------------------------------------------+
| ESXi    | 6.7.0   | 8169922 | 10.191.168.138 |
+----------------------------------------------+

VM information:
+-----------------------------------------------------+
| VM Name             | test_vm                       |
+-----------------------------------------------------+
| VM IP               | 10.191.167.228                |
+-----------------------------------------------------+
| Guest OS Type       | SLES 15.3 x86_64              |
+-----------------------------------------------------+
| VM Tools            | 11.2.5.26209 (build-17337674) |
+-----------------------------------------------------+
| Guest ID            | sles15_64Guest                |
+-----------------------------------------------------+
| Hardware Version    | vmx-14                        |
+-----------------------------------------------------+

Test Results (Total: 1, Failed: 0, No Run: 0, Elapsed Time: 00:17:57):
+-----------------------------------------+
| Name               | Status | Exec Time |
+-----------------------------------------+
| ovt_verify_install | Passed | 00:17:07  |
+-----------------------------------------+
```
