### PR TITLE
Fix ubuntu issue #175 and #176

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ This project supports below scenarios for end-to-end guest OS validation testing
 | SUSE Linux Enterprise 12 SP5, 15 SP0/SP1/SP2    |                                  |                          | :heavy_check_mark:                 |
 | Photon OS 3.x                                   | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Photon OS 4.0                                   |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
-| Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04 live-server   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Ubuntu 20.04, 20.10, 21.04 cloud image                 |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
+| Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04, 21.10 live-server   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Ubuntu 20.04, 20.10, 21.04, 21.10 cloud image                 |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04 desktop       |                                  |                          | :heavy_check_mark:                 |
 | Flatcar 2592.0.0 and later                      |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Debian 9.x, 10.x                                |                                  |                          | :heavy_check_mark:                 |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This project supports below scenarios for end-to-end guest OS validation testing
 | Photon OS 4.0                                   |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04, 21.10 live-server   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Ubuntu 20.04, 20.10, 21.04, 21.10 cloud image                 |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
-| Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04 desktop       |                                  |                          | :heavy_check_mark:                 |
+| Ubuntu 18.04, 18.10, 20.04, 20.10, 21.04, 21.10 desktop       |                                  |                          | :heavy_check_mark:                 |
 | Flatcar 2592.0.0 and later                      |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Debian 9.x, 10.x                                |                                  |                          | :heavy_check_mark:                 |
 | Astra Linux (Orel) 2.12.43                      |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |

--- a/common/README.md
+++ b/common/README.md
@@ -28,6 +28,7 @@
 * vm_wait_gosc_completed.yml: Wait for GOSC being completed
 * vm_add_serial_port.yml: Add a serial port to VM
 * vm_set_video_card.yml: Configure VM video card settings
+* vm_remove_serial_port.yml: Remove a serial port from VM
 
 ### Tasks for VM CPU or Memory settings
 * vm_enable_cpu_hotadd.yml: Enable VM CPU hotadd

--- a/common/vm_remove_serial_port.yml
+++ b/common/vm_remove_serial_port.yml
@@ -1,0 +1,22 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Remove a serial port to VM by using output file
+# Parameter:
+#   vm_serial_port_file_path: The serial port output file on datastore.
+
+- name: "Remove a serial port using output file"
+  vmware_guest_serial_port:
+    hostname: "{{ vsphere_host_name }}"
+    username: "{{ vsphere_host_user }}"
+    password: "{{ vsphere_host_user_password }}"
+    validate_certs: "{{ validate_certs | default(False) }}"
+    name: "{{ vm_name }}"
+    backings:
+      - type: "file"
+        file_path: "{{ vm_serial_port_file_path }}"
+        state: absent
+  register: remove_serial_port
+
+- name: "Display result of removing serial port"
+  debug: var=remove_serial_port

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -126,7 +126,7 @@
     # Retrieve guest system info
     - include_tasks: ../utils/get_linux_system_info.yml
 
-    # Add new user for Photon OS and Ubuntu
+    # Add new user for Photon OS
     - block:
         - include_tasks: ../utils/add_user.yml
           vars:

--- a/linux/deploy_vm/templates/ubuntu-iso-user-data.j2
+++ b/linux/deploy_vm/templates/ubuntu-iso-user-data.j2
@@ -38,6 +38,7 @@ autoinstall:
     password: {{ vm_password_hash }}
   packages:
     - net-tools
+    - sg3-utils
   late-commands:
     - rm -f /etc/cloud/cloud.cfg.d/*-installer.cfg 2>/dev/null
     - sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /target/etc/ssh/sshd_config

--- a/linux/deploy_vm/templates/ubuntu-iso-user-data.j2
+++ b/linux/deploy_vm/templates/ubuntu-iso-user-data.j2
@@ -24,12 +24,6 @@ autoinstall:
         ssh_authorized_keys:
           - {{ ssh_public_key }}
 {% endif %}
-  network:
-    network:
-      version: 2
-      ethernets:
-        ens192:
-          dhcp4: yes
   ssh:
     install-server: true
     allow-pw: yes
@@ -42,6 +36,9 @@ autoinstall:
     hostname: ubuntu
     username: {{ vm_username }}
     password: {{ vm_password_hash }}
+  packages:
+    - net-tools
   late-commands:
     - rm -f /etc/cloud/cloud.cfg.d/*-installer.cfg 2>/dev/null
+    - sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /target/etc/ssh/sshd_config
     - echo 'Ubuntu autoinstall is completed' >/target/var/log/autoinstall.log

--- a/linux/deploy_vm/templates/ubuntu-ova-user-data.j2
+++ b/linux/deploy_vm/templates/ubuntu-ova-user-data.j2
@@ -18,7 +18,7 @@ users:
 {% endif %}
 package:
   - net-tools
-
+  - sg3-utils
 runcmd:
   - sed -i 's/^#*PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
   - systemctl restart sshd

--- a/linux/deploy_vm/templates/ubuntu-ova-user-data.j2
+++ b/linux/deploy_vm/templates/ubuntu-ova-user-data.j2
@@ -16,6 +16,8 @@ users:
     ssh_authorized_keys:
       - {{ ssh_public_key }}
 {% endif %}
+package:
+  - net-tools
 
 runcmd:
   - sed -i 's/^#*PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config

--- a/linux/deploy_vm/ubuntu/ubuntu_install_os.yml
+++ b/linux/deploy_vm/ubuntu/ubuntu_install_os.yml
@@ -6,8 +6,6 @@
   when: ubuntu_install_method == "simulation"
 
 - block:
-    - include_tasks: ../../../common/vm_wait_guest_ip.yml
-
     - name: "Wait for autoinstall early commands"
       command: "grep -c -e '{{ autoinstall_start_msg }}' {{ vm_serial_port_output_file }}"
       until:
@@ -15,9 +13,11 @@
         - autoinstall_started.stdout is defined
         - autoinstall_started.stdout == "1"
       delay: 5
-      retries: 120
+      retries: 150
       delegate_to: "{{ esxi_hostname }}"
       register: autoinstall_started
+
+    - include_tasks: ../../../common/vm_wait_guest_ip.yml
 
     - name: Sleep 200 seconds to wait confirm message for ubuntu
       pause:
@@ -70,4 +70,15 @@
         # cdrom_unit_num: "{{ unattend_iso_cdrom_unit_num | int }}"
         cdrom_controller_num: 0
         cdrom_unit_num: 1
+
+    # Remove serial port
+    - block:
+        - include_tasks: ../utils/shutdown.yml
+
+        - include_tasks: ../../../common/vm_remove_serial_port.yml
+
+        - include_tasks: ../../common/vm_set_power_state.yml
+          vars:
+            vm_power_state_set: 'powered-on'
+      when: vm_serial_port_file_path is defined and vm_serial_port_file_path
   when: ubuntu_install_method == "cloud-init"

--- a/linux/deploy_vm/ubuntu/vars_ubuntu_install.yml
+++ b/linux/deploy_vm/ubuntu/vars_ubuntu_install.yml
@@ -1,7 +1,7 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ubuntu_install_method_setting:
-  - os_version: "20.04/20.10/21.04"
+  - os_version: "20.04/20.10/21.04/21.10"
     install_method: "cloud-init"
     install_file: "ubuntu-iso-user-data.j2"
   - os_version: "18.04"

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -1,0 +1,44 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Skip GOSC testing if no vCenter or no open-vm-tools
+- include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: "Skip this test case as guest OS status doesn't meet GOSC requirements"
+  when: >
+    (vcenter_is_defined is undefined) or
+    (not vcenter_is_defined) or
+    (enable_cloudinit_gosc and not vmtools_is_ovt)
+
+- block:
+    - name: "Initialize GOSC support status"
+      set_fact:
+        gosc_is_supported: True
+
+    - name: "Set default guest OS list not support GOSC"
+      set_fact:
+        gos_not_support_gosc: ["FreeBSD", "Flatcar", "Debian", "SLED", "Astra Linux (Orel)"]
+
+    - name: "Set fact of GOSC support status to False"
+      set_fact:
+        gosc_is_supported: False
+      when:  guest_os_ansible_distribution in gos_not_support_gosc
+
+    - name: "Set fact of GOSC support status to False"
+      set_fact:
+        gosc_is_supported: False
+      when:
+        - guest_os_ansible_distribution == 'Ubuntu'
+        - guest_os_ansible_distribution_ver is version ('21.04', '>=')
+        - vcenter_version is version ('7.0.1', '<')
+        - not enable_cloudinit_gosc | bool
+
+    - block:
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "GOSC is not supported for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} on vCenter Server {{ vcenter_version }}. See https://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf."
+      when: not gosc_is_supported | bool
+  when:
+    - guest_os_ansible_distribution is defined
+    - guest_os_ansible_distribution_ver is defined
+    - vcenter_version is defined

--- a/linux/guest_customization/check_network_config.yml
+++ b/linux/guest_customization/check_network_config.yml
@@ -108,7 +108,8 @@
   debug: var=guest_gateway_success
 
 # Collect network config files for non-Photon Linux
-# Ubuntu Desktop 19.10 and later, Ubuntu Server 17.10 and later use netplan to manage network
+# On Ubuntu Desktop 19.10 and later or Ubuntu Server 17.10 and later, network configure files
+# are /etc/netplan/*.yaml
 - block:
     - name: "Set traditional GOSC network configuration file on Ubuntu {{ guest_os_ansible_distribution_ver }}"
       set_fact:
@@ -126,7 +127,8 @@
      (guest_os_with_gui is defined and guest_os_with_gui | bool and
       guest_os_ansible_distribution_ver is version('19.10', '>=')))
 
-# Debian 10/11, Ubuntu Desktop eariler than 19.10 use /etc/network/interfaces to manage network
+# On Debian 10/11 or Ubuntu Desktop eariler than 19.10, the network configure file is
+# /etc/network/interfaces
 - block:
     - name: "Set traditional GOSC network configuration files on Ubuntu Desktop/Debian OS"
       set_fact:

--- a/linux/guest_customization/check_network_config.yml
+++ b/linux/guest_customization/check_network_config.yml
@@ -108,28 +108,40 @@
   debug: var=guest_gateway_success
 
 # Collect network config files for non-Photon Linux
+# Ubuntu Desktop 19.10 and later, Ubuntu Server 17.10 and later use netplan to manage network
 - block:
-    - name: "Set fact of the network configure file for Ubuntu server"
+    - name: "Set traditional GOSC network configuration file on Ubuntu {{ guest_os_ansible_distribution_ver }}"
       set_fact:
-        src_network_file: "{{ netplan_config_file }}"
-      when:
-        - guest_os_ansible_distribution == "Ubuntu"
-        - guest_os_with_gui is defined and not guest_os_with_gui
-        - netplan_config_file is defined
-    - block:
-        - name: "Set traditional GOSC network configuration files on Ubuntu Desktop/Debian OS"
-          set_fact:
-            src_network_file: "/etc/network/interfaces"
-          when: "gosc_workflow == 'perl'"
+        src_network_file: "/etc/netplan/99-netcfg-vmware.yaml"
+      when: "gosc_workflow == 'perl'"
 
-        - name: "Set cloud-init GOSC network configuration files on Ubuntu/Debian OS"
-          set_fact:
-            src_network_file: "/etc/network/interfaces.d/50-cloud-init.cfg"
-          when: "gosc_workflow == 'cloud-init'"
-      when: >
-        (guest_os_ansible_distribution == "Ubuntu" and guest_os_with_gui is defined and guest_os_with_gui) or
-        (guest_os_ansible_distribution != "Ubuntu")
-  when: guest_os_family == "Debian"
+    - name: "Set cloud-init GOSC network configuration file on Ubuntu {{ guest_os_ansible_distribution_ver }}"
+      set_fact:
+        src_network_file: "/etc/netplan/50-cloud-init.yaml"
+      when: "gosc_workflow == 'cloud-init'"
+  when: >
+    (guest_os_ansible_distribution == "Ubuntu") and
+    (((guest_os_with_gui is undefined or not guest_os_with_gui | bool) and
+      guest_os_ansible_distribution_ver is version('17.10', '>=')) or
+     (guest_os_with_gui is defined and guest_os_with_gui | bool and
+      guest_os_ansible_distribution_ver is version('19.10', '>=')))
+
+# Debian 10/11, Ubuntu Desktop eariler than 19.10 use /etc/network/interfaces to manage network
+- block:
+    - name: "Set traditional GOSC network configuration files on Ubuntu Desktop/Debian OS"
+      set_fact:
+        src_network_file: "/etc/network/interfaces"
+      when: "gosc_workflow == 'perl'"
+
+    - name: "Set cloud-init GOSC network configuration files on Ubuntu/Debian OS"
+      set_fact:
+        src_network_file: "/etc/network/interfaces.d/50-cloud-init.cfg"
+      when: "gosc_workflow == 'cloud-init'"
+  when: >
+    (guest_os_ansible_distribution == "Debian") or
+    (guest_os_ansible_distribution == "Ubuntu" and
+     guest_os_ansible_distribution_ver is version('19.10', '<') and
+     guest_os_with_gui is defined and guest_os_with_gui | bool)
 
 - name: "Set GOSC network configuration files on RedHat"
   set_fact:
@@ -155,7 +167,7 @@
         dest_path: "{{ network_config_path }}"
   when:
     - guest_os_ansible_distribution != "VMware Photon OS"
-    - src_network_file is defined and not src_network_file
+    - src_network_file is defined and src_network_file
 
 # Collect network config files for Photon OS
 - block:

--- a/linux/guest_customization/linux_gosc_start.yml
+++ b/linux/guest_customization/linux_gosc_start.yml
@@ -46,6 +46,16 @@
   vars:
     check_gosc_state_keyword: False
 
+# Traditional GOSC will reboot guest OS (except for Photon) after all customization done
+- name: Sleep 30 seconds to wait guest reboot for traditional GOSC
+  pause:
+    seconds: 30
+  when:
+    - guest_os_ansible_distribution != "VMware Photon OS"
+    - not enable_cloudinit_gosc | bool
+    - gosc_state_keyword_found is defined
+    - gosc_state_keyword_found | bool
+
 - block:
     - include_tasks: ../../common/vm_wait_guest_ip.yml
     # In case VM get new DHCP IP address after GOSC

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -12,23 +12,11 @@
       set_fact:
         enable_cloudinit_gosc: "{% if gosc_workflow  == 'cloud-init' %}True{% else %}False{% endif %}"
 
-    - name: "Set default guest OS list not support GOSC"
-      set_fact:
-        gos_not_support_gosc: ["FreeBSD", "Flatcar", "Debian", "SLED", "Astra Linux (Orel)"]
-
     - include_tasks: ../setup/test_setup.yml
       vars:
         skip_test_no_vmtools: True
 
-    - include_tasks: ../../common/skip_test_case.yml
-      vars:
-        skip_msg: "Skip this test case as guest OS status doesn't meet GOSC requirements"
-      when: >
-        (vcenter_is_defined is undefined) or
-        (not vcenter_is_defined) or
-        (enable_cloudinit_gosc and not vmtools_is_ovt) or
-        ((guest_os_ansible_distribution is defined) and
-        (guest_os_ansible_distribution in gos_not_support_gosc))
+    - include_tasks: check_gosc_support_status.yml
 
     - block:
        # Traditional GOSC in Photon OS is implemented with cloud-init,
@@ -132,8 +120,6 @@
 
     # Modify cloud-init GOSC config in guest OS
     - include_tasks: ../utils/enable_disable_cloudinit_cfg.yml
-    # Get netplan config file for Ubuntu server
-    - include_tasks: ../utils/get_netplan_config_file.yml
     # Execute guest customization on VM
     - include_tasks: linux_gosc_start.yml
     # Check guest customization results

--- a/linux/guest_customization/wait_gosc_complete_msg.yml
+++ b/linux/guest_customization/wait_gosc_complete_msg.yml
@@ -18,7 +18,7 @@
     vm_username: "{{ vm_username }}"
     vm_password: "{{ vm_password }}"
     vm_shell: "/usr/bin/grep"
-    vm_shell_args: '-c -e "{{ wait_gosc_msg_regexp }}" {{ wait_gosc_log_file }} | grep 1 >/dev/null'
+    vm_shell_args: '-c -e "{{ wait_gosc_msg_regexp }}" {{ wait_gosc_log_file }} >/dev/null'
     vm_shell_env:
       - "PATH=/usr/local/bin:/usr/bin:/sbin/bin:/bin"
       - "LC_ALL=en_US.UTF-8"

--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -82,6 +82,7 @@
             - /etc/cloud/cloud-init.disabled
             - /var/lib/cloud/seed/nocloud-net
             - /etc/cloud/cloud.cfg.d/50-curtin-networking.cfg
+            - /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
             - /etc/cloud/cloud.cfg.d/99-installer.cfg
           when: guest_os_ansible_distribution is defined and guest_os_ansible_distribution == "Ubuntu"
           loop_control:


### PR DESCRIPTION
In Ubuntu 21.10, the network interface name is changed, not ens192 any more. So remove the network interface config from cloud-init user-data for autoinstall, and remove the serial port after OS installation to fix #176 