### PR TITLE
VM customvalues was repaced by advanced_settings

### DIFF
--- a/common/vm_set_extra_config.yml
+++ b/common/vm_set_extra_config.yml
@@ -3,7 +3,7 @@
 ---
 # Add or update custom configure item for VM
 # Parameters:
-#   vm_custom_values: a key-value pair list to be set for VM
+#   vm_advanced_settings: a key-value pair list to be set for VM
 #
 - name: "Set custom configue values for VM"
   vmware_guest:
@@ -14,7 +14,7 @@
     datacenter: "{{ vsphere_host_datacenter }}"
     folder: "{{ vm_folder }}"
     name: "{{ vm_name }}"
-    customvalues: "{{ vm_custom_values }}"
+    advanced_settings: "{{ vm_advanced_settings }}"
   register: vm_extra_config_set_result
 
 - include_tasks: vm_get_extra_config.yml
@@ -23,6 +23,6 @@
     that:
       - vm_extra_item.key in vm_extra_config
       - vm_extra_config[vm_extra_item.key] == vm_extra_item.value
-  with_items: "{{ vm_custom_values }}"
+  with_items: "{{ vm_advanced_settings }}"
   loop_control:
     loop_var: vm_extra_item

--- a/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
+++ b/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
@@ -13,7 +13,7 @@
 - name: "Defining the Ignition config in Guestinfo"
   include_tasks: ../../../common/vm_set_extra_config.yml
   vars:
-    vm_custom_values:
+    vm_advanced_settings:
       - key: "guestinfo.coreos.config.data"
         value: "{{ ignition_config_data }}"
       - key: "guestinfo.coreos.config.data.encoding"

--- a/linux/utils/device_connectable_enable.yml
+++ b/linux/utils/device_connectable_enable.yml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Add isolation.device settings in vmx
-- name: "Initialize vm_custom_values for isolation.device.connectable.disable and isolation.device.edit.disable"
+- name: "Initialize vm_advanced_settings for isolation.device.connectable.disable and isolation.device.edit.disable"
   set_fact:
-    vm_custom_values:
+    vm_advanced_settings:
       - key: "isolation.device.connectable.disable"
         value: "FALSE"
       - key: "isolation.device.edit.disable"
@@ -15,9 +15,9 @@
 # Shutdown VM if key-value pair is not as expected in VMX file
 - include_tasks: shutdown.yml
   when: >
-    (vm_custom_values[0].key not in vm_extra_config) or
-    (vm_extra_config[vm_custom_values[0].key] | lower != vm_custom_values[0].value | lower) or
-    (vm_custom_values[1].key not in vm_extra_config) or
-    (vm_extra_config[vm_custom_values[1].key] | lower != vm_custom_values[1].value | lower)
+    (vm_advanced_settings[0].key not in vm_extra_config) or
+    (vm_extra_config[vm_advanced_settings[0].key] | lower != vm_advanced_settings[0].value | lower) or
+    (vm_advanced_settings[1].key not in vm_extra_config) or
+    (vm_extra_config[vm_advanced_settings[1].key] | lower != vm_advanced_settings[1].value | lower)
 
 - include_tasks: ../../common/vm_set_extra_config.yml


### PR DESCRIPTION
Fix #75 
In https://github.com/ansible-collections/community.vmware/commit/f913056612c776b6527aa3c373fe7cb7358d2762#, customvalues was replaced by advanced_settings. Correct the parameter name in common task.

```
Test Results (Total: 1, Failed: 0, No Run: 0, Elapsed Time: 00:06:42):
+----------------------------------+
| Name        | Status | Exec Time |
+----------------------------------+
| device_list | Passed | 00:05:37  |
+----------------------------------+
```
