### PR TITLE
Fix Debian 11.3 testing issue

### DIFF
--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -152,7 +152,6 @@ d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
 d-i apt-setup/disable-cdrom-entries boolean true
-#d-i apt-setup/contrib boolean true
 
 # Don't add any security and updates repo to avoid an upgrade during installation
 d-i apt-setup/services-select multiselect

--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -152,6 +152,7 @@ d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
 d-i apt-setup/disable-cdrom-entries boolean true
+#d-i apt-setup/contrib boolean true
 
 # Don't add any security and updates repo to avoid an upgrade during installation
 d-i apt-setup/services-select multiselect
@@ -164,7 +165,7 @@ tasksel tasksel/desktop multiselect gnome
 
 # Individual additional packages to install
 # There is no open-vm-tools-desktop and cloud-init in CDROM
-d-i pkgsel/include string build-essential vim locales open-vm-tools openssh-server
+d-i pkgsel/include string build-essential vim locales open-vm-tools openssh-server sg3-utils
 
 # Policy for applying updates. May be "none" (no automatic updates),
 # "unattended-upgrades" (install security updates automatically), or

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -89,15 +89,16 @@
         # For other OS, cloud-init GOSC requires cloud-init 18.5 or later installed.
         - name: "Set fact of cloud-init version for supporting GOSC"
           set_fact:
+            operator: >-
+              {% if guest_os_ansible_distribution != 'Debian' %}>{% else %}>={% endif %}
             gosc_required_cloudinit_version: >-
               {% if guest_os_ansible_distribution != 'Debian' %}18.5{% else %}22.1{% endif %}
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >
-              The guest OS doesn't have cloud-init (> {{ gosc_required_cloudinit_version }}) installed.
-              Skip to run this test case.
-          when: (not cloudinit_version) or cloudinit_version is version(gosc_required_cloudinit_version, '<=')
+              The guest OS doesn't have required cloud-init ({{ operator }} {{ gosc_required_cloudinit_version }}) installed. Skip to run this test case.
+          when: (not cloudinit_version) or not (cloudinit_version is version(gosc_required_cloudinit_version, operator))
       when: enable_cloudinit_gosc
 
     # Initialize the GOSC spec

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -82,27 +82,22 @@
     # Check cloud-init version for cloud-init gosc workflow
     - include_tasks: ../utils/cloudinit_pkg_check.yml
 
-    # Skip cloud-init GOSC if cloud-init version is lower than 18.5
+    # Skip cloud-init GOSC if cloud-init version is lower than required version.
     - block:
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: >
-              The guest OS doesn't have cloud-init (> 18.5) installed.
-              Skip to run this test case.
-          when:
-            - guest_os_ansible_distribution != "Debian"
-            - (not cloudinit_version) or (cloudinit_version is version('18.5', '<='))
-
         # Debian 10 and 11 cloud-init GOSC depends on cloud-init 22.1 or later
         # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008039
+        # For other OS, cloud-init GOSC requires cloud-init 18.5 or later installed.
+        - name: "Set fact of cloud-init version for supporting GOSC"
+          set_fact:
+            gosc_required_cloudinit_version: >-
+              {% if guest_os_ansible_distribution != 'Debian' %}18.5{% else %}22.1{% endif %}
+
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >
-              The guest OS doesn't have cloud-init (>= 22.1) installed.
+              The guest OS doesn't have cloud-init (> {{ gosc_required_cloudinit_version }}) installed.
               Skip to run this test case.
-          when:
-            - guest_os_ansible_distribution == "Debian"
-            - (not cloudinit_version) or (cloudinit_version is version('22.1', '<='))
+          when: (not cloudinit_version) or cloudinit_version is version(gosc_required_cloudinit_version, '<=')
       when: enable_cloudinit_gosc
 
     # Initialize the GOSC spec

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -83,14 +83,27 @@
     - include_tasks: ../utils/cloudinit_pkg_check.yml
 
     # Skip cloud-init GOSC if cloud-init version is lower than 18.5
-    - include_tasks: ../../common/skip_test_case.yml
-      vars:
-        skip_msg: >
-          "The guest OS doesn't have cloud-init (> 18.5) installed.
-          Skip to run this test case."
-      when:
-        - enable_cloudinit_gosc
-        - (not cloudinit_version) or (cloudinit_version is version('18.5', '<='))
+    - block:
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >
+              The guest OS doesn't have cloud-init (> 18.5) installed.
+              Skip to run this test case.
+          when:
+            - guest_os_ansible_distribution != "Debian"
+            - (not cloudinit_version) or (cloudinit_version is version('18.5', '<='))
+
+        # Debian 10 and 11 cloud-init GOSC depends on cloud-init 22.1 or later
+        # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008039
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >
+              The guest OS doesn't have cloud-init (>= 22.1) installed.
+              Skip to run this test case.
+          when:
+            - guest_os_ansible_distribution == "Debian"
+            - (not cloudinit_version) or (cloudinit_version is version('22.1', '<='))
+      when: enable_cloudinit_gosc
 
     # Initialize the GOSC spec
     - name: Initialize the GOS customization spec

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -106,5 +106,14 @@
       apt:
         name: "{{ package_name }}"
         state: "{{ package_state }}"
+        update_cache: true
       delegate_to: "{{ vm_guest_ip }}"
+      when: guest_os_family == "Debian"
+
+    - name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+      apt:
+        name: "{{ package_name }}"
+        state: "{{ package_state }}"
+      delegate_to: "{{ vm_guest_ip }}"
+      when: guest_os_family == "Astra Linux (Orel)"
   when: guest_os_family in ["Debian", "Astra Linux (Orel)"]


### PR DESCRIPTION
1. Fix #279 by installing sg3-utils at deployment for new VM, and update cache while installing it on existing VM.
2. Skip cloud-init GOSC testing when cloud-init version is not 22.1 or later.

```
+-------------------------------------------------------------------------+
| Guest OS Distribution     | Debian 11.3 x86_64                          |
+-------------------------------------------------------------------------+
| CloudInit Version         | 20.4.1-2+deb11u1                            |
+-------------------------------------------------------------------------+
| GUI Installed             | True                                        |
+-------------------------------------------------------------------------+
| Config Guest Id           | debian11_64Guest                            |
+-------------------------------------------------------------------------+
| GuestInfo Guest Id        | debian11_64Guest                            |
+-------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Debian GNU/Linux 11 (64-bit)                |
+-------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                  |
+-------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                          |
|                           | bitness='64'                                |
|                           | distroName='Debian GNU/Linux 11 (bullseye)' |
|                           | distroVersion='11'                          |
|                           | familyName='Linux'                          |
|                           | kernelVersion='5.10.0-13-amd64'             |
|                           | prettyName='Debian GNU/Linux 11 (bullseye)' |
+-------------------------------------------------------------------------+

...

+------------------------------------------------+
| Name                    |   Status | Exec Time |
+------------------------------------------------+
| gosc_cloudinit_dhcp     | * No Run | 00:01:29  |
| gosc_cloudinit_staticip | * No Run | 00:01:25  |
| lsilogic_vhba_device_ops |   Passed | 00:05:12  |
+------------------------------------------------+
```