### PR TITLE
Add Astra Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This project supports below scenarios for end-to-end guest OS validation testing
 | Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04 desktop       |                                  |                          | :heavy_check_mark:                 |
 | Flatcar 2592.0.0 and later                      |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Debian 9.x, 10.x                                |                                  |                          | :heavy_check_mark:                 |
+| Astra Linux (Orel) 2.12.43                      |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Windows 10, 11                                  | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Windows Server 2019, 2022                       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Windows Server SAC releases                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -169,7 +169,7 @@
                     - vmware_video_package_result.rc == 0
                     - vmware_video_package_result.stdout is defined
                     - vmware_video_package_result.stdout
-              when: guest_os_family == "Debian"
+              when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
             - block:
                 - include_tasks: ../utils/get_installed_package_info.yml

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -14,7 +14,7 @@
 
     - name: "Set default guest OS list not support GOSC"
       set_fact:
-        gos_not_support_gosc: ["FreeBSD", "Flatcar", "Debian", "SLED"]
+        gos_not_support_gosc: ["FreeBSD", "Flatcar", "Debian", "SLED", "Astra Linux (Orel)"]
 
     - include_tasks: ../setup/test_setup.yml
       vars:

--- a/linux/network_device_ops/enable_new_ethernet.yml
+++ b/linux/network_device_ops/enable_new_ethernet.yml
@@ -55,7 +55,7 @@
       changed_when: False
       delegate_to: "{{ vm_guest_ip }}"
     - debug: var=network_config.stdout_lines
-  when: guest_os_ansible_distribution != "VMware Photon OS"
+  when: guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]
 
 # Apply netplan network config changes in Ubuntu server
 - block:
@@ -81,7 +81,7 @@
   shell: "ifdown {{ eth_dev }}; ifup {{ eth_dev }}"
   delegate_to: "{{ vm_guest_ip }}"
   register: set_link_down_up
-  when: guest_os_ansible_distribution not in ["VMware Photon OS", "Ubuntu", "Flatcar"]
+  when: guest_os_ansible_distribution not in ["VMware Photon OS", "Ubuntu", "Flatcar", "Astra Linux (Orel)"]
 
 # Get IP address of new interface
 - name: "Get link '{{ eth_dev }}' status"

--- a/linux/open_vm_tools/get_install_uninstall_cmd.yml
+++ b/linux/open_vm_tools/get_install_uninstall_cmd.yml
@@ -52,7 +52,7 @@
     package_uninstall_cmd: "apt-get purge -y"
     check_update_cmd: "apt-get update"
     clean_cache_cmd: "apt-get clean"
-  when: guest_os_family == "Debian"
+  when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
 - name: "Check OS commands are valid"
   assert:

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -36,6 +36,12 @@
             - include_tasks: ../utils/enable_auto_login.yml
               vars:
                 autologin_user: "vmware"
+              when: guest_os_ansible_distribution != 'Astra Linux (Orel)'
+
+            - include_tasks: ../utils/enable_auto_login_fly_dm.yml
+              vars:
+                autologin_user: "vmware"
+              when: guest_os_ansible_distribution == 'Astra Linux (Orel)'
 
             # Reboot to make changes take effect and wait for tools running
             - include_tasks: ../utils/vm_reboot.yml

--- a/linux/open_vm_tools/set_ovt_facts.yml
+++ b/linux/open_vm_tools/set_ovt_facts.yml
@@ -19,7 +19,7 @@
   set_fact:
     ovt_service: "open-vm-tools"
     vgauth_service: "vgauth"
-  when: guest_os_family == "Debian"
+  when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
 - name: "Add extra package libvmtools0 for SUSE"
   set_fact:

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -23,9 +23,9 @@
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip testcase because {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} doesn't support secure boot."
-          when:
-            - guest_os_ansible_distribution == "Rocky"
-            - guest_os_ansible_distribution_ver is version('8.4', '<=')
+          when: >
+            (guest_os_ansible_distribution == "Rocky" and guest_os_ansible_distribution_ver is version('8.4', '<=')) or
+            (guest_os_ansible_distribution == "Astra Linux (Orel)")
 
         - include_tasks: ../../common/vm_get_boot_info.yml
 

--- a/linux/utils/check_guest_os_gui.yml
+++ b/linux/utils/check_guest_os_gui.yml
@@ -10,7 +10,7 @@
   - name: "Set fact of guest OS with/without desktop experience"
     set_fact:
       guest_os_with_gui: "{% if not result.stat.exists %}False{% else %}True{% endif %}"
-  when: guest_os_family == "Debian"
+  when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
 # For SLES/SLED, if runlevel is 5, means OS has Desktop
 - block:

--- a/linux/utils/enable_auto_login_fly_dm.yml
+++ b/linux/utils/enable_auto_login_fly_dm.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Enable FLY-DM auto login for user
+# Parameter:
+#   autologin_user: The username to auto login
+
+- name: "Enable FLY-DM autologin for {{ guest_os_ansible_distribution }}"
+  block:
+
+    - ansible.builtin.lineinfile:
+        path: /etc/X11/fly-dm/fly-dmrc
+        regexp: "{{ item }}"
+        state: absent
+      loop:
+        - ".*AutoLoginEnable=.*"
+        - ".*AutoLoginUser=.*"
+
+    - ansible.builtin.lineinfile:
+        path: /etc/X11/fly-dm/fly-dmrc
+        line: "{{ item }}"
+        insertafter: "^\\[X-:0-Core\\]$"
+      loop:
+        - "AutoLoginEnable=true"
+        - "AutoLoginUser={{ autologin_user }}"
+
+  delegate_to: "{{ vm_guest_ip }}"

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -105,4 +105,4 @@
         name: "{{ package_name }}"
         state: "{{ package_state }}"
       delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_family == "Debian"
+  when: guest_os_family in ["Debian", "Astra Linux (Orel)"]

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -32,7 +32,7 @@
         - name: "Set the vgauth service name for Ubuntu/Debian"
           set_fact:
             vgauth_service: "vgauth"
-          when: guest_os_family == "Debian"
+          when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
         # Check VGAuth processe is running
         - include_tasks: ../utils/check_process_status.yml

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -12,7 +12,7 @@
     - block:
         - name: "Set SCSI command tools package name"
           set_fact:
-            sg3_utils_pkg: "{{ 'sg3-utils' if guest_os_family == 'Debian' else 'sg3_utils' }}"
+            sg3_utils_pkg: "{{ 'sg3-utils' if guest_os_family in ['Debian', 'Astra Linux (Orel)'] else 'sg3_utils' }}"
     
         # Install SCSI command tools
         - include_tasks: ../utils/get_installed_package_info.yml


### PR DESCRIPTION
Hello.
This is an adaptation of tests for the Astra Linux Orel distro (https://astralinux.ru/).

Image for tests - https://nas01.astralinux.ru/sharing/wJss3PxqA

```
Testbed information:
+-------------------------------------------------------------+
| Product | Version | Build    | Hostname or IP               |
+-------------------------------------------------------------+
| vCenter | 7.0.2   | 17694817 | vcsa01.stand01.astralinux.ru |
+-------------------------------------------------------------+
| ESXi    | 7.0.2   | 17867351 | esxi.astratest.local         |
+-------------------------------------------------------------+

VM information:
+------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                 |
+------------------------------------------------------------------------+
| VMTools Version           | 11.3.0.29534 (build-18090558)              |
+------------------------------------------------------------------------+
| IP                        | ip here                           |
+------------------------------------------------------------------------+
| GuestInfo Guest Id        | other5xLinux64Guest                        |
+------------------------------------------------------------------------+
| Hardware Version          | vmx-19                                     |
+------------------------------------------------------------------------+
| Guest OS Type             | Astra Linux (Orel) 2.12.43 x86_64          |
+------------------------------------------------------------------------+
| CloudInit Version         |                                            |
+------------------------------------------------------------------------+
| Config Guest Id           | other5xLinux64Guest                        |
+------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 5.x or later Linux (64-bit)          |
+------------------------------------------------------------------------+
| Name                      | DEPLOY_VM_5.4_TEST                         |
+------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                         |
|                           | bitness='64'                               |
|                           | distroName='AstraLinuxCE'                  |
|                           | distroVersion='2.12.43'                    |
|                           | familyName='Linux'                         |
|                           | kernelVersion='5.4.0-71-generic'           |
|                           | prettyName='Astra Linux CE 2.12.43 (Orel)' |
+------------------------------------------------------------------------+

Test Results (Total: 28, Failed: 0, No Run: 5, Elapsed Time: 01:23:23):
+-------------------------------------------------------------+
| Name                                 |   Status | Exec Time |
+-------------------------------------------------------------+
| deploy_ova                           |   Passed | 00:03:25  |
| ovt_verify_install                   |   Passed | 00:06:51  |
| ovt_verify_status                    |   Passed | 00:03:00  |
| vgauth_check_service                 |   Passed | 00:00:56  |
| check_ip_address                     |   Passed | 00:01:00  |
| stat_balloon                         |   Passed | 00:00:45  |
| stat_hosttime                        |   Passed | 00:00:51  |
| check_inbox_driver                   |   Passed | 00:01:05  |
| check_os_fullname                    |   Passed | 00:01:00  |
| check_efi_firmware                   |   Passed | 00:00:56  |
| cpu_hot_add_basic                    |   Passed | 00:05:21  |
| check_quiesce_snapshot_custom_script |   Passed | 00:01:36  |
| memory_hot_add_basic                 |   Passed | 00:06:24  |
| device_list                          |   Passed | 00:03:24  |
| secureboot_enable_disable            | * No Run | 00:01:00  |
| e1000e_network_device_ops            |   Passed | 00:01:36  |
| vmxnet3_network_device_ops           |   Passed | 00:01:40  |
| cpu_multicores_per_socket            |   Passed | 00:11:36  |
| gosc_perl_dhcp                       | * No Run | 00:00:54  |
| gosc_perl_staticip                   | * No Run | 00:00:48  |
| gosc_cloudinit_dhcp                  | * No Run | 00:00:52  |
| gosc_cloudinit_staticip              | * No Run | 00:00:46  |
| paravirtual_vhba_device_ops          |   Passed | 00:04:06  |
| lsilogic_vhba_device_ops             |   Passed | 00:04:59  |
| lsilogicsas_vhba_device_ops          |   Passed | 00:04:12  |
| sata_vhba_device_ops                 |   Passed | 00:04:30  |
| nvme_vhba_device_ops                 |   Passed | 00:02:31  |
| ovt_verify_uninstall                 |   Passed | 00:03:51  |
+-------------------------------------------------------------+
```

