### PR TITLE
Fix #211 Replace end_play with end_host

### DIFF
--- a/common/skip_test_case.yml
+++ b/common/skip_test_case.yml
@@ -10,4 +10,4 @@
   debug:
     msg: "{{ skip_msg }}"
 
-- meta: end_play
+- meta: end_host

--- a/linux/check_os_fullname/otherlinux_fullname_map.yml
+++ b/linux/check_os_fullname/otherlinux_fullname_map.yml
@@ -5,9 +5,9 @@
 
 # If there is no best match of the guest full name on ESXi server, it will show the guest OS detailed information
 # in the guest full name, which include the kernel version and os distribution
-- name: "Set guest detailed data for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi 6.7GA"
+- name: "Set unmapped guest fullname for {{ guest_os_ansible_distribution}} {{ guest_os_ansible_distribution_ver }} on ESXi 6.7GA"
   set_fact:
-    guest_detailed_data: "Linux {{ guest_os_ansible_kernel }} {{ guest_os_ansible_distribution }}"
+    unmapped_os_fullname: "Linux {{ guest_os_ansible_kernel }} {{ guest_os_ansible_distribution }}"
 
 # Linux 5.x
 - block:

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -4,14 +4,14 @@
 # Wait VMware tools to report Guest OS fullname
 - include_tasks: ../../common/vm_get_guest_info.yml
 
-# If the guest os full name has detailed OS info on ESXi 6.7GA, test passed
+# If the guest os full name is unmapped and displays OS detailed data, test passed
 - block:
     - debug:
         msg: "guest OS detailed information is shown in guest OS full name, test passed"
     - meta: end_host
   when:
-    - guest_detailed_data is defined and guest_detailed_data
-    - guest_detailed_data in guestinfo_guest_full_name
+    - unmapped_os_fullname is defined and unmapped_os_fullname
+    - unmapped_os_fullname in guestinfo_guest_full_name
 
 - block:
     - name: "Assert Guest OS fullname is either {{ guest_fullname[0] }} or {{ guest_fullname[1] }}"

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -8,7 +8,7 @@
 - block:
     - debug:
         msg: "guest OS detailed information is shown in guest OS full name, test passed"
-    - meta: end_play
+    - meta: end_host
   when:
     - guest_detailed_data is defined and guest_detailed_data
     - guest_detailed_data in guestinfo_guest_full_name

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -16,7 +16,7 @@
         - name: "Skip testcase: {{ ansible_play_name }}"
           debug:
             msg: "Skip test case due to new_vm is set to '{{ new_vm | default(False) }}'"
-        - meta: end_play
+        - meta: end_host
       when: new_vm is undefined or not new_vm|bool
 
     - block:


### PR DESCRIPTION
Use end_host instead of end_play to skip the rest of tasks in a playbook.

Signed-off-by: Qi Zhang <qiz@vmware.com>