### PR TITLE
Fix #155 only reset testcase name when running deploy_vm

### DIFF
--- a/linux/setup/test_rescue.yml
+++ b/linux/setup/test_rescue.yml
@@ -11,8 +11,8 @@
 #
 - name: "Set test case name for deploy VM testing case"
   set_fact:
-    current_testcase_name: "{{ deploy_casename }}"
-  when: deploy_casename is defined and deploy_casename
+    current_testcase_name: "{{ deploy_casename | default(ansible_play_name) }}"
+  when: ansible_play_name == "deploy_vm"
 
 - name: "By default take failed snapshot"
   set_fact:

--- a/windows/setup/rescue_cleanup.yml
+++ b/windows/setup/rescue_cleanup.yml
@@ -11,8 +11,8 @@
 #
 - name: "Set test case name"
   set_fact:
-    current_testcase_name: "{{ deploy_casename }}"
-  when: deploy_casename is defined and deploy_casename
+    current_testcase_name: "{{ deploy_casename | default(ansible_play_name) }}"
+  when: ansible_play_name == "deploy_vm"
 
 - debug:
     msg: "Testcase: {{ current_testcase_name }} failed"


### PR DESCRIPTION
Only deploy_vm needs to overwrite testcase name, so update the condition for resetting current_testcase_name in rescue task files