### PR TITLE
Add wait ip task before continueing ubuntu cloud-init autoinstall

### DIFF
--- a/linux/deploy_vm/ubuntu/ubuntu_install_os.yml
+++ b/linux/deploy_vm/ubuntu/ubuntu_install_os.yml
@@ -6,9 +6,12 @@
   when: ubuntu_install_method == "simulation"
 
 - block:
+    - include_tasks: ../../../common/vm_wait_guest_ip.yml
+
     - name: Sleep 300 seconds to wait confirm message for ubuntu
       pause:
         seconds: 300
+
     - include_tasks: ../../../common/vm_guest_send_key.yml
       vars:
         keys_send:


### PR DESCRIPTION
Fix #54
Signed-off-by: Qi Zhang <qiz@vmware.com>
Ubuntu cloud-init autoinstall will firstly get IP address and then show the autoinstall confirmation message, so add a wait ip task before sending confirmation 'yes'.

```
Testbed information:
+-----------------------------------------------+
| Product | Version | Build    | Hostname or IP |
+-----------------------------------------------+
| vCenter | 7.0.2   | 17694817 | 10.161.66.226  |
+-----------------------------------------------+
| ESXi    | 7.0.2   | 17630552 | 10.161.70.69   |
+-----------------------------------------------+


VM information:
+-------------------------------------------+
| VM Name             | ubuntu-21.04-4      |
+-------------------------------------------+
| VM IP               | 10.161.85.93        |
+-------------------------------------------+
| Guest OS Type       | Ubuntu 21.04 x86_64 |
+-------------------------------------------+


Test Results (Total: 1, Failed: 0, No Run: 0, Elapsed Time: 00:15:21):
+--------------------------------------------------------+
| Name                              | Status | Exec Time |
+--------------------------------------------------------+
| deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:15:04  |
+--------------------------------------------------------+
```