### PR TITLE
Fix ubuntu_version failure when ISO name has no version

### DIFF
--- a/linux/deploy_vm/ubuntu/prepare_ubuntu_iso_install.yml
+++ b/linux/deploy_vm/ubuntu/prepare_ubuntu_iso_install.yml
@@ -21,8 +21,8 @@
 - name: "Set Ubuntu autoinstall method"
   set_fact:
     ubuntu_install_method: |-
-      {%- if ubuntu_version is version('20.04', '>=') -%}cloud-init
-      {%- elif ubuntu_version is version('20.04', '<') -%}simulation
+      {%- if ubuntu_version and ubuntu_version is version('20.04', '>=') -%}cloud-init
+      {%- elif ubuntu_version and ubuntu_version is version('20.04', '<') -%}simulation
       {%- else -%}cloud-init
       {%- endif -%}
   when: ubuntu_edition == 'server'


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
If the Ubuntu ISO name doesn't contain any version information, like jammy-live-server-amd64.iso, set fact of ubuntu_install_method would fail as ubuntu_version is empty. And the task would fail with below message:

```
2022-03-03 03:53:27,003 | TASK [Set Ubuntu autoinstall method] ***********************
task path: /home/worker/workspace/Ansible_Cycle_Ubuntu_20.04.4_ISO/ansible-vsphere-gos-validation/linux/deploy_vm/ubuntu/prepare_ubuntu_iso_install.yml:21
fatal: [localhost]: FAILED! => {
    "msg": "Input version value cannot be empty"
}
```