### PR TITLE
Fix #185 correct guest full name of rhel 9 on ESXi < 7.0.0

### DIFF
--- a/linux/check_os_fullname/rhel_fullname_map.yml
+++ b/linux/check_os_fullname/rhel_fullname_map.yml
@@ -1,24 +1,19 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Map RHEL when ESXi >= 6.7.0
-- name: "Set guest_fullname variable for RHEL on ESXi >= 6.7.0"
+- name: "Set guest_fullname variable for RHEL {{ guest_os_ansible_distribution_major_ver }} on ESXi < 6.7.0"
   set_fact:
-    guest_fullname: "Red Hat Enterprise Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-  when: esxi_version is version('6.7.0', '>=')
+    guest_fullname: "Red Hat Enterprise Linux {{ [guest_os_ansible_distribution_major_ver | int, 7] | min }} {{ bitness }}"
+  when: esxi_version is version('6.7.0', '<')
 
-# Map RHEL-8 when ESXi <= 6.5.0
-- name: "Set guest_fullname variable for RHEL-8 on ESXi <= 6.5.0"
+- name: "Set guest_fullname variable for RHEL {{ guest_os_ansible_distribution_major_ver }} on ESXi >= 6.7.0 and ESXi <= 7.0.0"
   set_fact:
-    guest_fullname: "Red Hat Enterprise Linux 7 {{ bitness }}"
+    guest_fullname: "Red Hat Enterprise Linux {{ [guest_os_ansible_distribution_major_ver | int, 8] | min }} {{ bitness }}"
   when:
-    - guest_os_ansible_distribution_major_ver | int == 8
-    - esxi_version is version('6.5.0', '<=')
+    - esxi_version is version('6.7.0', '>=')
+    - esxi_version is version('7.0.0', '<=')
 
-# Map RHEL-7 and earlier when ESXi <= 6.5.0
-- name: "Set guest_fullname variable for RHEL-7 and earlier on ESXi <= 6.5.0"
+- name: "Set guest_fullname variable for RHEL {{ guest_os_ansible_distribution_major_ver }} on ESXi >= 7.0.1"
   set_fact:
-    guest_fullname: "Red Hat Enterprise Linux {{ guest_os_ansible_distribution_major_ver }} {{ bitness }}"
-  when:
-    - guest_os_ansible_distribution_major_ver | int <= 7
-    - esxi_version is version('6.5.0', '<=')
+    guest_fullname: "Red Hat Enterprise Linux {{ [guest_os_ansible_distribution_major_ver | int, 9] | min }} {{ bitness }}"
+  when: esxi_version is version('7.0.1', '>=')


### PR DESCRIPTION

```
Testbed information:
+-----------------------------------------------+
| Product | Version | Build    | Hostname or IP |
+-----------------------------------------------+
| vCenter | 7.0.0   | 15952599 | x.x.x.x   |
+-----------------------------------------------+
| ESXi    | 7.0.0   | 15843807 | x.x.x.x  |
+-----------------------------------------------+


VM information:
+-----------------------------------------------------------------------------------+
| Name                      | test_vm_1639020563600                                 |
+-----------------------------------------------------------------------------------+
| IP                        | x.x.x.x                                        |
+-----------------------------------------------------------------------------------+
| Guest OS Type             | RedHat 9.0 x86_64                                     |
+-----------------------------------------------------------------------------------+
| VMTools Version           | 11.3.0.29534 (build-18090558)                         |
+-----------------------------------------------------------------------------------+
| CloudInit Version         |                                                       |
+-----------------------------------------------------------------------------------+
| Config Guest Id           | rhel8_64Guest                                         |
+-----------------------------------------------------------------------------------+
| Hardware Version          | vmx-17                                                |
+-----------------------------------------------------------------------------------+
| GuestInfo Guest Id        | rhel8_64Guest                                         |
+-----------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Enterprise Linux 8 (64-bit)                   |
+-----------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                            |
+-----------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                    |
|                           | bitness='64'                                          |
|                           | distroName='Red Hat Enterprise Linux'                 |
|                           | distroVersion='9.0'                                   |
|                           | familyName='Linux'                                    |
|                           | kernelVersion='5.14.0-1.7.1.el9.x86_64'               |
|                           | prettyName='Red Hat Enterprise Linux 9.0 Beta (Plow)' |
+-----------------------------------------------------------------------------------+


Test Results (Total: 5, Failed: 0, No Run: 4, Elapsed Time: 00:05:16):
+----------------------------------------------------+
| Name                        |   Status | Exec Time |
+----------------------------------------------------+
| check_os_fullname           |   Passed | 00:01:09  |
+----------------------------------------------------+
```