### PR TITLE
Fix memory_hot_add_basic failure due to ip change

### DIFF
--- a/linux/memory_hot_add_basic/memory_set_and_validate.yml
+++ b/linux/memory_hot_add_basic/memory_set_and_validate.yml
@@ -24,20 +24,29 @@
     - include_tasks: ../../common/vm_set_memory_size.yml
       vars:
         memory_mb: "{{ mem_after_hotadd }}"
-    - include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'powered-on'
+
+    - block:
+        - include_tasks: ../../common/vm_set_power_state.yml
+          vars:
+            vm_power_state_set: 'powered-on'
+
+        - include_tasks: ../../common/update_inventory.yml
       when:
         - mem_before_hotadd | int <= 3072
         - mem_after_hotadd | int > 3072
     
-    # Check VM connection is not broken and/or VM boots up after cold add
-    - name: "Pause 5 seconds then check VM connection status"
-      pause:
-        seconds: 5
-    - include_tasks: ../../common/vm_wait_connection.yml
-      vars:
-        vm_wait_connection_timeout: 900
+    # Check VM connection is not broken after memory hot add
+    - block:
+        - name: "Pause 5 seconds then check VM connection status"
+          pause:
+            seconds: 5
+        - include_tasks: ../../common/vm_wait_connection.yml
+          vars:
+            vm_wait_connection_timeout: 900
+      when: >
+        mem_before_hotadd | int > 3072 or
+        mem_after_hotadd | int <= 3072
+
 
     # Get VM memory size in guest OS
     - include_tasks: ../utils/wait_for_memory_blocks.yml


### PR DESCRIPTION
Fix #235 by updating inventory after memory cold add

```
+-----------------------------------------------------------+
| Guest OS Type             | VMware Photon OS 4.0 x86_64   |
+-----------------------------------------------------------+
| VMTools Version           | 11.3.5.31214 (build-18557794) |
+-----------------------------------------------------------+
| CloudInit Version         |                               |
+-----------------------------------------------------------+
| Config Guest Id           | vmwarePhoton64Guest           |
+-----------------------------------------------------------+
| Hardware Version          | vmx-14                        |
+-----------------------------------------------------------+
| GuestInfo Guest Id        | vmwarePhoton64Guest           |
+-----------------------------------------------------------+
| GuestInfo Guest Full Name | VMware Photon OS (64-bit)     |
+-----------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                    |
+-----------------------------------------------------------+
| GuestInfo Detailed Data   |                               |
+-----------------------------------------------------------+


Test Results (Total: 2, Failed: 0, No Run: 1, Elapsed Time: 00:07:09):
+---------------------------------------------+
| Name                 |   Status | Exec Time |
+---------------------------------------------+
| memory_hot_add_basic |   Passed | 00:05:53  |
```