### PR TITLE
Add ignore_errors in vm_take_snapshot.yml

### DIFF
--- a/common/vm_revert_snapshot.yml
+++ b/common/vm_revert_snapshot.yml
@@ -4,14 +4,15 @@
 # Revert to snapshot of VM
 # Parameters:
 #   snapshot_name: the name of snapshot to revert
-#   skip_if_not_exist: skip reverting snapshot if the snapshot doesn't exist. Default is False.
+#   skip_if_not_exist: if set to True, revert snapshot task will not fail when snapshot doesn't exist.
+#   Default value is False.
 #
-- name: Set fact of skip revert of snapshot not exist
+- name: Set fact of revert to snapshot failed if not exist
   set_fact:
     skip_if_not_exist: False
   when: skip_if_not_exist is undefined
 
-- name: "Revert {{ vm_name }} to snapshot {{ snapshot_name }}"
+- name: "Revert to snapshot {{ snapshot_name }}"
   vmware_guest_snapshot:
     hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"
@@ -22,35 +23,32 @@
     name: "{{ vm_name }}"
     state: revert
     snapshot_name: "{{ snapshot_name }}"
-  ignore_errors: yes
+  ignore_errors: True
   register: revert_result
-
 - debug: var=revert_result
   when: enable_debug is defined and enable_debug
 
 # Handle revert snasphot failure
 - block:
-    - name: "Get snasphot nonexistent message"
+    - name: "Check snasphot not exist failure message"
       set_fact:
-        msg_no_snapshots: "{{ revert_result.msg|regex_search('does not have any snapshots to revert') }}"
-        msg_not_find_snapshot: "{{ revert_result.msg|regex_search('Couldn.t find any snapshots with specified name') }}"
-    - name: "Get snasphot nonexistent status"
-      set_fact:
-        error_of_snapshot_nonexistent: "{{ msg_no_snapshots or msg_not_find_snapshot }}"
-    - block:
-        - name: "Snapshot {{ snapshot_name }} doesn't exist"
-          debug:
-            msg: "Snapshot {{ snapshot_name }} doesn't exist"
-        - name: "Revert to nonexistent snapshot {{ snapshot_name }} failed"
-          fail:
-            msg: "Revert to nonexistent snapshot {{ snapshot_name }} failed"
-          when: not skip_if_not_exist
-      when: error_of_snapshot_nonexistent
-    - name: "Revert to {{ snapshot_name }} failed"
+        msg_no_snapshots: "{{ revert_result.msg | regex_search('does not have any snapshots to revert') }}"
+        msg_not_find_snapshot: "{{ revert_result.msg | regex_search('Couldn.t find any snapshots with specified name') }}"
+    
+    # Ignore snapshot not exist failure when skip_if_not_exist is set to True
+    - debug:
+        msg: "Snapshot '{{ snapshot_name }}' not exist, but 'skip_if_not_exist' is set to True"
+      when:
+        - skip_if_not_exist
+        - msg_no_snapshots or msg_not_find_snapshot
+    
+    # Other failures
+    - name: "Revert snapshot failed"
       fail:
-        msg: "Revert to {{ snapshot_name }} failed"
-      when: not error_of_snapshot_nonexistent
+        msg: "Revert to snapshot '{{ snapshot_name }}' failed"
   when:
+    - "'failed' in revert_result"
+    - revert_result.failed
     - "'msg' in revert_result"
 
 # Get snapshot facts until current snapshot is the expected one

--- a/common/vm_take_snapshot.yml
+++ b/common/vm_take_snapshot.yml
@@ -14,6 +14,7 @@
     snapshot_name: "{{ snapshot_name }}"
     quiesce: "{{ is_quiesce | default(False) }}"
     memory_dump: "{{ dump_memory | default(True) }}"
+  ignore_errors: "{{ vm_take_snapshot_ignore_err | default(False) }}"
   register: task_result
 - name: Display the result of taking snapshot
   debug: var=task_result

--- a/linux/utils/test_rescue.yml
+++ b/linux/utils/test_rescue.yml
@@ -40,15 +40,15 @@
       vars:
         snapshot_name: "fail-{{ testcase }}-{{ timestamp }}"
         dump_memory: "yes"
+        vm_take_snapshot_ignore_err: True
   when: take_fail_snapshot
 
 # Clean router VM, vSwitch and port group
 - block:
-    - block:
-        - include_tasks: ../../common/vm_revert_snapshot.yml
-          vars:
-            snapshot_name: "{{ base_snapshot_name }}"
-            skip_if_not_exist: True
+    - include_tasks: ../../common/vm_revert_snapshot.yml
+      vars:
+        snapshot_name: "{{ base_snapshot_name }}"
+        skip_if_not_exist: True
       when: revert_to_base
     - include_tasks: ../../common/network_testbed_cleanup.yml
   when:
@@ -56,9 +56,8 @@
     - exit_testing_when_fail is defined and exit_testing_when_fail
 
 # Exit ansible run if exit_testing_when_fail is True
-- block:
-    - name: "Exit testing when exit_testing_when_fail is set True"
-      fail:
-        msg: "Failed to run test case {{ testcase }}"
+- name: "Exit testing when exit_testing_when_fail is set True"
+  fail:
+    msg: "Failed to run test case {{ testcase }}"
   when:
     - exit_testing_when_fail is defined and exit_testing_when_fail

--- a/windows/setup/rescue_cleanup.yml
+++ b/windows/setup/rescue_cleanup.yml
@@ -22,6 +22,7 @@
       vars:
         snapshot_name: "{{ current_testcase_name }}_fail_{{ timestamp }}"
         dump_memory: yes
+        vm_take_snapshot_ignore_err: True
   when: rescue_take_failed_snapshot is undefined or rescue_take_failed_snapshot|bool
 
 # Revert back to base snapshot when test case failed


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Fixes #89 
1. Refine common task `vm_revert_snapshot.yml`.
2. Add ignore_errors in common task `vm_take_snapshot.yml`.
3. Set ignore_errors to True in test rescue tasks.