### PR TITLE
Fix 97 update photon cache

### DIFF
--- a/linux/deploy_vm/set_new_vm_user_account.yml
+++ b/linux/deploy_vm/set_new_vm_user_account.yml
@@ -4,6 +4,12 @@
 # If configured VM username is not 'root', will add this user
 # when installing guest OS, while use 'root' user account
 # to run the testing
+
+- name: "Set a default regular user for testing"
+  set_fact:
+    new_user: "vmware"
+  when: vm_username == "root"
+
 - block:
     - name: "A new user '{{ vm_username }}' will be added"
       set_fact:

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -40,7 +40,6 @@
       vars:
         package_name: "cloud-init"
         package_state: "latest"
-        update_cache: True
       when: guest_os_ansible_distribution == "VMware Photon OS"
 
     # Install perl if guest OS doesn't have it
@@ -55,7 +54,6 @@
           vars:
             package_name: "perl"
             package_state: "latest"
-            update_cache: True
           when:
             - which_perl_result.rc is undefined or which_perl_result.rc != 0
             - guest_os_ansible_kernel is version('4.0', '<')
@@ -64,7 +62,6 @@
           vars:
             package_name: "perl-interpreter"
             package_state: "latest"
-            update_cache: True
           when:
             - which_perl_result.rc is undefined or which_perl_result.rc != 0
             - guest_os_ansible_kernel is version('4.0', '>=')

--- a/linux/network_device_ops/network_device_test.yml
+++ b/linux/network_device_ops/network_device_test.yml
@@ -11,7 +11,6 @@
       vars:
         package_name: "distrib-compat"
         package_state: "present"
-        update_cache: True
       when:
         - guest_os_ansible_distribution == "VMware Photon OS"
         - guest_os_ansible_distribution_major_ver | int < 4

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -18,6 +18,11 @@
         - (new_vm is undefined) or (not new_vm | bool)
         - vmtools_is_running
 
+    # Update photon repo cache
+    - include_tasks: ../utils/repo_update.yml
+      vars:
+        check_update_cmd: "tdnf makecache"
+
     - include_tasks: ../utils/get_installed_package_info.yml
       vars:
         package_name: "gawk"
@@ -26,7 +31,6 @@
       vars:
         package_name: "gawk"
         package_state: "present"
-        update_cache: True
       when:
         - package_info is defined
         - package_info | length == 0

--- a/linux/utils/cloudinit_pkg_check.yml
+++ b/linux/utils/cloudinit_pkg_check.yml
@@ -22,12 +22,10 @@
 - block:
     # Install cloud-init if it doesn't exist
     - block:
-        - include_tasks: repo_update.yml
         - include_tasks: install_uninstall_package.yml
           vars:
             package_name: "cloud-init"
             package_state: "present"
-            update_cache: True
 
         - include_tasks: get_installed_package_info.yml
           vars:

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -5,7 +5,6 @@
 #Parameters
 #  package_name: one or a list of packages to be installed or removed
 #  package_state: [absent, installed, latest, present, removed]. Default is present.
-#  update_cache: True to update cache or no before installing packages. Default is False.
 # Return:
 #  package_manage_output: The output of installing or uninstalling package
 
@@ -19,7 +18,6 @@
 - name: "Initialize variables for installing or uninstalling package"
   set_fact:
     package_state: "{% if package_state is undefined %}present{% endif %}"
-    update_cache: "{% if update_cache is undefined %}False{% endif %}"
     package_manage_output: ""
     local_task_name: |-
       {%- if package_state in [ 'installed', 'present' ] -%}
@@ -42,29 +40,6 @@
   when: guest_os_ansible_distribution in ['Rocky', 'CentOS', 'OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
 
 - block:
-    - block:
-       - name: "Set the fact that tdnf has not made cache"
-         set_fact:
-           tdnf_makecache: False
-
-       # When networking or dns is not ready, tdnf commands would fail
-       # So here we add retries for tndf makecache
-       - include_tasks: repo_update.yml
-         vars:
-           check_update_cmd: "tdnf makecache"
-
-       - name: "Set the fact that tdnf has finished making cache"
-         set_fact:
-           tdnf_makecache: True
-         when:
-           - repo_update_output is defined
-           - repo_update_output.stderr is defined
-           - not repo_update_output.stderr
-      when: >
-        (tdnf_makecache is undefined) or
-        (not tdnf_makecache) or
-        (update_cache is defined and update_cache)
-
     - name: "Convert packages name list to a string"
       set_fact:
         package_name_str: |-

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -23,7 +23,6 @@
           vars:
             package_name: "{{ sg3_utils_pkg }}"
             package_state: "present"
-            update_cache: True
           when:
             - package_info is defined
             - package_info | length == 0

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -111,10 +111,11 @@ validate_certs: False
 
 # In OS automatic install configuration files in this folder 'autoinstall',
 # default user account info is as below:
-# For Linux: user name must be 'root' for existing VM. For new VM, the password
-# for root is set with vm_password. If vm_username is not root, a new user with
-# vm_username will be added and password will be set with vm_password, and all
-# testing will be executed with root user.
+# For Linux: user name must be 'root' for existing VM. If vm_username is root,
+# a default regular user 'vmware' will be created; if vm_username is not root,
+# a new regular user specified by vm_username will be added. Both the root user
+# and regular user's password will be set with vm_password. All testing will be
+# executed with root user.
 # For Windows client: user name is 'test', password is B1gd3m0z.
 # For Windows Server: user name is 'Administrator', password is B1gd3m0z.
 vm_name: "CentOS_82_ansible_test"


### PR DESCRIPTION
Fix #97 Only update photon cache before taking base snapshot, then the following installing packages won't need to update again.

Fix #128 Add a default regular user 'vmware' if vm_username is root.