### PR TITLE
Fix #163 Check inbox driver vmw_pvrdma and ptp_vmw 

### DIFF
--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -34,7 +34,11 @@
 
         - name: "Get OS Release for SUSE"
           set_fact:
-            inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'Release': 'SLE ' ~ guest_os_ansible_distribution_major_ver ~ ' SP' ~ guest_os_ansible_distribution_minor_ver}) }}"
+            inbox_drivers_versions: >-
+              {{
+                inbox_drivers_versions |
+                combine({'Release': 'SLE ' ~ guest_os_ansible_distribution_major_ver ~ ' SP' ~ guest_os_ansible_distribution_minor_ver})
+              }}
           when: guest_os_ansible_distribution in ['SLES', 'SLED']
 
         - name: "Get OS Release for RHEL"
@@ -44,7 +48,11 @@
 
         - name: "Get OS Release for {{ guest_os_ansible_distribution }}"
           set_fact:
-            inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'Release': guest_os_ansible_distribution ~ ' ' ~ guest_os_ansible_distribution_ver}) }}"
+            inbox_drivers_versions: >-
+              {{
+                inbox_drivers_versions |
+                combine({'Release': guest_os_ansible_distribution ~ ' ' ~ guest_os_ansible_distribution_ver})
+              }}
           when: guest_os_ansible_distribution not in ['SLES', 'SLED', "RedHat"]
 
         - name: "Get OS kernel version"
@@ -75,7 +83,7 @@
             - cloudinit_version is defined
             - cloudinit_version
 
-        - name: "Get drivers version in VMware Photon OS"
+        - name: "Get drivers version in VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
           block:
             - name: "Check driver version"
               shell: "if [ -e /sys/module/{{ driver }}/version ]; then cat /sys/module/{{ driver }}/version ; fi"
@@ -88,54 +96,108 @@
 
             - name: Set fact of driver version dict
               set_fact:
-                inbox_drivers_versions: "{{ inbox_drivers_versions | combine({driver.driver: driver.stdout}) }}"
-              with_items: "{{ photon_drivers.results }}"
-              loop_control:
-                loop_var: driver
+                inbox_drivers_versions: >-
+                  {{
+                    inbox_drivers_versions |
+                    combine(photon_drivers.results |
+                            selectattr('stdout', 'defined') |
+                            selectattr('stdout', '!=', '') |
+                            items2dict(key_name='driver', value_name='stdout'))
+                  }}
           when:
             - guest_os_ansible_distribution == "VMware Photon OS"
+            - guest_os_ansible_distribution_major_ver | int < 4
 
-        - name: "Get drivers version in {{ guest_os_ansible_distribution }}"
+        - name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
           block:
-            - name: "Initialize fact of modules information"
-              set_fact:
-                vmware_modules_info: []
-
-            - name: "Get module information"
-              command: "modinfo {{ module_name }}"
-              register: modinfo_result
+            # Get inbox driver's version
+            - name: "Get inbox drivers version"
+              shell: "modinfo -F version {{ module_name }} | grep -v 'name:'"
+              register: modinfo_version
               delegate_to: "{{ vm_guest_ip }}"
-              failed_when: False
+              ignore_errors: True
               loop: "{{ inbox_drivers }}"
               loop_control:
                 loop_var: module_name
 
-            - name: "Convert modinfo result to dictionary"
+            - name: "Update fact of inbox driver version dict with driver's version"
               set_fact:
-                vmware_modules_info: "{{ vmware_modules_info + ['\n'.join(item.stdout_lines | select('match', '^\\w+:.*[^:]$')) | from_yaml | combine({'module_name': item.module_name }) ] }}"
-              when: item.stdout_lines is defined and item.stdout_lines | length
-              loop: "{{ modinfo_result.results }}"
-
-            - set_fact:
-                vmware_modules: "{{ vmware_modules_info | selectattr('version', 'defined') | items2dict(key_name='module_name', value_name='version') }}"
-              when: vmware_modules_info is defined and vmware_modules_info | length > 0
-
-            - name: "Set fact of inbox drivers versions"
-              set_fact:
-                inbox_drivers_versions: "{{ inbox_drivers_versions | combine(vmware_modules) }}"
-              when: vmware_modules is defined and vmware_modules
-
-            - name: "Get srcversion for inbox drivers which has no version"
-              set_fact:
-                inbox_drivers_versions: "{{ inbox_drivers_versions | combine({item.module_name: item.srcversion}) }}"
+                inbox_drivers_versions: >-
+                  {{
+                    inbox_drivers_versions |
+                    combine(modinfo_version.results |
+                            selectattr('stdout', 'defined') |
+                            selectattr('stdout', '!=', '') |
+                            items2dict(key_name='module_name', value_name='stdout'))
+                  }}
               when:
-                - item.module_name not in vmware_modules
-                - item.srcversion is defined
-              with_items: "{{ vmware_modules_info }}"
+                - modinfo_version is defined
+                - modinfo_version.results | length > 0
 
-          when:
-            - guest_os_ansible_system == "Linux"
-            - guest_os_ansible_distribution != "VMware Photon OS"
+            # If the inbox driver has no version, get its srcversion
+            - name: "Get inbox drivers src version"
+              shell: "modinfo -F srcversion {{ module_name }} | grep -v 'name:'"
+              register: modinfo_srcversion
+              delegate_to: "{{ vm_guest_ip }}"
+              ignore_errors: True
+              loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
+              loop_control:
+                loop_var: module_name
+
+            - name: "Update fact of inbox driver version dict with driver's srcversion"
+              set_fact:
+                inbox_drivers_versions: >-
+                  {{
+                    inbox_drivers_versions |
+                    combine(modinfo_srcversion.results |
+                            selectattr('stdout', 'defined') |
+                            selectattr('stdout', '!=', '') |
+                            items2dict(key_name='module_name', value_name='stdout'))
+                  }}
+              when:
+                - modinfo_srcversion is defined
+                - modinfo_srcversion.results | length > 0
+
+            # If the inbox driver has no srcversion, get its vermagic which is actually same as kernel version
+            # If the driver exists but has no vermagic, leave the driver version as empty
+            - name: "Get inbox driver vermagic"
+              shell: "modinfo -F vermagic {{ module_name }} | grep -v 'name:'"
+              register: modinfo_vermagic
+              delegate_to: "{{ vm_guest_ip }}"
+              ignore_errors: True
+              loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
+              loop_control:
+                loop_var: module_name
+
+            - name: "Update fact of inbox driver version dict with driver's vermagic"
+              set_fact:
+                inbox_drivers_versions: >-
+                  {{
+                    inbox_drivers_versions |
+                    combine(modinfo_vermagic.results |
+                            selectattr('rc', 'equalto', '0') |
+                            selectattr('stdout', 'defined') |
+                            items2dict(key_name='module_name', value_name='stdout'))
+                   }}
+              when:
+                - modinfo_vermagic is defined
+                - modinfo_vermagic.results | length > 0
+          when: >
+            (guest_os_ansible_distribution != "VMware Photon OS") or
+            (guest_os_ansible_distribution == "VMware Photon OS" and
+            guest_os_ansible_distribution_major_ver | int >= 4)
+
+        # If the driver is not found in guest OS, set its version to 'N/A'
+        - name: "Update fact of inbox driver version dict to set not found driver version with 'N/A'"
+          set_fact:
+            inbox_drivers_versions: >-
+              {{
+                inbox_drivers_versions |
+                combine({module_name: 'N/A'})
+              }}
+          loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
+          loop_control:
+            loop_var: module_name
 
         - name: "Check whether Xorg server is installed"
           command: "which Xorg"

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -110,78 +110,54 @@
 
         - name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
           block:
-            # Get inbox driver's version
-            - name: "Get inbox drivers version"
-              shell: "modinfo -F version {{ module_name }} | grep -v 'name:'"
-              register: modinfo_version
+            - name: "Get module information of inbox drivers"
+              command: "modinfo {{ module_name }}"
+              register: modinfo_result
               delegate_to: "{{ vm_guest_ip }}"
               ignore_errors: True
               loop: "{{ inbox_drivers }}"
               loop_control:
                 loop_var: module_name
 
-            - name: "Update fact of inbox driver version dict with driver's version"
+            - name: "Set fact of found inbox driver modules"
               set_fact:
-                inbox_drivers_versions: >-
-                  {{
-                    inbox_drivers_versions |
-                    combine(modinfo_version.results |
-                            selectattr('stdout', 'defined') |
-                            selectattr('stdout', '!=', '') |
-                            items2dict(key_name='module_name', value_name='stdout'))
+                builtin_modules: "{{ modinfo_result.results | selectattr('rc', 'equalto', 0) }}"
+
+            - name: "Set fact of inbox driver version with its version"
+              set_fact:
+                inbox_drivers_versions: >
+                  {{ inbox_drivers_versions |
+                     combine({item.module_name:''.join(item.stdout_lines |
+                                                        select('match', 'version:', ignorecase=True)) |
+                              regex_replace('version:\s*', '')})
                   }}
-              when:
-                - modinfo_version is defined
-                - modinfo_version.results | length > 0
+              with_items: "{{ builtin_modules }}"
 
-            # If the inbox driver has no version, get its srcversion
-            - name: "Get inbox drivers src version"
-              shell: "modinfo -F srcversion {{ module_name }} | grep -v 'name:'"
-              register: modinfo_srcversion
-              delegate_to: "{{ vm_guest_ip }}"
-              ignore_errors: True
-              loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
-              loop_control:
-                loop_var: module_name
-
-            - name: "Update fact of inbox driver version dict with driver's srcversion"
+            - name: "Set fact of inbox driver version with its srcversion"
               set_fact:
-                inbox_drivers_versions: >-
-                  {{
-                    inbox_drivers_versions |
-                    combine(modinfo_srcversion.results |
-                            selectattr('stdout', 'defined') |
-                            selectattr('stdout', '!=', '') |
-                            items2dict(key_name='module_name', value_name='stdout'))
+                inbox_drivers_versions: >
+                  {{ inbox_drivers_versions |
+                     combine({item.module_name:''.join(item.stdout_lines |
+                                                        select('match', 'srcversion:', ignorecase=True)) |
+                              regex_replace('srcversion:\s*', '')})
                   }}
-              when:
-                - modinfo_srcversion is defined
-                - modinfo_srcversion.results | length > 0
+              when: >
+                item.module_name not in inbox_drivers_versions or
+                not inbox_drivers_versions[item.module_name]
+              with_items: "{{ builtin_modules }}"
 
-            # If the inbox driver has no srcversion, get its vermagic which is actually same as kernel version
-            # If the driver exists but has no vermagic, leave the driver version as empty
-            - name: "Get inbox driver vermagic"
-              shell: "modinfo -F vermagic {{ module_name }} | grep -v 'name:'"
-              register: modinfo_vermagic
-              delegate_to: "{{ vm_guest_ip }}"
-              ignore_errors: True
-              loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
-              loop_control:
-                loop_var: module_name
-
-            - name: "Update fact of inbox driver version dict with driver's vermagic"
+            - name: "Set fact of inbox driver version with its vermagic"
               set_fact:
-                inbox_drivers_versions: >-
-                  {{
-                    inbox_drivers_versions |
-                    combine(modinfo_vermagic.results |
-                            selectattr('rc', 'equalto', '0') |
-                            selectattr('stdout', 'defined') |
-                            items2dict(key_name='module_name', value_name='stdout'))
-                   }}
-              when:
-                - modinfo_vermagic is defined
-                - modinfo_vermagic.results | length > 0
+                inbox_drivers_versions: >
+                  {{ inbox_drivers_versions |
+                     combine({item.module_name:''.join(item.stdout_lines |
+                                                        select('match', 'vermagic:', ignorecase=True)) |
+                              regex_replace('vermagic:\s*', '')})
+                  }}
+              when: >
+                item.module_name not in inbox_drivers_versions or
+                not inbox_drivers_versions[item.module_name]
+              with_items: "{{ builtin_modules }}"
           when: >
             (guest_os_ansible_distribution != "VMware Photon OS") or
             (guest_os_ansible_distribution == "VMware Photon OS" and

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -12,7 +12,16 @@
   vars_files:
     - "{{ testing_vars_file | default('../../vars/test.yml') }}"
   vars:
-    inbox_drivers: ["vmxnet3", "vmw_vmci", "vsock", "vmw_vsock_vmci_transport", "vmw_pvscsi", "vmw_balloon", "vmwgfx"]
+    inbox_drivers:
+      - vmxnet3
+      - vmw_vmci
+      - vsock
+      - vmw_vsock_vmci_transport
+      - vmw_pvscsi
+      - vmw_balloon
+      - vmwgfx
+      - vmw_pvrdma
+      - ptp_vmw
   tasks:
     - name: "Initialized inbox drivers' versions dict"
       set_fact:
@@ -115,6 +124,15 @@
               set_fact:
                 inbox_drivers_versions: "{{ inbox_drivers_versions | combine(vmware_modules) }}"
               when: vmware_modules is defined and vmware_modules
+
+            - name: "Get srcversion for inbox drivers which has no version"
+              set_fact:
+                inbox_drivers_versions: "{{ inbox_drivers_versions | combine({item.module_name: item.srcversion}) }}"
+              when:
+                - item.module_name not in vmware_modules
+                - item.srcversion is defined
+              with_items: "{{ vmware_modules_info }}"
+
           when:
             - guest_os_ansible_system == "Linux"
             - guest_os_ansible_distribution != "VMware Photon OS"

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -30,7 +30,7 @@
     - block:
         - include_tasks: ../setup/test_setup.yml
           vars:
-            skip_test_no_vmtools: True
+            skip_test_no_vmtools: False
 
         - name: "Get OS Release for SUSE"
           set_fact:


### PR DESCRIPTION
Fix #163 Check the inbox driver's version of vmw_pvrdma and ptp_vmw:
If the driver has version information, get the driver's versioin;
otherwise, if the driver has srcversion information, get the driver's srcversion;
otherwise, if the driver has vermagic information, get the driver's vermagic;
otherwise, if the driver exists but has no information about version/srcversion/vermagic, leave its version empty.
otherwise, set the driver's version as 'N/A' which indicates the driver is not found.

Example of inbox driver versions:
CentOS 8.5
```
"inbox_drivers_versions": {
        "Release": "CentOS 8.5",
        "cloud-init": "21.1",
        "kernel": "4.18.0-348.el8.x86_64",
        "open-vm-tools": "11.2.5.26209 (build-17337674)",
        "ptp_vmw": "188B9501F71B9AD0C3834B4",
        "vmw_balloon": "1.5.0.0-k",
        "vmw_pvrdma": "EFF44787273489FFA7BAAC2",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.18.0.0",
        "vmxnet3": "1.5.0.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.2.1",
        "xorg server": "1.20.11"
    }
```
VMware Photon OS 3.0 Rev3
```
    "inbox_drivers_versions": {
        "Release": "VMware Photon OS 3.0",
        "cloud-init": "19.4",
        "kernel": "4.19.132-5.ph3-esx",
        "open-vm-tools": "11.1.0.19887 (build-16036546)",
        "ptp_vmw": "N/A",
        "vmw_balloon": "1.5.0.0-k",
        "vmw_pvrdma": "N/A",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.15.0.0",
        "vmxnet3": "1.5.1.0-k",
        "vsock": "1.0.2.0-k"
    }
```

Ubuntu 22.04
```
    "inbox_drivers_versions": {
        "Release": "Ubuntu 22.04",
        "cloud-init": "22.1-14-g2e17a0d6-0ubuntu1~22.04.5",
        "kernel": "5.15.0-30-generic",
        "open-vm-tools": "11.3.5.31214 (build-18557794)",
        "ptp_vmw": "188B9501F71B9AD0C3834B4",
        "vmw_balloon": "ECD69D409A352515CC15B45",
        "vmw_pvrdma": "F0092285123462CEC485ECB",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.19.0.0",
        "vmxnet3": "1.6.0.0-k",
        "vsock": "1.0.2.0-k"
    }

```
RHEL-7.9
```
"inbox_drivers_versions": {
        "Release": "RHEL 7.9",
        "kernel": "3.10.0-1160.el7.x86_64",
        "open-vm-tools": "11.0.5.17716 (build-15389592)",
        "ptp_vmw": "N/A",
        "vmw_balloon": "1.4.1.0-k",
        "vmw_pvrdma": "8866055B396E30FABDD284C",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.4.0-k",
        "vmwgfx": "2.15.0.0",
        "vmxnet3": "1.4.17.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.2.1",
        "xorg server": "1.20.4"
    }
```
Rocky 8.5
```
    "inbox_drivers_versions": {
        "Release": "Rocky 8.5",
        "cloud-init": "21.1",
        "kernel": "4.18.0-348.el8.0.2.x86_64",
        "open-vm-tools": "11.2.5.26209 (build-17337674)",
        "ptp_vmw": "188B9501F71B9AD0C3834B4",
        "vmw_balloon": "1.5.0.0-k",
        "vmw_pvrdma": "EFF44787273489FFA7BAAC2",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.18.0.0",
        "vmxnet3": "1.5.0.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.2.1",
        "xorg server": "1.20.11"
    }
```
Debian 11.3
```
"inbox_drivers_versions": {
        "Release": "Debian 11.2",
        "kernel": "5.10.0-10-amd64",
        "open-vm-tools": "11.2.5.26209 (build-17337674)",
        "ptp_vmw": "N/A",
        "vmw_balloon": "5.10.0-10-amd64 SMP mod_unload modversions ",
        "vmw_pvrdma": "N/A",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.18.0.0",
        "vmxnet3": "1.5.0.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.3.0-3",
        "xorg server": "1.20.11"
    }
```
Photon 4.0 Rev2
```
    "inbox_drivers_versions": {
        "Release": "VMware Photon OS 4.0",
        "cloud-init": "21.4",
        "kernel": "5.10.83-7.ph4-esx",
        "open-vm-tools": "11.3.5.31214 (build-18557794)",
        "ptp_vmw": "5.10.83-7.ph4-esx SMP mod_unload ",
        "vmw_balloon": "",
        "vmw_pvrdma": "N/A",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.18.0.0",
        "vmxnet3": "1.5.0.0-k",
        "vsock": "1.0.2.0-k"
    }
```
SLED 15 SP4
```
    "inbox_drivers_versions": {
        "Release": "SLE 15 SP4",
        "kernel": "5.14.21-150400.20-default",
        "open-vm-tools": "11.3.5.31214 (build-18557794)",
        "ptp_vmw": "188B9501F71B9AD0C3834B4",
        "vmw_balloon": "ECD69D409A352515CC15B45",
        "vmw_pvrdma": "F0092285123462CEC485ECB",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.18.1.0",
        "vmxnet3": "1.6.0.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.3.0",
        "xorg server": "1.20.3"
    }
```