### PR TITLE
Fix #198 Flatcar 3033.2.0 check_ip_address

### DIFF
--- a/linux/utils/ethernet_ip_get.yml
+++ b/linux/utils/ethernet_ip_get.yml
@@ -49,7 +49,7 @@
 #Get IP address in guest
 - block:
     - name: Get IP in guest
-      shell: ip -br addr show | grep -v lo  | grep -v virbr | awk '{OFS="\n";i=3; while (i<=NF) {print $i; i++}}' | cut -d '/' -f 1
+      shell: ip -br addr show | grep -v lo  | grep -v virbr | awk '{OFS="\n";i=3; while (i<=NF) {print $i; i++}}' | grep '/' | cut -d '/' -f 1
       register: result
       delegate_to: "{{ vm_guest_ip }}"
 


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Fix #198 
```
+---------------------------------------------------------------------------------------------+
| Guest OS Type             | Flatcar 3033.2.0 x86_64                                         |
+---------------------------------------------------------------------------------------------+
| VMTools Version           | 11.3.5.31214 (build-18557794)                                   |
+---------------------------------------------------------------------------------------------+
| CloudInit Version         |                                                                 |
+---------------------------------------------------------------------------------------------+
| Config Guest Id           | other3xLinux64Guest                                             |
+---------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                                          |
+---------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | other5xLinux64Guest                                             |
+---------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 5.x Linux (64-bit)                                        |
+---------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                      |
+---------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                              |
|                           | bitness='64'                                                    |
|                           | buildNumber='2021-12-10-1820'                                   |
|                           | distroName='Flatcar Container Linux by Kinvolk'                 |
|                           | distroVersion='3033.2.0'                                        |
|                           | familyName='Linux'                                              |
|                           | kernelVersion='5.10.84-flatcar'                                 |
|                           | prettyName='Flatcar Container Linux by Kinvolk 3033.2.0 (Oklo)' |
+---------------------------------------------------------------------------------------------+


Test Results (Total: 1, Failed: 0, No Run: 0, Elapsed Time: 00:01:40):
+---------------------------------------+
| Name             | Status | Exec Time |
+---------------------------------------+
| check_ip_address | Passed | 00:01:20  |
+---------------------------------------+

```