### PR TITLE
[Windows] Set expected guest fullname to OS fullname got from guest

### DIFF
--- a/common/vm_wait_log_msg.yml
+++ b/common/vm_wait_log_msg.yml
@@ -8,7 +8,9 @@
 #   vm_wait_log_retries: how many times to re-check log about waiting message
 #   vm_wait_log_delay: seconds to delay for a retry
 #   vm_wait_log_ignore_errors: True to ignore task failure. Default is False.
-
+#   vm_wait_log_hide_output: True to hide the output, False will print the
+#   output of log content. Default is True.
+#
 - name: "Set fact of VM log file path in datastore"
   set_fact:
     vm_log_file_path: "{{ vm_dir_name }}/{{ vm_wait_log_name }}"
@@ -33,6 +35,7 @@
     password: "{{ vsphere_host_user_password }}"
     validate_certs: "{{ validate_certs | default(False) }}"
   register: get_vm_log_content
+  no_log: "{{ vm_wait_log_hide_output | default(True) }}"
   until:
     - get_vm_log_content is defined
     - get_vm_log_content.content is defined

--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -60,6 +60,10 @@
               when: expected_guest_fullname == ""
           when: guest_os_product_type != "client"
 
+        - name: Set expected guest fullname to OS fullname got in guest
+          set_fact:
+            expected_guest_fullname: "{{ (' ').join(os_fullname_guest.split()[:-1]) ~ ' (' ~ guest_os_ansible_architecture ~ ')' }}"
+          when: expected_guest_fullname == ""
         - debug:
             msg: "Expected guest fullname on ESXi '{{ esxi_version }}': {{ expected_guest_fullname }}"
 


### PR DESCRIPTION
When there is new or unknown guest ID got from VM, no get mapping expected guest fullname, set it to the OS fullname got in guest OS.
Signed-off-by: dianew <dianew@vmware.com>