### PR TITLE
Fix #151 check serial port status in device_list

### DIFF
--- a/linux/device_list/device_connection_validate.yml
+++ b/linux/device_list/device_connection_validate.yml
@@ -14,15 +14,29 @@
     device_is_connected: "{{ device_status.split(':')[-1].strip(' ') | lower == 'enabled' }}"
   when: device_status.split(':') | length > 2
 
-- name: "Map '{{ device_name }}' to 'Network adapter {{ device_name | int + 1 }}'"
-  set_fact:
-    device_label: "Network adapter {{ device_name | int + 1 }}"
-  when: "'Ethernet' in device_name"
+- block:
+    - name: "Set device number in VM config"
+      set_fact:
+        device_num: "{{ device_name | regex_search('[0-9]+$') | int + 1 }}"
 
-- name: "Map '{{ device_name }}' to 'Floppy drive {{ device_name | int + 1 }}'"
-  set_fact:
-    device_label: "Floppy drive {{ device_name | int + 1 }}"
-  when: "'floppy' in device_name"
+    - name: "Map '{{ device_name }}' to 'Network adapter {{ device_num }}'"
+      set_fact:
+        device_label: "Network adapter {{ device_num }}"
+      when: "'Ethernet' in device_name"
+
+    - name: "Map '{{ device_name }}' to 'Floppy drive {{ device_num }}'"
+      set_fact:
+        device_label: "Floppy drive {{ device_num }}"
+      when: "'floppy' in device_name"
+
+    - name: "Map '{{ device_name }}' to 'Serial port {{ device_num }}'"
+      set_fact:
+        device_label: "Serial port {{ device_num }}"
+      when: "'serial' in device_name"
+  when: >
+    ('Ethernet' in device_name) or
+    ('floppy' in device_name) or
+    ('serial' in device_name)
 
 - block:
     - name: "Map '{{ device_name }}' to '{{ device_name | regex_replace('ide', 'IDE ') }}'"


### PR DESCRIPTION
When VM has serial ports, it will also been listed by "vmware-toolbox-cmd device list". This fix adds status checking for serial ports.

Signed-off-by: Qi Zhang <qiz@vmware.com>

Tested with Ubuntu 21.10 cloud image OVA:

```
VM information:
+---------------------------------------------------------------+
| Name                      | ubuntu-21.10                      |
+---------------------------------------------------------------+
| IP                        | 10.186.207.15                     |
+---------------------------------------------------------------+
| Guest OS Type             | Ubuntu 21.10 x86_64               |
+---------------------------------------------------------------+
| VMTools Version           | 11.3.0.29534 (build-18090558)     |
+---------------------------------------------------------------+
| CloudInit Version         |                                   |
+---------------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                     |
+---------------------------------------------------------------+
| Hardware Version          | vmx-19                            |
+---------------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                     |
+---------------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)             |
+---------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                        |
+---------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                |
|                           | bitness='64'                      |
|                           | distroName='Ubuntu'               |
|                           | distroVersion='21.10'             |
|                           | familyName='Linux'                |
|                           | kernelVersion='5.13.0-19-generic' |
|                           | prettyName='Ubuntu 21.10'         |
+---------------------------------------------------------------+

Test Results (Total: 1, Failed: 0, No Run: 0, Elapsed Time: 00:07:34):
+----------------------------------+
| Name        | Status | Exec Time |
+----------------------------------+
| device_list | Passed | 00:06:31  |
+----------------------------------+
```

```
TASK [Device status detected by VMware Tools] *****************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:74
ok: [localhost] => {
    "device_status": "serial0: Disabled"
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Device status in VM config] *****************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:77
ok: [localhost] => {
    "vm_devices_with_label": [
        {
            "_vimtype": "vim.vm.device.VirtualSerialPort",
            "backing": {
                "_vimtype": "vim.vm.device.VirtualSerialPort.DeviceBackingInfo",
                "deviceName": "Serial Port 3",
                "useAutoDetect": false
            },
            "connectable": {
                "_vimtype": "vim.vm.device.VirtualDevice.ConnectInfo",
                "allowGuestControl": true,
                "connected": false,
                "migrateConnect": null,
                "startConnected": true,
                "status": "unrecoverableError"
            },
            "controllerKey": 400,
            "deviceInfo": {
                "_vimtype": "vim.Description",
                "label": "Serial port 1",
                "summary": "Serial Port 3"
            },
            "key": 9000,
            "slotInfo": null,
            "unitNumber": 1,
            "yieldOnPoll": false
        }
    ]
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Check device has correct status reported] ***************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:80
ok: [localhost] => {
    "changed": false,
    "msg": "Device status detected by VMware Tools: 'serial0: Disabled', the same in VM config: Serial port 1 connected is False"
}

...

TASK [Device status detected by VMware Tools] *****************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:74
ok: [localhost] => {
    "device_status": "serial1: Enabled"
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Device status in VM config] *****************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:77
ok: [localhost] => {
    "vm_devices_with_label": [
        {
            "_vimtype": "vim.vm.device.VirtualSerialPort",
            "backing": {
                "_vimtype": "vim.vm.device.VirtualSerialPort.FileBackingInfo",
                "backingObjectId": null,
                "datastore": "vim.Datastore:datastore-16",
                "fileName": "[datastore2] ubuntu-21.10/serial.log"
            },
            "connectable": {
                "_vimtype": "vim.vm.device.VirtualDevice.ConnectInfo",
                "allowGuestControl": true,
                "connected": true,
                "migrateConnect": null,
                "startConnected": true,
                "status": "ok"
            },
            "controllerKey": 400,
            "deviceInfo": {
                "_vimtype": "vim.Description",
                "label": "Serial port 2",
                "summary": "File [datastore2] ubuntu-21.10/serial.log"
            },
            "key": 9001,
            "slotInfo": null,
            "unitNumber": 2,
            "yieldOnPoll": true
        }
    ]
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Check device has correct status reported] ***************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:80
ok: [localhost] => {
    "changed": false,
    "msg": "Device status detected by VMware Tools: 'serial1: Enabled', the same in VM config: Serial port 2 connected is True"
}

```