### PR TITLE
[Windows] Add secureboot check before enable testsigning

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -12,6 +12,7 @@
 * vm_get_device_with_label.yml: Get VM device with a specific label
 * vm_get_video_card.yml: Get VM video card settings
 * vm_get_cdrom_devices.yml: Get VM CDROM devices info list
+* vm_get_vbs_status.yml: Get Windows VM VBS enablement status
 
 ### Tasks for VM deploy or remove
 * vm_create.yml: Create a new VM on ESXi host

--- a/common/vm_get_vbs_status.yml
+++ b/common/vm_get_vbs_status.yml
@@ -1,10 +1,11 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- include_tasks: ../../common/vm_get_config.yml
+# Get Windows VM VBS enablement status
+- include_tasks: vm_get_config.yml
   vars:
     property_list: ['config.flags.vbsEnabled']
-- name: Set fact of the VBS enablement status
+- name: Set fact of VM VBS enablement status
   set_fact:
     vm_vbs_enanled: "{{ vm_config.config.flags.vbsEnabled }}"
 - debug:

--- a/common/vm_get_vbs_status.yml
+++ b/common/vm_get_vbs_status.yml
@@ -7,6 +7,6 @@
     property_list: ['config.flags.vbsEnabled']
 - name: Set fact of VM VBS enablement status
   set_fact:
-    vm_vbs_enanled: "{{ vm_config.config.flags.vbsEnabled }}"
+    vm_vbs_enanled: "{{ vm_config.config.flags.vbsEnabled if vm_config.config.flags.vbsEnabled else False }}"
 - debug:
     msg: "VM VBS is enabled: {{ vm_vbs_enanled }}"

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -16,6 +16,15 @@
   tasks:
     - block:
         - include_tasks: ../setup/test_setup.yml
+        
+        # Refer to KB article https://kb.vmware.com/s/article/52584
+        - include_tasks: ../../common/vm_get_vbs_status.yml
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case due to CPU hotadd not supported for VM with VBS enabled."
+          when:
+            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
+
         - name: Set fact of the initial CPU number and cores per socket
           set_fact:
             initial_cpu_num: 2

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,6 +14,15 @@
   tasks:
     - block:
         - include_tasks: ../setup/test_setup.yml
+        
+        # Refer to KB article https://kb.vmware.com/s/article/52584
+        - include_tasks: ../../common/vm_get_vbs_status.yml
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
+          when:
+            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
+        
         - name: "Set fact of initial memory size 2048MB for 32bit client"
           set_fact:
             vm_initial_mem_mb: 2048

--- a/windows/wintools_complete_install_verify/enable_test_signing.yml
+++ b/windows/wintools_complete_install_verify/enable_test_signing.yml
@@ -3,6 +3,14 @@
 ---
 # Enable test signing in Windows guest OS for testing on VMware tools
 # containing not MS WHQL signed drivers
+#
+# If secure boot is enabled, disable secure boot firstly
+- include_tasks: ../../common/vm_get_boot_info.yml
+- include_tasks: ../secureboot_enable_disable/change_secureboot_config.yml
+  vars:
+    change_secureboot: 'disable'
+  when: vm_secureboot_enabled is defined and vm_secureboot_enabled | bool 
+
 - include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "bcdedit.exe -set TESTSIGNING ON"

--- a/windows/wintools_complete_install_verify/get_vbs_enable_status.yml
+++ b/windows/wintools_complete_install_verify/get_vbs_enable_status.yml
@@ -1,0 +1,11 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- include_tasks: ../../common/vm_get_config.yml
+  vars:
+    property_list: ['config.flags.vbsEnabled']
+- name: Set fact of the VBS enablement status
+  set_fact:
+    vm_vbs_enanled: "{{ vm_config.config.flags.vbsEnabled }}"
+- debug:
+    msg: "VM VBS is enabled: {{ vm_vbs_enanled }}"

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -24,6 +24,14 @@
             vmtools_esxi_bundled: False
           when: vmtools_esxi_bundled is undefined
 
+        # If VBS is enabled, will not install under development tools due to secureboot is enabled
+        - include_tasks: get_vbs_enable_status.yml
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case due to under development VMware tools can not test on VM with VBS enabled."
+          when:
+            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
+            - is_development_tools is defined and is_development_tools | bool
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -25,7 +25,7 @@
           when: vmtools_esxi_bundled is undefined
 
         # If VBS is enabled, will not install under development tools due to secureboot is enabled
-        - include_tasks: get_vbs_enable_status.yml
+        - include_tasks: ../../common/vm_get_vbs_status.yml
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to under development VMware tools can not test on VM with VBS enabled."


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Fixes #164
Fixes #144 
1. disable secure boot before enable test signing,
2. if VBS is enabled, then test will be skipped on development tools.