### PR TITLE
Update match pattern for filtering package information

### DIFF
--- a/linux/utils/get_installed_package_info.yml
+++ b/linux/utils/get_installed_package_info.yml
@@ -34,7 +34,7 @@
     - block:
         - name: "Set the fact of package info about '{{ package_name }}'"
           set_fact:
-            package_info: "{{ '\n'.join(package_fact_result.stdout_lines | select('match', '^\\w+:.*[^:]$')) | from_yaml }}"
+            package_info: "{{ '\n'.join(package_fact_result.stdout_lines | select('match', '^\\w+\\s*:.*[^:]$')) | from_yaml }}"
 
         # In the output of querying packages on Ubuntu/Debian, it is using 'Package' parameter for package name
         - name: "Set package name in package info"


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Fix #51 
The output of querying package information could have spaces following package properties.
For example,
```
    "stdout_lines": [
        "Name        : openssh-server",
        "Version     : 8.0p1",
        "Release     : 5.el8",
        "Architecture: x86_64",
        "Install Date: Mon 07 Jun 2021 08:11:28 AM EDT",
        "Group       : System Environment/Daemons",
        "Size        : 1034528",
        "License     : BSD",
        "Signature   : RSA/SHA256, Fri 31 Jul 2020 08:22:03 AM EDT, Key ID 82562ea9ad986da3",
        "Source RPM  : openssh-8.0p1-5.el8.src.rpm",
        "Build Date  : Fri 31 Jul 2020 08:21:15 AM EDT",
        "Build Host  : jenkins-10-147-72-125-6ff307d2-bdc3-47e1-8da0-642273fc4d3d.appad2iad.osdevelopmeniad.oraclevcn.com",
        "Relocations : (not relocatable)",
        "Vendor      : Oracle America",
        "URL         : http://www.openssh.com/portable.html",
        "Summary     : An open source SSH server daemon",
        "Description :",
        "OpenSSH is a free version of SSH (Secure SHell), a program for logging",
        "into and executing commands on a remote machine. This package contains",
        "the secure shell daemon (sshd). The sshd daemon allows SSH clients to",
        "securely connect to your SSH server."
    ]
```

With the fix, now package info got from above output will be:
```
    "package_info": {
        "Architecture": "x86_64",
        "Group": "System Environment/Daemons",
        "License": "BSD",
        "Name": "openssh-server",
        "Release": "5.el8",
        "Relocations": "(not relocatable)",
        "Signature": "RSA/SHA256, Fri 31 Jul 2020 08:22:03 AM EDT, Key ID 82562ea9ad986da3",
        "Size": 1034528,
        "Summary": "An open source SSH server daemon",
        "URL": "http://www.openssh.com/portable.html",
        "Vendor": "Oracle America",
        "Version": "8.0p1"
    }
```