### PR TITLE
Skip Perl GOSC when Photon doesn't install bundled open-vm-tools

### DIFF
--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -19,12 +19,12 @@
       set_fact:
         gos_not_support_gosc: ["FreeBSD", "Flatcar", "Debian", "SLED", "Astra Linux (Orel)"]
 
-    - name: "Set fact of GOSC support status to False"
+    - name: "Set fact of GOSC support status to False for {{ guest_os_ansible_distribution }}"
       set_fact:
         gosc_is_supported: False
       when:  guest_os_ansible_distribution in gos_not_support_gosc
 
-    - name: "Set fact of GOSC support status to False"
+    - name: "Set fact of GOSC support status to False for Ubuntu {{ guest_os_ansible_distribution_ver }} from {{ vcenter_version }}"
       set_fact:
         gosc_is_supported: False
       when:
@@ -32,6 +32,26 @@
         - guest_os_ansible_distribution_ver is version ('21.04', '>=')
         - vcenter_version is version ('7.0.1', '<')
         - not enable_cloudinit_gosc | bool
+
+    - block:
+        - include_tasks: ../utils/get_installed_package_info.yml
+          vars:
+            package_name: "open-vm-tools"
+
+        - name: "Set fact of GOSC support status to False for Photon OS with not bundled open-vm-tools"
+          set_fact:
+            gosc_is_supported: False
+          when:
+            - not enable_cloudinit_gosc | bool
+            - package_info is defined
+            - package_info.Release is defined
+            - "'ph' not in package_info.Release | string"
+
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "GOSC is not supported for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} with open-vm-tools {{ vmtools_version }}."
+          when: not gosc_is_supported | bool
+      when: guest_os_ansible_distribution == 'VMware Photon OS'
 
     - block:
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -42,16 +42,17 @@
           set_fact:
             gosc_is_supported: False
           when:
-            - not enable_cloudinit_gosc | bool
             - package_info is defined
             - package_info.Release is defined
             - "'ph' not in package_info.Release | string"
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "GOSC is not supported for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} with open-vm-tools {{ vmtools_version }}."
+            skip_msg: "Perl GOSC is not supported for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} with not bundled open-vm-tools {{ vmtools_version }}."
           when: not gosc_is_supported | bool
-      when: guest_os_ansible_distribution == 'VMware Photon OS'
+      when:
+        - guest_os_ansible_distribution == 'VMware Photon OS'
+        - not enable_cloudinit_gosc | bool
 
     - block:
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -46,6 +46,7 @@
             package_name: "open-vm-tools-gosc-{{ vmtools_version }}"
             package_state: "present"
           when:
+            - not enable_cloudinit_gosc | bool
             - guest_os_ansible_distribution_major_ver | int >= 4
             - vmtools_version is defined
             - vmtools_version is version('11.3.5', '>=')


### PR DESCRIPTION
Fix #172 Perl GOSC on Photon OS requires OS bundled open-vm-tools. If the OVT installed is not from Photon OS's repository, skip to run perl GOSC testing on it.

```
+---------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                |
|                           | bitness='64'                      |
|                           | distroName='VMware Photon OS'     |
|                           | distroVersion='4.0'               |
|                           | familyName='Linux'                |
|                           | kernelVersion='5.10.61-1.ph4-esx' |
|                           | prettyName='VMware Photon OS 4.0' |
+---------------------------------------------------------------+


Test Results (Total: 4, Failed: 0, No Run: 2, Elapsed Time: 00:16:04):
+------------------------------------------------+
| Name                    |   Status | Exec Time |
+------------------------------------------------+
| gosc_perl_dhcp          | * No Run | 00:01:18  |
| gosc_perl_staticip      | * No Run | 00:01:02  |
| gosc_cloudinit_dhcp     |   Passed | 00:05:58  |
| gosc_cloudinit_staticip |   Passed | 00:05:39  |
+------------------------------------------------+
```
Signed-off-by: Qi Zhang <qiz@vmware.com>