### PR TITLE
Add Alma Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This project supports below scenarios for end-to-end guest OS validation testing
 * Deploy VM from an OVA template
 * Existing VM with installed guest OS, which should satisfy below requirments.
   * SSH and Python are installed and enabled
+  * The vm_python variable in vars/test.yml must be set with correct python path. Or user can set PATH in /etc/environment in guest OS to include the binary directory path to python.
   * The root user should be enabled and permitted to log in through SSH in Linux guest OS
   * Execute [ConfigureRemotingForAnsible.ps1](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1) script in Windows guest OS in advance
 

--- a/common/get_guest_system_info.yml
+++ b/common/get_guest_system_info.yml
@@ -43,7 +43,10 @@
     - name: "Set OS family for {{ guest_os_ansible_distribution }} to RedHat"
       set_fact:
         guest_os_family: "RedHat"
-      when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux", "Rocky", "Amazon", "Fedora"]
+      when:
+        - "'ansible_distribution_file_variety' in guest_system_info"
+        - guest_system_info.ansible_distribution_file_variety == "RedHat"
+        - guest_os_family != "RedHat"
 
     - name: "Print guest OS information"
       debug:

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -40,10 +40,6 @@
                 guest_fullname: "Ubuntu Linux {{ bitness }}"
               when: guest_os_ansible_distribution == "Ubuntu"
 
-            # Map RockyLinux and Flatcar full name
-            - include_tasks: otherlinux_fullname_map.yml
-              when: guest_os_ansible_distribution in ["Rocky", "Flatcar"]
-
             # Map RHEL full name
             - include_tasks: rhel_fullname_map.yml
               when: guest_os_ansible_distribution == "RedHat"
@@ -77,6 +73,10 @@
               set_fact:
                 guest_fullname: "FreeBSD {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
               when: guest_os_ansible_distribution == "FreeBSD"
+
+            # Map Other Linux
+            - include_tasks: otherlinux_fullname_map.yml
+              when: guest_os_ansible_distribution not in ["RedHat", "SLES", "SLED", "CentOS", "OracleLinux", "Ubuntu", "Debian", "Amazon", "VMware Photon OS", "FreeBSD"]
 
             # Validate guest OS fullname in guestinfo
             - include_tasks: validate_os_fullname.yml

--- a/linux/check_os_fullname/otherlinux_fullname_map.yml
+++ b/linux/check_os_fullname/otherlinux_fullname_map.yml
@@ -2,25 +2,54 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Map Flatcar, RockyLinux, or other Linux distribution which doesn't have a unique guest id
-# Flatcar 2605 and later
+
+# If there is no best match of the guest full name on ESXi server, it will show the guest OS detailed information
+# in the guest full name, which include the kernel version and os distribution
+- name: "Set guest detailed data for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi 6.7GA"
+  set_fact:
+    guest_detailed_data: "Linux {{ guest_os_ansible_kernel }} {{ guest_os_ansible_distribution }}"
+
+# Linux 5.x
 - block:
-    # Map Flatcar when ESXi <= 7.0.0
-    - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
-      set_fact:
-        guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
+    # Map Linux 5.x when ESXi <= 7.0.0
+    - block:
+        - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
+          set_fact:
+            guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
+          when: "'other3xLinux' in vm_guest_id"
+
+        - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
+          set_fact:
+            guest_fullname: ["Other 4.x or later Linux {{ bitness }}", "Other 4.x Linux {{ bitness }}"]
+          when: "'other4xLinux' in vm_guest_id"
       when: esxi_version is version('7.0.0', '<=')
 
-    # Map Flatcar when ESXi > 7.0.0 as Other 5.x or later Linux is supported on ESXi 7.0.1 and later
+    # Map Linux 5.x when ESXi > 7.0.0 as Other 5.x or later Linux is supported on ESXi 7.0.1 and later
     - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi > 7.0.0"
       set_fact:
         guest_fullname: "Other 5.x or later Linux {{ bitness }}"
       when: esxi_version is version('7.0.0', '>')
   when: guest_os_ansible_kernel is version('5.0', '>=')
 
-# Flatcar 2512 and earlier or RockyLinux
-- name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }}"
-  set_fact:
-    guest_fullname: ["Other 4.x or later Linux {{ bitness }}", "Other 4.x Linux {{ bitness }}"]
+# Linux 4.x
+- block:
+    - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi <= 7.0.0"
+      set_fact:
+        guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
+      when: esxi_version is version('6.7.0', '<')
+
+    - name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }}"
+      set_fact:
+        guest_fullname: ["Other 4.x or later Linux {{ bitness }}", "Other 4.x Linux {{ bitness }}"]
+      when: esxi_version is version('6.7.0', '>=')
   when:
     - guest_os_ansible_kernel is version('5.0', '<')
     - guest_os_ansible_kernel is version('4.0', '>=')
+
+# Linux 3.x
+- name: "Set guest_fullname variable for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }}"
+  set_fact:
+    guest_fullname: ["Other 3.x or later Linux {{ bitness }}", "Other 3.x Linux {{ bitness }}"]
+  when:
+    - guest_os_ansible_kernel is version('4.0', '<')
+    - guest_os_ansible_kernel is version('3.0', '>=')

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -4,15 +4,15 @@
 # Wait VMware tools to report Guest OS fullname
 - include_tasks: ../../common/vm_wait_guest_fullname.yml
 
-# If the guest os full name has detailed OS info, test passed
+# If the guest os full name has detailed OS info on ESXi 6.7GA, test passed
 - block:
     - include_tasks: ../../common/print_test_result.yml
       vars:
         test_result: "Passed"
     - meta: end_play
   when:
-    - guest_os_ansible_distribution in ["Flatcar", "Rocky"]
-    - guest_os_ansible_distribution in vm_guest_facts.instance.hw_guest_full_name
+    - guest_detailed_data is defined and guest_detailed_data
+    - guest_detailed_data in vm_guest_facts.instance.hw_guest_full_name
 
 - block:
     - name: "Assert Guest OS fullname is either {{ guest_fullname[0] }} or {{ guest_fullname[1] }}"

--- a/linux/deploy_vm/flatcar/flatcar_post_config.yml
+++ b/linux/deploy_vm/flatcar/flatcar_post_config.yml
@@ -9,23 +9,6 @@
 
 - debug: var=ap3_install_result
 
-- block:
-    # Overwrite vm_python in inventory
-    - name: "Reset vm_python to /opt/bin/python"
-      set_fact:
-        vm_python: "/opt/bin/python"
-
-    - name: "Update host variable ansible_python_interpreter"
-      add_host:
-        hostname: "{{ vm_guest_ip }}"
-        groups: "target_vm"
-        ansible_python_interpreter: "{{ vm_python }}"
-      when:
-        - vm_guest_ip is defined
-        - groups.target_vm is defined
-        - vm_guest_ip in groups.target_vm
-  when: (vm_python != "/opt/bin/python") or (vm_python != "/opt/bin/python3")
-
 - name: "Check /etc/ssh/sshd_config status"
   stat:
     path: "/etc/ssh/sshd_config"

--- a/linux/deploy_vm/flatcar/install_python3.sh
+++ b/linux/deploy_vm/flatcar/install_python3.sh
@@ -79,7 +79,7 @@ else
     rm -rf $ap_python3_download_dir
 
     # Add /opt/bin to PATH for python auto discovery
-    echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin' >>/etc/environment
+    echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:$ap_python3_bin_dir" >>/etc/environment
 
     python_version=$($ap_python3_bin_dir/python -V)
     rc=$?

--- a/linux/deploy_vm/flatcar/install_python3.sh
+++ b/linux/deploy_vm/flatcar/install_python3.sh
@@ -78,6 +78,9 @@ else
     echo "Remove directory $ap_python3_download_dir"
     rm -rf $ap_python3_download_dir
 
+    # Add /opt/bin to PATH for python auto discovery
+    echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin' >>/etc/environment
+
     python_version=$($ap_python3_bin_dir/python -V)
     rc=$?
     if [ $rc -eq 0 ]; then

--- a/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
+++ b/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
@@ -26,6 +26,12 @@
 # Skip checking guest full name here because we will check it in TD1 case
 - include_tasks: ../../../common/vm_wait_guest_fullname.yml
 
+# Set vm_python to auto
+- name: "Reset vm_python to auto"
+  set_fact:
+    vm_python: "auto"
+  when: vm_python is defined and vm_python != "auto"
+
 # Get guest ip
 - include_tasks: ../../../common/update_inventory.yml
   vars:

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -16,8 +16,21 @@
         - meta: end_play
       when:
         - new_disk_ctrl_type in ["lsilogic", "lsilogicsas"]
-        - guest_os_ansible_distribution in ["RedHat", "CentOS", "Rocky"]
+        - guest_os_family == "RedHat"
+        - guest_os_ansible_distribution != "OracleLinux"
         - guest_os_ansible_distribution_major_ver | int >= 8
+
+    - block:
+        - name: "Skip testcase: {{ ansible_play_name }}"
+          debug:
+            msg: "Skip test case because VM with hardware version {{ vm_hardware_version_num }} doesn't support {{ new_disk_ctrl_type }} controller"
+        - include_tasks: ../../common/print_test_result.yml
+          vars:
+            test_result: "No Run"
+        - meta: end_play
+      when:
+        - new_disk_ctrl_type == "nvme"
+        - vm_hardware_version_num | int < 13
 
     - name: "Set fact of the iozone file path"
       set_fact:


### PR DESCRIPTION
Fix #100, #102, #91
Changes include:
1. Map OS family to RedHat if ansible_distribution_file_variety="RedHat"
2. Validate other Linux's guest full name with linux/check_os_fullname/otherlinux_fullname_map.yml according to linux kernel version. And if OS detailed data is detected in guest full name, pass the test.
3. Exclude OracleLinux from skipping tests lsilogic_vhba_device_ops and lsilogicsas_vhba_device_ops, as OracleLinux still supports the two scsi controllers.
4. Skip nvme_vhba_device_ops if VM's hardware version is less than 13.
5. Set /etc/environment in Flatcar to include the binary dir path to python, so that it can be discovered automatically by ansible.