### PR TITLE
Change photon repo's baseurl for Photon 3.x and earlier

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -55,10 +55,18 @@ guest_customization/gosc_cloudinit_dhcp.yml
 vhba_hot_add_remove/nvme_vhba_device_ops.yml
 ```
 
-4. VMware Photon OS 3.0 and later
+4. VMware Photon OS 3.x
+* Failure: After reinstalling open-vm-tools 11.2.5, the VGAuthService cann't be started successfully due to xmlsec1 version mismatch
+* Workaround: Manually upgrade xmlsec1 package by running command 'tdnf install xmlsec1', and then reboot Photon OS.
+* Affected test cases:
+```
+vgauth_check_service/vgauth_check_service.yml
+```
+
+5. VMware Photon OS 3.0 and later
 * Failure: When hot adding or removing NVMe disk to existing controller, VMware Photon OS cannot detect NVMe disk changes.
 * Workaround: not available
 * Affected test cases:
 ```
-nvme_vhba_device_ops
+vhba_hot_add_remove/nvme_vhba_device_ops.yml
 ```

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -102,12 +102,12 @@
 - block:
     - name: "Set the fact of Photon OS {{ guest_os_ansible_distribution_major_ver }} online repos"
       set_fact:
-        photon_online_repos: ["photon", "photon-updates"]
+        photon_online_repos: ["photon", "photon-updates", "photon-extras"]
       when: guest_os_ansible_distribution_major_ver | int < 4
 
     - name: "Set the fact of Photon OS {{ guest_os_ansible_distribution_major_ver }} online repos"
       set_fact:
-        photon_online_repos: ["photon", "photon-release", "photon-updates"]
+        photon_online_repos: ["photon", "photon-release", "photon-updates", "photon-extras"]
       when: guest_os_ansible_distribution_major_ver | int >= 4
 
     - include_tasks: ../../common/update_ini_style_file.yml
@@ -117,4 +117,12 @@
         option_name: "enabled"
         option_value: 1
       with_items: "{{ photon_online_repos }}"
+
+    # Update baseurl to repos on https://packages.vmware.com/photon
+    - block:
+        - name: "Update repo's baseurl"
+          command: "sed -i 's#dl.bintray.com/vmware/#packages.vmware.com/photon/$releasever/#' /etc/yum.repos.d/{{ item }}.repo"
+          delegate_to: "{{ vm_guest_ip }}"
+          with_items: "{{ photon_online_repos }}"
+      when: guest_os_ansible_distribution_major_ver | int < 4
   when: guest_os_ansible_distribution == 'VMware Photon OS'


### PR DESCRIPTION
Fix #86 
Signed-off-by: Qi Zhang <qiz@vmware.com>
```


VM information:
+-----------------------------------------------------+
| VM Name             | photon-os-3.0                 |
+-----------------------------------------------------+
| VM IP               | 10.78.204.46                  |
+-----------------------------------------------------+
| Guest OS Type       | VMware Photon OS 3.0 x86_64   |
+-----------------------------------------------------+
| VM Tools            | 11.2.5.26209 (build-17337674) |
+-----------------------------------------------------+
| Cloud-Init          | 18.3                          |
+-----------------------------------------------------+
| Guest ID            | vmwarePhoton64Guest           |
+-----------------------------------------------------+
| Hardware Version    | vmx-13                        |
+-----------------------------------------------------+


Test Results (Total: 28, Failed: 2, No Run: 0, Elapsed Time: 01:49:30):
+-------------------------------------------------------------+
| Name                                 |   Status | Exec Time |
+-------------------------------------------------------------+
| deploy_vmwarephoton_ova              |   Passed | 00:02:04  |
| ovt_verify_install                   |   Passed | 00:09:10  |
| ovt_verify_status                    |   Passed | 00:00:25  |
| vgauth_check_service                 | * Failed | 00:15:51  |
| check_ip_address                     |   Passed | 00:00:41  |
| stat_balloon                         |   Passed | 00:00:18  |
| stat_hosttime                        |   Passed | 00:00:19  |
| check_inbox_driver                   |   Passed | 00:00:27  |
| check_os_fullname                    |   Passed | 00:00:40  |
| check_efi_firmware                   |   Passed | 00:00:13  |
| cpu_hot_add_basic                    |   Passed | 00:02:07  |
| check_quiesce_snapshot_custom_script |   Passed | 00:01:06  |
| memory_hot_add_basic                 |   Passed | 00:03:13  |
| device_list                          |   Passed | 00:01:54  |
| secureboot_enable_disable            |   Passed | 00:03:10  |
| e1000e_network_device_ops            |   Passed | 00:03:07  |
| vmxnet3_network_device_ops           |   Passed | 00:03:10  |
| cpu_multicores_per_socket            |   Passed | 00:03:11  |
| gosc_perl_dhcp                       |   Passed | 00:05:48  |
| gosc_perl_staticip                   |   Passed | 00:05:35  |
| gosc_cloudinit_dhcp                  |   Passed | 00:06:05  |
| gosc_cloudinit_staticip              |   Passed | 00:05:50  |
| paravirtual_vhba_device_ops          |   Passed | 00:01:27  |
| lsilogic_vhba_device_ops             |   Passed | 00:04:20  |
| lsilogicsas_vhba_device_ops          |   Passed | 00:01:30  |
| sata_vhba_device_ops                 |   Passed | 00:01:47  |
| nvme_vhba_device_ops                 | * Failed | 00:01:50  |
| ovt_verify_uninstall                 |   Passed | 00:02:20  |
+-------------------------------------------------------------+
```

The failed case `vgauth_check_service` was caused by a Photon OS bug. When reinstalling open-vm-tools, tdnf didn't upgrade its dependency xmlsec1 automatically, and it caused vgauth service can not be started successfully due to version mismatch of xmlsec1.