### PR TITLE
Add workaround task for creating VM with IDE boot disk

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -16,6 +16,7 @@
 
 ### Tasks for VM deploy or remove
 * vm_create.yml: Create a new VM on ESXi host
+* vm_create_with_ide_disk.yml: Create a new VM which boot from an IDE disk on ESXi host
 * ovf_deploy.yml: Deploy OVF template to VM
 * ovf_export.yml: Export VM to OVF template
 * vm_remove.yml: Delete VM from ESXi host

--- a/common/vm_create_with_ide_disk.yml
+++ b/common/vm_create_with_ide_disk.yml
@@ -1,0 +1,62 @@
+# Copyright 2021-2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Create a new VM with IDE disk as boot disk
+# Parameters:
+#   vm_name (required): the name of the new VM.
+#   guest_id (required): the guest ID of new created VM.
+#   datastore (required): the name of datastore where new VM created.
+#   vm_power_state (optional): the power state of VM after creation, valid values are
+#     'poweredon', 'powered-on', 'poweredoff', 'powered-off', default value is 'poweredoff'.
+#   memory_mb (optional): the VM memory size in MB, default value is 4096.
+#   cpu_number (optional): the VM CPU number, default value is 2.
+#   num_cpu_cores_per_socket (optional): VM CPU cores per socket number, default is 1.
+#   firmware (optional): VM firmware type, valid values are 'efi', 'bios',
+#     default value is 'efi'.
+#   hardware_version (optional): the hardware version of VM, if not specified will create
+#     VM with the latest hardware version ESXi supported.
+#   vm_cdroms (optional): VM CDROM list, this parameter is optional, but if you want to install
+#     guest OS after VM created, please configure the OS installation ISO files.
+#   boot_disk_size_gb (optional): the boot disk size in GB, default value is 32.
+#   network_adapter_type (optional): the network adapter type, valid values are 'e1000',
+#     'e1000e', 'vmxnet3', default value is 'vmxnet3'.
+#   vm_network_name (optional): the name of network to connect, default is 'VM Network',
+#     and type of of IP assignment is set to 'dhcp'.
+#
+- include_tasks: vm_create.yml
+  vars:
+    boot_disk_controller: 'paravirtual'
+
+# Get VM id
+- include_tasks: vm_get_id.yml
+
+- name: "Get IDE controller number and unit number for boot disk"
+  set_fact:
+    ide_disk_ctlr_num: "{{ ((vm_cdroms | length) / 2) | int }}"
+    ide_disk_unit_num: "{{ ((vm_cdroms | length) % 2) | int }}"
+  when: cdrom_controller_type == 'ide'
+
+- name: "Get IDE controller number and unit number for boot disk"
+  set_fact:
+    ide_disk_ctlr_num: 0
+    ide_disk_unit_num: 0
+  when: cdrom_controller_type != 'ide'
+
+- fail:
+    msg: "Can't create VM with IDE disk as all IDE controllers are occupied"
+  when: ide_disk_ctlr_num | int > 1
+
+- name: "Set boot disk size in KB"
+  set_fact:
+    boot_disk_size_kb:  "{{ (boot_disk_size_gb | int) * 1024 * 1024 }}"
+
+- block:
+    - name: "Remove pre-added PVSCSI boot disk"
+      shell: "vim-cmd /vmsvc/device.diskremove {{ vm_id }} 0 0 scsi"
+
+    - name: "Remove pre-added PVSCSI controller"
+      shell: "vim-cmd /vmsvc/device.ctlrremove {{ vm_id }} scsi 0"
+
+    - name: "Add IDE boot disk"
+      shell: "vim-cmd /vmsvc/device.diskadd {{ vm_id }} {{ boot_disk_size_kb }} {{ ide_disk_ctlr_num }} {{ ide_disk_unit_num  }} {{ datastore }} ide"
+  delegate_to: "{{ esxi_hostname }}"

--- a/common/vm_get_id.yml
+++ b/common/vm_get_id.yml
@@ -1,6 +1,10 @@
 # Copyright 2021-2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+- name: "Initialize VM ID"
+  set_fact:
+    vm_id: ''
+
 - name: "Get VM '{{ vm_name }}' facts from ESXi host"
   vmware_guest_info:
     hostname: "{{ esxi_hostname }}"
@@ -9,13 +13,23 @@
     validate_certs: "{{ validate_certs | default(False) }}"
     datacenter: "ha-datacenter"
     name: "{{ vm_name }}"
-  register: vm_guest_facts
+  register: vm_moid_facts
 - name: Display the VM guest facts
-  debug: var=vm_guest_facts
+  debug: var=vm_moid_facts
   when: enable_debug is defined and enable_debug
 
 - name: "Set fact of the VM ID of VM '{{ vm_name }}'"
   set_fact:
-    vm_id: "{{ vm_guest_facts.instance.moid | default(0) }}"
+    vm_id: "{{ vm_moid_facts.instance.moid | int }}"
+  when:
+    - vm_moid_facts is defined
+    - vm_moid_facts.instance is defined
+    - vm_moid_facts.instance.moid is defined
+    - vm_moid_facts.instance.moid
+
+- fail:
+    msg: "Failed to get VM ID"
+  when: not vm_id
+
 - debug:
-    msg: "Get VM '{{ vm_name }}' moid from ESXi host '{{ esxi_hostname }}': {{ vm_id }}"
+    msg: "Get VM '{{ vm_name }}' ID from ESXi host '{{ esxi_hostname }}': {{ vm_id }}"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -51,6 +51,10 @@
     - include_tasks: check_configured_cdrom_iso.yml
     # Create a new VM
     - include_tasks: ../../common/vm_create.yml
+      when: boot_disk_controller != 'ide'
+    - include_tasks: ../../common/vm_create_with_ide_disk.yml
+      when: boot_disk_controller == 'ide'
+
     - include_tasks: ../../common/vm_get_vm_info.yml
 
     # Add a serial port to monitor autoinstall process

--- a/sample/test.yml
+++ b/sample/test.yml
@@ -186,7 +186,7 @@ cpu_number: 2
 cpu_cores_per_socket: 1
 # Firmware valid value 'bios' or 'efi'.
 firmware: "efi"
-# Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', or 'nvme'.
+# Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', 'nvme', or 'ide'.
 boot_disk_controller: "paravirtual"
 boot_disk_size_gb: 32
 # Network adapter type valid value is 'vmxnet3' or 'e1000e'.

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -180,7 +180,7 @@ cpu_number: 2
 cpu_cores_per_socket: 1
 # Firmware valid value 'bios' or 'efi'.
 firmware: "efi"
-# Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', or 'nvme'.
+# Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', 'nvme', or 'ide'.
 boot_disk_controller: "paravirtual"
 boot_disk_size_gb: 40
 # Valid value is 'vmxnet3' or 'e1000e'.

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -66,6 +66,10 @@
           set_fact:
             boot_disk_size_gb: "{{ [64, boot_disk_size_gb | default(64) | int] | max }}"
         - include_tasks: ../../common/vm_create.yml
+          when: boot_disk_controller != 'ide'
+        - include_tasks: ../../common/vm_create_with_ide_disk.yml
+          when: boot_disk_controller == 'ide'
+
         # When firmware is EFI, configure force EFI setup once
         - name: Enable force setup once when VM firmware is EFI and send keys to VM
           block:


### PR DESCRIPTION
This is a workaround for issue https://github.com/vmware/ansible-vsphere-gos-validation/issues/224, so that it won't block our IDE testing. After https://github.com/vmware/ansible-vsphere-gos-validation/issues/224 is fixed, we can remove the workaround task.

Signed-off-by: Qi Zhang <qiz@vmware.com>