### PR TITLE
Remove serial port from Ubuntu VM after OVA deployment

### DIFF
--- a/linux/deploy_vm/ubuntu/reconfigure_ubuntu_ova_vm.yml
+++ b/linux/deploy_vm/ubuntu/reconfigure_ubuntu_ova_vm.yml
@@ -72,3 +72,18 @@
   vars:
     local_path: "{{ tmp_seed_dir }}"
 
+# Remove serial port
+- include_tasks: ../utils/shutdown.yml
+
+- include_tasks: ../../common/vm_remove_serial_port.yml
+
+- fail:
+    msg: "Failed to remove serial port from VM"
+  when: >
+    remove_serial_port is undefined or
+    remove_serial_port.changed is undefined or
+    not remove_serial_port.changed
+
+- include_tasks: ../../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>

Fix #248 
```
+-----------------------------------------------------------+
| Guest OS Type             | Ubuntu 21.10 x86_64           |
+-----------------------------------------------------------+
| Hardware Version          | vmx-14                        |
+-----------------------------------------------------------+
| VMTools Version           | 11.3.0.29534 (build-18090558) |
+-----------------------------------------------------------+
| CloudInit Version         | 21.3-1-g6803368d-0ubuntu3     |
+-----------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                 |
+-----------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                 |
+-----------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)         |
+-----------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                    |
+-----------------------------------------------------------+
| GuestInfo Detailed Data   |                               |
+-----------------------------------------------------------+


Test Results (Total: 28, Failed: 0, No Run: 4, Elapsed Time: 01:25:21):
+-------------------------------------------------------------+
| Name                                 |   Status | Exec Time |
+-------------------------------------------------------------+
| deploy_ubuntu_ova                    |   Passed | 00:06:45  |
| ovt_verify_install                   |   Passed | 00:06:30  |
| ovt_verify_status                    |   Passed | 00:00:59  |
| vgauth_check_service                 |   Passed | 00:00:54  |
| check_ip_address                     |   Passed | 00:00:50  |
| stat_balloon                         |   Passed | 00:00:47  |
| stat_hosttime                        |   Passed | 00:00:49  |
| check_inbox_driver                   |   Passed | 00:01:01  |
| check_os_fullname                    |   Passed | 00:00:49  |
| check_efi_firmware                   | * No Run | 00:00:46  |
| cpu_hot_add_basic                    |   Passed | 00:05:40  |
| check_quiesce_snapshot_custom_script |   Passed | 00:01:50  |
| memory_hot_add_basic                 |   Passed | 00:07:09  |
| device_list                          |   Passed | 00:03:04  |
| secureboot_enable_disable            | * No Run | 00:00:46  |
| e1000e_network_device_ops            |   Passed | 00:02:03  |
| vmxnet3_network_device_ops           |   Passed | 00:01:48  |
| cpu_multicores_per_socket            |   Passed | 00:10:01  |
| gosc_perl_dhcp                       | * No Run | 00:00:45  |
| gosc_perl_staticip                   | * No Run | 00:00:50  |
| gosc_cloudinit_dhcp                  |   Passed | 00:06:02  |
| gosc_cloudinit_staticip              |   Passed | 00:05:42  |
| paravirtual_vhba_device_ops          |   Passed | 00:02:30  |
| lsilogic_vhba_device_ops             |   Passed | 00:02:56  |
| lsilogicsas_vhba_device_ops          |   Passed | 00:02:31  |
| sata_vhba_device_ops                 |   Passed | 00:02:38  |
| nvme_vhba_device_ops                 |   Passed | 00:03:08  |
| ovt_verify_uninstall                 |   Passed | 00:03:12  |
+-------------------------------------------------------------+
```