### PR TITLE
Support Rocky Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This project supports below scenarios for end-to-end guest OS validation testing
 | Red Hat Enterprise Linux 7.x, 8.x               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Oracle Linux 7.x, 8.x                           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Rocky Linux 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | SUSE Linux Enterprise 15 SP2, SP3               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | SUSE Linux Enterprise 12 SP5, 15 SP0/SP1        |                                  |                          | :heavy_check_mark:                 |
 | Photon OS 3.x                                   | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |

--- a/common/get_guest_system_info.yml
+++ b/common/get_guest_system_info.yml
@@ -24,6 +24,7 @@
         guest_os_ansible_kernel: "{{ guest_system_info.ansible_kernel }}"
         guest_os_ansible_distribution_release: "{{ guest_system_info.ansible_distribution_release if 'ansible_distribution_release' in guest_system_info else 'N/A' }}"
         guest_os_ansible_pkg_mgr: "{{ guest_system_info.ansible_pkg_mgr if 'ansible_pkg_mgr' in guest_system_info else 'N/A' }}"
+        guest_os_family: "{{ guest_system_info.ansible_os_family if 'ansible_os_family' in guest_system_info else '' }}"
 
     # Get Debian OS version from /etc/debian_version
     - block:
@@ -39,6 +40,11 @@
           when: debian_version_result.stdout is defined and debian_version_result.stdout
       when: guest_os_ansible_distribution == "Debian"
 
+    - name: "Set OS family for {{ guest_os_ansible_distribution }} to RedHat"
+      set_fact:
+        guest_os_family: "RedHat"
+      when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux", "Rocky", "Amazon", "Fedora"]
+
     - name: "Print guest OS information"
       debug:
         msg:
@@ -50,6 +56,7 @@
           - "Guest OS version: {{ guest_os_ansible_distribution_ver }}"
           - "Guest OS kernel: {{ guest_os_ansible_kernel }}"
           - "Guest OS release: {{ guest_os_ansible_distribution_release }}"
+          - "Guest OS family: {{ guest_os_family }}"
 
     - name: "Set fact that ansible system information about guest OS has been retrieved"
       set_fact:

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -149,8 +149,8 @@
             - name: "Initialize VMware video driver package name"
               set_fact:
                 video_driver_pkg_name: |-
-                  {%- if guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux"] -%}xorg-x11-drv-vmware
-                  {%- elif guest_os_ansible_distribution in ["SLES", "SLED"] -%}xf86-video-vmware
+                  {%- if guest_os_family == "RedHat" -%}xorg-x11-drv-vmware
+                  {%- elif guest_os_family == "Suse" -%}xf86-video-vmware
                   {%- else -%}{%- endif -%}
 
             - block:
@@ -168,7 +168,7 @@
                     - vmware_video_package_result.rc == 0
                     - vmware_video_package_result.stdout is defined
                     - vmware_video_package_result.stdout
-              when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+              when: guest_os_family == "Debian"
 
             - block:
                 - include_tasks: ../utils/get_installed_package_info.yml

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -40,9 +40,9 @@
                 guest_fullname: "Ubuntu Linux {{ bitness }}"
               when: guest_os_ansible_distribution == "Ubuntu"
 
-            # Map Flatcar full name
-            - include_tasks: flatcar_fullname_map.yml
-              when: guest_os_ansible_distribution == "Flatcar"
+            # Map RockyLinux and Flatcar full name
+            - include_tasks: otherlinux_fullname_map.yml
+              when: guest_os_ansible_distribution in ["Rocky", "Flatcar"]
 
             # Map RHEL full name
             - include_tasks: rhel_fullname_map.yml
@@ -50,7 +50,7 @@
 
             # Map SLES full name
             - include_tasks: sles_fullname_map.yml
-              when: guest_os_ansible_distribution == "SLES" or guest_os_ansible_distribution == "SLED"
+              when: guest_os_ansible_distribution in ["SLES", "SLED"]
 
             # Map VMware Photon OS guest full name
             - include_tasks: photon_fullname_map.yml

--- a/linux/check_os_fullname/otherlinux_fullname_map.yml
+++ b/linux/check_os_fullname/otherlinux_fullname_map.yml
@@ -1,23 +1,24 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+# Map Flatcar, RockyLinux, or other Linux distribution which doesn't have a unique guest id
 # Flatcar 2605 and later
 - block:
     # Map Flatcar when ESXi <= 7.0.0
-    - name: "Set guest_fullname variable for Flatcar {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
+    - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
       set_fact:
         guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
       when: esxi_version is version('7.0.0', '<=')
 
     # Map Flatcar when ESXi > 7.0.0 as Other 5.x or later Linux is supported on ESXi 7.0.1 and later
-    - name: "Set guest_fullname variable for Flatcar {{ guest_os_ansible_distribution_ver }} on ESXi > 7.0.0"
+    - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi > 7.0.0"
       set_fact:
         guest_fullname: "Other 5.x or later Linux {{ bitness }}"
       when: esxi_version is version('7.0.0', '>')
   when: guest_os_ansible_kernel is version('5.0', '>=')
 
-# Flatcar 2512 and earlier
-- name: "Set guest_fullname variable for Flatcar {{ guest_os_ansible_distribution_ver }}"
+# Flatcar 2512 and earlier or RockyLinux
+- name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }}"
   set_fact:
     guest_fullname: ["Other 4.x or later Linux {{ bitness }}", "Other 4.x Linux {{ bitness }}"]
   when:

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -11,8 +11,8 @@
         test_result: "Passed"
     - meta: end_play
   when:
-    - guest_os_ansible_distribution == "Flatcar"
-    - "'Flatcar' in vm_guest_facts.instance.hw_guest_full_name"
+    - guest_os_ansible_distribution in ["Flatcar", "Rocky"]
+    - guest_os_ansible_distribution in vm_guest_facts.instance.hw_guest_full_name
 
 - block:
     - name: "Assert Guest OS fullname is either {{ guest_fullname[0] }} or {{ guest_fullname[1] }}"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -65,16 +65,20 @@
         - "'sle' in guest_id"
         - firmware is defined and firmware|lower == "bios"
 
-    # For RHEL, CentOS, OracleLinux, sendkey to boot screen to not do
-    # disk check and start installation directly
+    # For RHEL, CentOS, RockyLinux, OracleLinux, sendkey to boot screen to not do
+    # disk check and start installation directly. RockyLinux is using Other 4.x or
+    # later Linux (64-bit) as guest OS type.
     - block:
         - include_tasks: ../../common/vm_guest_send_key.yml
           vars:
             keys_send:
               - UPARROW
               - ENTER
-      when:
-        - ('rhel' in guest_id) or ('centos' in guest_id) or ('oracleLinux' in guest_id)
+      when: >
+        ('rhel' in guest_id) or
+        ('centos' in guest_id) or
+        ('oracleLinux' in guest_id) or
+        ('other' in guest_id)
 
     # For Photon OS installation
     - block:
@@ -90,7 +94,7 @@
       when:
         - "'Photon' in guest_id"
 
-    # For RedHat, OracleLinux, CentOS, SLED, SLES, Ubuntu installation
+    # For RedHat, OracleLinux, CentOS, RockyLinux, SLED, SLES, Ubuntu installation
     # Wait Guest OS is installed and connectable
     - block:
         - include_tasks: ../../common/update_inventory.yml
@@ -133,9 +137,9 @@
               pause:
                 seconds: 5
           when:
+            - guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS"]
             - guest_os_ansible_distribution_major_ver|int == 7
             - guest_os_with_gui is defined and guest_os_with_gui
-            - guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS"]
         - block:
             - include_tasks: ../utils/wait_for_service_status.yml
               vars:
@@ -158,7 +162,7 @@
           when: unattend_install_conf is defined and unattend_install_conf
       when:
         - "'Photon' not in guest_id"
-        - guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS", "SLED", "SLES"]
+        - guest_os_family in ["RedHat", "Suse"]
 
     - include_tasks: ../../common/print_test_result.yml
       vars:

--- a/linux/guest_customization/check_network_config.yml
+++ b/linux/guest_customization/check_network_config.yml
@@ -128,17 +128,17 @@
       when: >
         (guest_os_ansible_distribution == "Ubuntu" and guest_os_with_gui is defined and guest_os_with_gui) or
         (guest_os_ansible_distribution != "Ubuntu")
-  when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+  when: guest_os_family == "Debian"
 
 - name: "Set GOSC network configuration files on RedHat"
   set_fact:
     src_network_file: "/etc/sysconfig/network-scripts/ifcfg-{{ guest_iface_name }}"
-  when: guest_os_ansible_distribution in ["RedHat", "CentOS", "Amazon", "OracleLinux"]
+  when: guest_os_family == "RedHat"
 
 - name: "Set GOSC network configuration files on SLE"
   set_fact:
     src_network_file: "/etc/sysconfig/network/ifcfg-{{ guest_iface_name }}"
-  when: guest_os_ansible_distribution in ["SLES", "SLED"]
+  when: guest_os_family == "Suse"
 
 - block:
     - name: "Print the network configuration file on {{ guest_os_ansible_distribution }}"

--- a/linux/guest_customization/linux_gosc_start.yml
+++ b/linux/guest_customization/linux_gosc_start.yml
@@ -9,15 +9,15 @@
     - name: "Set fact of the hosts template file hosts.debian.tmpl"
       set_fact:
         hosts_template_file: "/etc/cloud/templates/hosts.debian.tmpl"
-      when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+      when: guest_os_family == "Debian"
     - name: "Set fact of the hosts template file hosts.redhat.tmpl"
       set_fact:
         hosts_template_file: "/etc/cloud/templates/hosts.redhat.tmpl"
-      when: guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS"]
+      when: guest_os_family == "RedHat"
     - name: "Set fact of the hosts template file hosts.suse.tmpl"
       set_fact:
         hosts_template_file: "/etc/cloud/templates/hosts.suse.tmpl"
-      when: guest_os_ansible_distribution in ["SLES", "SLED"]
+      when: guest_os_family == "Suse"
     - name: "Set fact of the hosts template file hosts.photon.tmpl"
       set_fact:
         hosts_template_file: "/etc/cloud/templates/hosts.photon.tmpl"

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -58,7 +58,7 @@
             update_cache: True
           when:
             - which_perl_result.rc is undefined or which_perl_result.rc != 0
-            - guest_os_ansible_distribution_major_ver | int == 7
+            - guest_os_ansible_kernel is version('4.0', '<')
 
         - include_tasks: ../utils/install_uninstall_package.yml
           vars:
@@ -67,10 +67,10 @@
             update_cache: True
           when:
             - which_perl_result.rc is undefined or which_perl_result.rc != 0
-            - guest_os_ansible_distribution_major_ver | int >= 8
+            - guest_os_ansible_kernel is version('4.0', '>=')
       when:
         - not enable_cloudinit_gosc | bool
-        - guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux']
+        - guest_os_family == "RedHat"
 
     # Check cloud-init version for cloud-init gosc workflow
     - include_tasks: ../utils/cloudinit_pkg_check.yml

--- a/linux/network_device_ops/enable_new_ethernet.yml
+++ b/linux/network_device_ops/enable_new_ethernet.yml
@@ -7,7 +7,7 @@
       set_fact:
         network_conf_template: rhel_network_conf.j2
         network_conf_path: "/etc/sysconfig/network-scripts/ifcfg-{{ eth_dev }}"
-      when: guest_os_ansible_distribution in ["RedHat", "CentOS", "Amazon", "OracleLinux"]
+      when: guest_os_family == "RedHat"
 
     - name: "Set fact of the network configure file for Ubuntu desktop"
       set_fact:
@@ -33,7 +33,7 @@
       set_fact:
         network_conf_template: sles_network_conf.j2
         network_conf_path: "/etc/sysconfig/network/ifcfg-{{ eth_dev }}"
-      when: guest_os_ansible_distribution in ["SLES", "SLED"]
+      when: guest_os_family == "Suse"
 
     - name: "Set fact of the network configure file for Flatcar"
       set_fact:

--- a/linux/open_vm_tools/get_install_uninstall_cmd.yml
+++ b/linux/open_vm_tools/get_install_uninstall_cmd.yml
@@ -25,8 +25,8 @@
     check_update_cmd: "dnf check-update"
     clean_cache_cmd: "dnf clean all"
   when:
-    - guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux']
-    - guest_os_ansible_distribution_major_ver | int > 7
+    - guest_os_family == "RedHat"
+    - guest_os_ansible_pkg_mgr | lower == "dnf"
 
 - name: "Set OS commands for installing or uninstalling packages on {{ guest_os_ansible_distribution }}"
   set_fact:
@@ -35,16 +35,8 @@
     check_update_cmd: "yum check-update"
     clean_cache_cmd: "yum clean all"
   when:
-    - guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux']
-    - guest_os_ansible_distribution_major_ver | int <= 7
-
-- name: "Set OS commands for installing or uninstalling packages on {{ guest_os_ansible_distribution }}"
-  set_fact:
-    package_install_cmd: "yum install -y"
-    package_uninstall_cmd: "yum remove -y"
-    check_update_cmd: "yum check-update"
-    clean_cache_cmd: "yum clean all"
-  when: guest_os_ansible_distribution == "Amazon"
+    - guest_os_family == "RedHat"
+    - guest_os_ansible_pkg_mgr | lower == "yum"
 
 - name: "Set OS commands for installing or uninstalling packages on {{ guest_os_ansible_distribution }}"
   set_fact:
@@ -52,7 +44,7 @@
     package_uninstall_cmd: "zypper remove -y"
     check_update_cmd: "zypper ref"
     clean_cache_cmd: "zypper clean -a"
-  when: guest_os_ansible_distribution in ['SLES', 'SLED']
+  when: guest_os_family == "Suse"
 
 - name: "Set OS commands for installing or uninstalling packages on {{ guest_os_ansible_distribution }}"
   set_fact:
@@ -60,7 +52,7 @@
     package_uninstall_cmd: "apt-get purge -y"
     check_update_cmd: "apt-get update"
     clean_cache_cmd: "apt-get clean"
-  when: guest_os_ansible_distribution in ['Ubuntu', 'Debian']
+  when: guest_os_family == "Debian"
 
 - name: "Check OS commands are valid"
   assert:

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -3,7 +3,7 @@
 ---
 # Description:
 #   This test case is to verify open-vm-tools installation. If VM doesn't install open-vm-tools, this case will install open-vm-tools from
-# OS ISO image (RHEL/SLES/SLED) or official online repository (Ubuntu/Photon OS/CentOS/OracleLinux). Or if it already has open-vm-tools
+# OS ISO image (RHEL/SLES/SLED) or official online repository (Ubuntu/Photon OS/CentOS/RockyLinux/OracleLinux). Or if it already has open-vm-tools
 # installed and updat_tools is set True in vars/test.yml, it will reinstall open-vm-tools. And then check the install or reinstall output.
 #
 - name: ovt_verify_install

--- a/linux/open_vm_tools/set_ovt_facts.yml
+++ b/linux/open_vm_tools/set_ovt_facts.yml
@@ -19,12 +19,12 @@
   set_fact:
     ovt_service: "open-vm-tools"
     vgauth_service: "vgauth"
-  when: guest_os_ansible_distribution in ['Ubuntu', 'Debian']
+  when: guest_os_family == "Debian"
 
 - name: "Add extra package libvmtools0 for SUSE"
   set_fact:
     ovt_packages: "{{ ovt_packages | union(['libvmtools0']) }}"
-  when: guest_os_ansible_distribution in ['SLES', 'SLED']
+  when: guest_os_family == "Suse"
 
 - name: "Update the fact of open-vm-tools packages and proecesses for OS with desktop"
   set_fact:

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -21,6 +21,19 @@
           vars:
             vmtools_check: "False"
 
+        - block:
+            - name: "Skip testcase: {{ ansible_play_name }}"
+              debug:
+                msg: "Skip testcase because {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} doesn't support secure boot."
+
+            - include_tasks: ../../common/print_test_result.yml
+              vars:
+                test_result: "No Run"
+            - meta: end_play
+          when:
+            - guest_os_ansible_distribution == "Rocky"
+            - guest_os_ansible_distribution_ver is version('8.4', '<=')
+
         - include_tasks: ../../common/vm_get_boot_info.yml
 
         - block:

--- a/linux/utils/add_extra_online_repo.yml
+++ b/linux/utils/add_extra_online_repo.yml
@@ -13,7 +13,7 @@
     repo_name: "{{ extra_repo_name }}"
     repo_baseurl: "{{ extra_repo_baseurl }}"
     gpg_check: False
-  when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux", "SLES", "SLED", "VMware Photon OS"]
+  when: guest_os_family in ["RedHat", "Suse", "VMware Photon OS"]
 
 # Add APT source
 - block:
@@ -33,4 +33,4 @@
       vars:
         file: "{{ apt_source_file }}"
         line_content: "{{ apt_source }}"
-  when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+  when: guest_os_family == "Debian"

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -3,7 +3,7 @@
 ---
 # Add official online package repository
 - block:
-    - name: "Set BaseOS repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+    - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
       set_fact:
         online_repos:
           - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}"
@@ -14,7 +14,7 @@
         - guest_os_ansible_distribution == "CentOS"
         - guest_os_ansible_distribution_major_ver | int < 8
 
-    - name: "Set BaseOS and AppStream repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+    - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
       set_fact:
         online_repos:
           - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
@@ -33,7 +33,7 @@
         - guest_os_ansible_distribution == "CentOS"
         - guest_os_ansible_distribution_major_ver | int >= 8
 
-    - name: "Set BaseOS and AppStream repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+    - name: "Set online repositories for Rocky Linux {{ guest_os_ansible_distribution_ver }}"
       set_fact:
         online_repos:
           - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -10,7 +10,9 @@
             baseurl: "http://mirror.centos.org/$contentdir/$releasever/os/$basearch"
             mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra"
             gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
-      when: guest_os_ansible_distribution_major_ver | int < 8
+      when:
+        - guest_os_ansible_distribution == "CentOS"
+        - guest_os_ansible_distribution_major_ver | int < 8
 
     - name: "Set BaseOS and AppStream repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
       set_fact:
@@ -23,7 +25,27 @@
             baseurl: "http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/"
             mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra"
             gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
-      when: guest_os_ansible_distribution_major_ver | int >= 8
+          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_PowerTools"
+            baseurl: "http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/"
+            mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra"
+            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+      when:
+        - guest_os_ansible_distribution == "CentOS"
+        - guest_os_ansible_distribution_major_ver | int >= 8
+
+    - name: "Set BaseOS and AppStream repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+      set_fact:
+        online_repos:
+          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
+            mirrorlist: "https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever"
+            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial"
+          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_AppStrem"
+            mirrorlist: "https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever"
+            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial"
+          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_PowerTools"
+            mirrorlist: "https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever"
+            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial"
+      when: guest_os_ansible_distribution == "Rocky"
 
     - include_tasks: add_repo_from_baseurl.yml
       vars:
@@ -35,7 +57,7 @@
       with_list: "{{ online_repos }}"
       loop_control:
         loop_var: "online_repo"
-  when: guest_os_ansible_distribution == "CentOS"
+  when: guest_os_ansible_distribution in ["CentOS", "Rocky"]
 
 - block:
     - name: "Set default online repository for OracleLinux {{ guest_os_ansible_distribution_ver }}"

--- a/linux/utils/add_repo_from_baseurl.yml
+++ b/linux/utils/add_repo_from_baseurl.yml
@@ -22,6 +22,7 @@
     gpg_key_path: |-
       {%- if guest_os_ansible_distribution == "RedHat" -%}file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       {%- elif guest_os_ansible_distribution == "CentOS" -%}file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+      {%- elif guest_os_ansible_distribution == "Rocky" -%}file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
       {%- elif guest_os_ansible_distribution == "OracleLinux"  -%}file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
       {%- elif guest_os_ansible_distribution == "VMware Photon OS"  -%}file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
       {%- else -%}{%- endif -%}
@@ -69,7 +70,7 @@
         - add_yum_repo_result is defined
         - add_yum_repo_result.diff is defined
         - add_yum_repo_result.diff.after_header is defined
-  when: guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux', 'VMware Photon OS', 'Amazon']
+  when: guest_os_family in ["RedHat", "VMware Photon OS"]
 
 # Add repo for SLES/SLED
 - block:
@@ -89,4 +90,4 @@
         enabled: True
         runrefresh: True
       delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_ansible_distribution in ["SLES", "SLED"]
+  when: guest_os_family == "Suse"

--- a/linux/utils/check_guest_os_gui.yml
+++ b/linux/utils/check_guest_os_gui.yml
@@ -10,7 +10,7 @@
   - name: "Set fact of guest OS with/without desktop experience"
     set_fact:
       guest_os_with_gui: "{% if not result.stat.exists %}False{% else %}True{% endif %}"
-  when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+  when: guest_os_family == "Debian"
 
 # For SLES/SLED, if runlevel is 5, means OS has Desktop
 - block:
@@ -25,7 +25,7 @@
     - name: "Set fact of guest OS with/without desktop experience"
       set_fact:
         guest_os_with_gui: "{% if runlevel_output.stdout.find('5') != -1 %}True{% else %}False{% endif %}"
-  when: guest_os_ansible_distribution in ["SLES", "SLED"]
+  when: guest_os_family == "Suse"
 
 # Photon, Amazon and Flatcar have no desktop
 - block:
@@ -44,8 +44,7 @@
     - name: "Set fact of guest OS with/without desktop experience"
       set_fact:
         guest_os_with_gui: "{% if not X_output.stat.exists %}False{% else %}True{% endif %}"
-  when:
-    guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS", "Fedora"]
+  when: guest_os_family == "RedHat"
 
 - block:
     - name: "Check if guest OS has desktop environment"

--- a/linux/utils/disable_repo.yml
+++ b/linux/utils/disable_repo.yml
@@ -11,13 +11,13 @@
     - name: "Disable all yum repositories"
       shell: "sed -i 's/enabled *= *1/enabled=0/' /etc/yum.repos.d/*.repo"
       delegate_to: "{{ vm_guest_ip }}"
-      when: guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux', 'VMware Photon OS', 'Amazon']
+      when: guest_os_family in ['RedHat', 'VMware Photon OS']
 
     # SUSE
     - name: "Disable all zypper repositories"
       shell: "sed -i 's/enabled *= *1/enabled=0/' /etc/zypp/repos.d/*.repo"
       delegate_to: "{{ vm_guest_ip }}"
-      when: guest_os_ansible_distribution in ['SLES', 'SLED']
+      when: guest_os_family == "Suse"
   when: repo_name is undefined or not repo_name
 
 # Disable repo with name {{ repo_name }}
@@ -33,7 +33,7 @@
           command: "dnf config-manager --set-disabled {{ repo_name }}"
           delegate_to: "{{ vm_guest_ip }}"
           when: guest_os_ansible_pkg_mgr | lower == "dnf"
-      when: guest_os_ansible_distribution in ['RedHat', 'CentOS', 'OracleLinux', 'Amazon']
+      when: guest_os_family == 'RedHat'
 
     # Photon OS
     - name: "Disable yum repository {{ repo_name }}"
@@ -45,6 +45,6 @@
     - name: "Disable zypper repository {{ repo_name }}"
       command: "zypper mr -d {{ repo_name }}"
       delegate_to: "{{ vm_guest_ip }}"
-      when: guest_os_ansible_distribution in ['SLES', 'SLED']
+      when: guest_os_family == "Suse"
   when: repo_name is defined and repo_name
 

--- a/linux/utils/enable_auto_login.yml
+++ b/linux/utils/enable_auto_login.yml
@@ -18,12 +18,12 @@
 - name: "Get GNOME configuration file for {{ guest_os_ansible_distribution }}"
   set_fact:
     gdm_conf_path: "/etc/gdm/custom.conf"
-  when: guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS"]
+  when: guest_os_family == "RedHat"
 
 - name: "Get GNOME configuration file for {{ guest_os_ansible_distribution }}"
   set_fact:
     gdm_conf_path: "/etc/sysconfig/displaymanager"
-  when: guest_os_ansible_distribution in ["SLES", "SLED"]
+  when: guest_os_family == "Suse"
 
 - name: "Get GNOME configuration file for Ubuntu"
   set_fact:
@@ -67,7 +67,7 @@
         - gdm_stat_result.stat.exists is defined
         - gdm_stat_result.stat.exists
   when:
-    - guest_os_ansible_distribution in ["RedHat", "OracleLinux", "CentOS", "Ubuntu", "Debian"]
+    - guest_os_family in ["RedHat", "Debian"]
     - enable_gnome_autologin is defined
     - enable_gnome_autologin
 

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -37,9 +37,9 @@
 - include_tasks: ../utils/add_local_dvd_repo.yml
   when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat']
 
-# Add online repo for CentOS, OracleLinux, Ubuntu, Debian and Photon
+# Add online repo for RockyLinux, CentOS, OracleLinux, Ubuntu, Debian and Photon
 - include_tasks: ../utils/add_official_online_repo.yml
-  when: guest_os_ansible_distribution in ['CentOS', 'OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
+  when: guest_os_ansible_distribution in ['Rocky', 'CentOS', 'OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
 
 - block:
     - block:
@@ -105,7 +105,7 @@
         allow_downgrade: yes
         state: "{{ package_state }}"
       delegate_to: "{{ vm_guest_ip }}"
-      when: guest_os_ansible_distribution_major_ver | int <= 7
+      when: guest_os_ansible_pkg_mgr | lower == "yum"
 
     - name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
       dnf:
@@ -113,23 +113,15 @@
         allow_downgrade: yes
         state: "{{ package_state }}"
       delegate_to: "{{ vm_guest_ip }}"
-      when: guest_os_ansible_distribution_major_ver | int >= 8
-  when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux"]
-
-- name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
-  yum:
-    name: "{{ package_name }}"
-    state: "{{ package_state }}"
-    update_cache: "{{ update_cache | default(True) }}"
-  delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_ansible_distribution == "Amazon"
+      when: guest_os_ansible_pkg_mgr | lower == "dnf"
+  when: guest_os_family == "RedHat"
 
 - name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
   zypper:
     name: "{{ package_name }}"
     state: "{{ package_state }}"
   delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_ansible_distribution in ["SLES", "SLED"]
+  when: guest_os_family == "Suse"
 
 - block:
     - include_tasks: remove_dpkg_lock_file.yml
@@ -138,4 +130,4 @@
         name: "{{ package_name }}"
         state: "{{ package_state }}"
       delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+  when: guest_os_family == "Debian"

--- a/linux/utils/set_proxy.yml
+++ b/linux/utils/set_proxy.yml
@@ -10,7 +10,7 @@
 - name: "Set the proxy config file for YUM in {{ guest_os_ansible_distribution }}"
   set_fact:
     proxy_conf_file: "/etc/yum.conf"
-  when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux"]
+  when: guest_os_family == "RedHat"
 
 - name: "Set the proxy config file for tdnf in {{ guest_os_ansible_distribution }}"
   set_fact:

--- a/linux/utils/test_setup.yml
+++ b/linux/utils/test_setup.yml
@@ -118,7 +118,7 @@
     # Prepare VM ansible run environment
     # If it is a Ubuntu or Debian system, modify sshd config to keep connection alive
     - include_tasks: ssh_keep_alive.yml
-      when: guest_os_ansible_distribution in ["Ubuntu", "Debian"]
+      when: guest_os_family == "Debian"
     # Diable auto update for Ubuntu OS
     - include_tasks: disable_auto_update.yml
 

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -37,7 +37,7 @@
             - name: "Set the vgauth service name for Ubuntu/Debian"
               set_fact:
                 vgauth_service: "vgauth"
-              when: guest_os_ansible_distribution in ['Ubuntu', 'Debian']
+              when: guest_os_family == "Debian"
 
             # Check VGAuth processe is running
             - include_tasks: ../utils/check_process_status.yml

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -16,7 +16,7 @@
         - meta: end_play
       when:
         - new_disk_ctrl_type in ["lsilogic", "lsilogicsas"]
-        - guest_os_ansible_distribution in ["RedHat", "CentOS"]
+        - guest_os_ansible_distribution in ["RedHat", "CentOS", "Rocky"]
         - guest_os_ansible_distribution_major_ver | int >= 8
 
     - name: "Set fact of the iozone file path"

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -12,9 +12,7 @@
     - block:
         - name: "Set SCSI command tools package name"
           set_fact:
-            sg3_utils_pkg: |-
-              {%- if guest_os_ansible_distribution in ["Ubuntu", "Debian"] -%}sg3-utils
-              {%- else -%}sg3_utils{%- endif -%}
+            sg3_utils_pkg: "{{ 'sg3-utils' if guest_os_family == 'Debian' else 'sg3_utils' }}"
     
         # Install SCSI command tools
         - include_tasks: ../utils/get_installed_package_info.yml


### PR DESCRIPTION
Add a new running time variable guest_os_family to categorize OS distributions, such as:
```
  For RedHat, CentOS, OracleLinux, Rocky, Amazon, Fedora, guest_os_family="RedHat" 
  For SLES, SLED, guest_os_family="Suse"
  For Ubuntu, Debian, guest_os_family="Debian"
  For VMware Photon OS, guest_os_family="VMware Photon OS" 
  For Flatcar,  guest_os_family="Flatcar"
  For Windows and Windows Server, guest_os_family="Windows"
```

With this variable, we can easily extend the support OS list for OS varieties.
