### PR TITLE
Fix #237 Update baseurl for CentOS online repos

### DIFF
--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -56,6 +56,7 @@
           vars:
             ansible_user: "{{ esxi_username }}"
             ansible_password: "{{ esxi_password }}"
+            ansible_host_key_checking: no
           delegate_to: "{{ esxi_hostname }}"
           register: check_esxi_shell
 

--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -5,6 +5,10 @@
 # Parameters
 #   ovt_packages: open-vm-tools package names
 
+# Update online repo for CentOS archived version and stream version
+- include_tasks: ../utils/add_official_online_repo.yml
+  when: guest_os_ansible_distribution == 'CentOS'
+
 - block:
     # Add a local repo from ISO image for RHEL/SLES/SLED
     - include_tasks: ../utils/add_local_dvd_repo.yml
@@ -12,7 +16,7 @@
 
     # Add online repo for CentOS, OracleLinux, Ubuntu, Debian and Photon
     - include_tasks: ../utils/add_official_online_repo.yml
-      when: guest_os_ansible_distribution in ['CentOS', 'OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
+      when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
   when: linux_ovt_repo_url is undefined or not linux_ovt_repo_url
 
 - include_tasks: ../utils/add_extra_online_repo.yml

--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -14,7 +14,7 @@
     - include_tasks: ../utils/add_local_dvd_repo.yml
       when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat']
 
-    # Add online repo for CentOS, OracleLinux, Ubuntu, Debian and Photon
+    # Add online repo for OracleLinux, Ubuntu, Debian and Photon
     - include_tasks: ../utils/add_official_online_repo.yml
       when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu', 'Debian', 'VMware Photon OS']
   when: linux_ovt_repo_url is undefined or not linux_ovt_repo_url

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -3,35 +3,64 @@
 ---
 # Add official online package repository
 - block:
-    - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
-      set_fact:
-        online_repos:
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}"
-            baseurl: "http://mirror.centos.org/$contentdir/$releasever/os/$basearch"
-            mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra"
-            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
-      when:
-        - guest_os_ansible_distribution == "CentOS"
-        - guest_os_ansible_distribution_major_ver | int < 8
+    - block:
+        - name: "List deprecated repositories"
+          shell: "grep -rGl 'mirror\\(list\\)\\?.centos.org' /etc/yum.repos.d/"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: list_centos_repos
 
-    - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
-      set_fact:
-        online_repos:
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
-            baseurl: "http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/"
-            mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra"
-            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_AppStrem"
-            baseurl: "http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/"
-            mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra"
-            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_PowerTools"
-            baseurl: "http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/"
-            mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra"
-            gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
-      when:
-        - guest_os_ansible_distribution == "CentOS"
-        - guest_os_ansible_distribution_major_ver | int >= 8
+        - name: "Display repositories which use CentOS mirrors"
+          debug: var=list_centos_repos
+  
+        - name: "Remove deprecated repositories"
+          file:
+            path: "{{ centos_repo_path }}"
+            state: absent
+          delegate_to: "{{ vm_guest_ip }}"
+          with_items: "{{ list_centos_repos.stdout_lines }}"
+          loop_control:
+            loop_var: centos_repo_path
+          when:
+            - list_centos_repos is defined
+            - list_centos_repos.stdout_lines is defined
+            - list_centos_repos.stdout_lines | length > 0
+
+        - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+          set_fact:
+            online_repos:
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}"
+                baseurl: "http://vault.centos.org/$contentdir/$releasever/os/$basearch"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
+          when: guest_os_ansible_distribution_major_ver | int < 8
+
+        - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+          set_fact:
+            online_repos:
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
+                baseurl: "http://vault.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_AppStrem"
+                baseurl: "http://vault.centos.org/$contentdir/$releasever/AppStream/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_PowerTools"
+                baseurl: "http://vault.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+          when: guest_os_ansible_distribution_major_ver | int == 8
+
+        - name: "Set online repositories for CentOS {{ guest_os_ansible_distribution_ver }}"
+          set_fact:
+            online_repos:
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
+                baseurl: "http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_AppStrem"
+                baseurl: "http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+              - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_PowerTools"
+                baseurl: "http://mirror.stream.centos.org/9-stream/CRB/$basearch/os/"
+                gpg_key_path: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
+          when: guest_os_ansible_distribution_major_ver | int >= 9
+      when: guest_os_ansible_distribution == "CentOS"
 
     - name: "Set online repositories for Rocky Linux {{ guest_os_ansible_distribution_ver }}"
       set_fact:
@@ -54,7 +83,7 @@
       vars:
         repo_name: "{{ online_repo.name }}"
         repo_baseurl: "{{ online_repo.baseurl }}"
-        repo_mirrorlist: "{{ online_repo.mirrorlist }}"
+        repo_mirrorlist: "{{ online_repo.mirrorlist | default(omit) }}"
         gpg_check: True
         gpg_key_path: "{{ online_repo.gpg_key_path }}"
       with_list: "{{ online_repos }}"

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -257,7 +257,7 @@ windows_has_inbox_driver: True
 # case result will be 'Failed'. For CentOS/OracleLinux/Photon OS/Ubuntu/Debian, open-vm-tools will be
 # installed from official online repositories.
 #
-# linux_ovt_repo_url: "http://mirror.centos.org/centos/8/BaseOS/x86_64/os/"
+# linux_ovt_repo_url: "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os"
 
 # In Windows test case 'wintools_complete_install_verify', there are 3 methods to configure the source of VMware tools.
 # (1) ESXi host bundled:


### PR DESCRIPTION
Fix #237 CentOS 8.x and earlier repos were moved out of CentOS mirrors

https://vault.centos.org provides access to older archived versions, including CentOS 8.x and earlier versions.
http://mirror.stream.centos.org contains new CentOS Stream releases, starting from release '9-stream'.

Signed-off-by: Qi Zhang <qiz@vmware.com>