### PR TITLE
[Windows] Add guest fullname check for Windows 11

### DIFF
--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -60,6 +60,9 @@
               when: expected_guest_fullname == ""
           when: guest_os_product_type != "client"
 
+        - debug:
+            msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+
         - name: "Verify guest fullname in guest info is expected"
           assert:
             that:

--- a/windows/check_os_fullname/win10_fullname.yml
+++ b/windows/check_os_fullname/win10_fullname.yml
@@ -4,12 +4,9 @@
 # VM guest ID 'Windows9_64Guest' and 'Windows9Guest' is used for
 # 'Windows 10' when ESXi >= 6.0.0 and hardware version >= 11.
 #
-- block:
-    - name: "Set fact of guest fullname for Windows 10 on ESXi >= 6.0.0"
-      set_fact:
-        expected_guest_fullname: "{{ 'Microsoft Windows 10 (' ~ guest_os_ansible_architecture ~ ')' }}"
-    - debug:
-        msg: "Expected guest fullname for Windows 10 on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+- name: "Set fact of guest fullname for Windows 10 on ESXi >= 6.0.0"
+  set_fact:
+    expected_guest_fullname: "{{ 'Microsoft Windows 10 (' ~ guest_os_ansible_architecture ~ ')' }}"
   when:
     - esxi_version is version('6.0.0', '>=')
     - (vm_guest_id == "windows9_64Guest") or (vm_guest_id == "windows9Guest")

--- a/windows/check_os_fullname/win11_fullname.yml
+++ b/windows/check_os_fullname/win11_fullname.yml
@@ -4,12 +4,9 @@
 # VM guest ID 'TBD' is used for 'Windows 11' when
 # ESXi > 7.0.3 and hardware version > 19.
 #
-- block:
-    - name: "Set fact of guest fullname for Windows 11 on ESXi > 7.0.3"
-      set_fact:
-        expected_guest_fullname: "Microsoft Windows 11 (64-bit)"
-    - debug:
-        msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+- name: "Set fact of guest fullname for Windows 11 on ESXi > 7.0.3"
+  set_fact:
+    expected_guest_fullname: "Microsoft Windows 11 (64-bit)"
   when:
     - esxi_version is version('7.0.3', '>=')
     # Will change to the Windows 11 guest ID when it's available

--- a/windows/check_os_fullname/winsrv2016orlater_fullname.yml
+++ b/windows/check_os_fullname/winsrv2016orlater_fullname.yml
@@ -21,15 +21,10 @@
           when: >
             (esxi_version is version('6.5.0', '=') and esxi_update_version | int >= 3) or
             (esxi_version is version('6.7.0', '=') and esxi_update_version | int >= 2)
-        - debug:
-            msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
       when: esxi_version is version('7.0.0', '<')
 
-    - block:
-        - name: "Set fact of expected guest fullname for Windows Server 2016 on ESXi >= 7.0.0"
-          set_fact:
-            expected_guest_fullname: "Microsoft Windows Server 2016 (64-bit)"
-        - debug:
-            msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+    - name: "Set fact of expected guest fullname for Windows Server 2016 on ESXi >= 7.0.0"
+      set_fact:
+        expected_guest_fullname: "Microsoft Windows Server 2016 (64-bit)"
       when: esxi_version is version('7.0.0', '>=')
   when: vm_guest_id == "windows9Server64Guest"

--- a/windows/check_os_fullname/winsrv2019_fullname.yml
+++ b/windows/check_os_fullname/winsrv2019_fullname.yml
@@ -4,12 +4,9 @@
 # Guest ID 'Windows2019srv_64Guest' is introduced in ESXi
 # version 7.0.0 and hardware version 17.
 #
-- block:
-    - name: "Set fact of guest fullname for Windows Server 2019 on ESXi >= 7.0.0"
-      set_fact:
-        expected_guest_fullname: "Microsoft Windows Server 2019 (64-bit)"
-    - debug:
-        msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+- name: "Set fact of guest fullname for Windows Server 2019 on ESXi >= 7.0.0"
+  set_fact:
+    expected_guest_fullname: "Microsoft Windows Server 2019 (64-bit)"
   when:
     - esxi_version is version('7.0.0', '>=')
     - vm_guest_id == "windows2019srv_64Guest"

--- a/windows/check_os_fullname/winsrv2022_fullname.yml
+++ b/windows/check_os_fullname/winsrv2022_fullname.yml
@@ -4,12 +4,9 @@
 # VM guest ID 'Windows2019srvNext_64Guest' for 'Windows Server 2022'
 # is introduced in ESXi 7.0.2 and hardware version 19.
 #
-- block:
-    - name: "Set fact of guest fullname for Windows Server 2022 on ESXi >= 7.0.2"
-      set_fact:
-        expected_guest_fullname: "Microsoft Windows Server 2022 (64-bit)"
-    - debug:
-        msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
+- name: "Set fact of guest fullname for Windows Server 2022 on ESXi >= 7.0.2"
+  set_fact:
+    expected_guest_fullname: "Microsoft Windows Server 2022 (64-bit)"
   when:
     - esxi_version is version('7.0.2', '>=')
     - vm_guest_id == "windows2019srvNext_64Guest"


### PR DESCRIPTION
Remove guest OS fullname got in guest OS check since check guest info reported is enough. Leave Windows 11 guest ID to "TBD" after it's available in the future.
This is the expected result.
```
TASK [Verify guest fullname in guest info is expected] *************************
task path: /root/ansible-vsphere-gos-validation/windows/check_os_fullname/check_os_fullname.yml:63
fatal: [localhost]: FAILED! => {
    "assertion": "os_fullname_guestinfo == expected_guest_fullname",
    "changed": false,
    "evaluated_to": false,
    "msg": "Guest fullname in guest info: Microsoft Windows 10 (64-bit), is not the same as expected one: Microsoft Windows 11 (64-bit)."
}
```
```
TASK [Verify guest fullname in guest info is expected] *************************
task path: /root/ansible-vsphere-gos-validation/windows/check_os_fullname/check_os_fullname.yml:63
ok: [localhost] => {
    "changed": false,
    "msg": "Guest fullname in guest info: Microsoft Windows 10 (64-bit) is the same as expected one."
}
```
```
TASK [Verify guest fullname in guest info is expected] *************************
task path: /root/ansible-vsphere-gos-validation/windows/check_os_fullname/check_os_fullname.yml:63
ok: [localhost] => {
    "changed": false,
    "msg": "Guest fullname in guest info: Microsoft Windows Server 2022 (64-bit) is the same as expected one."
}
```