### PR TITLE
Fix #58 Check self.testing_vars before use it

### DIFF
--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -322,13 +322,15 @@ class CallbackModule(CallbackBase):
         +---------------------------------------------------------+
         """
 
-        if not self.vcenter_info['hostname'] and \
-           'vcenter_hostname' in self.testing_vars and \
-           self.testing_vars['vcenter_hostname']:
+        if (self.testing_vars and
+            not self.vcenter_info['hostname'] and
+            'vcenter_hostname' in self.testing_vars and
+            self.testing_vars['vcenter_hostname']):
             self.vcenter_info['hostname'] = self.testing_vars['vcenter_hostname']
-        if not self.esxi_info['hostname'] and \
-           'esxi_hostname' in self.testing_vars and \
-           self.testing_vars['esxi_hostname']:
+        if (self.testing_vars and
+            not self.esxi_info['hostname'] and
+            'esxi_hostname' in self.testing_vars and
+            self.testing_vars['esxi_hostname']):
             self.esxi_info['hostname'] = self.testing_vars['esxi_hostname']
 
         msg = "Testbed information:\n"
@@ -408,7 +410,9 @@ class CallbackModule(CallbackBase):
         # Get VM name from testing vars file and set log dir
         msg = 'VM information:\n'
 
-        if 'vm_name' in self.testing_vars and self.testing_vars['vm_name']:
+        if (self.testing_vars and
+            'vm_name' in self.testing_vars and
+            self.testing_vars['vm_name']):
             self.vm_info['VM Name'] = self.testing_vars['vm_name']
         else:
             msg += "Not found VM information\n"


### PR DESCRIPTION
Fix #58 
Signed-off-by: Qi Zhang <qiz@vmware.com>

Tested with an empty test.yml
```
TASK [Set the log files path of this test run] *******************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/env_setup/create_local_log_path.yml:5
fatal: [localhost]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'vm_name' is undefined\n\nThe error appears to be in '/home/qiz/workspace/github/ansible-vsphere-gos-validation/env_setup/create_local_log_path.yml': line 5, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Create the current test run log files path in specified dir or in default dir.\n- name: \"Set the log files path of this test run\"\n  ^ here\n"
}

PLAY RECAP *******************************************************************************************************
localhost                  : ok=10   changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


TEST SUMMARY *****************************************************************************************************
Testbed information:
Not found vCenter or ESXi server information
VM information:
Not found VM information
Test Results (Total: 0, Elapsed Time: 00:00:02):
```

Tested with vars/test.yml missing
```
ansible-playbook [core 2.11.0] 
  config file = /home/qiz/workspace/github/ansible-vsphere-gos-validation/ansible.cfg
  configured module search path = ['/home/qiz/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.8/dist-packages/ansible
  ansible collection location = /home/qiz/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.8.10 (default, Jun  2 2021, 10:49:15) [GCC 9.4.0]
  jinja version = 2.11.3
  libyaml = True
Using /home/qiz/workspace/github/ansible-vsphere-gos-validation/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Parsed /etc/ansible/hosts inventory source with ini plugin
ERROR! vars file {{ testing_vars_file | default('../vars/test.yml') }} was not found
Could not find file on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option
```