### PR TITLE
Remove xorriso from requirement.txt and add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ $ pip install -r requirements.txt
 ```
 $ ansible-galaxy install -r requirements.yml
 ```
-4. Log in to local control machine as root or a user in sudoers
+4. To test VMware Photon OS, Debian, and Ubuntu with ISO installation, it is also required to install `xorriso` package on your control machine.
+5. Log in to local control machine as root or a user in sudoers
 
 ### Steps to Launch Testing
 1. Git clone project from github to your workspace on control machine,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ netaddr
 pywinrm
 pypsrp
 pyvmomi
-xorriso
 ansible-core


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
`xorriso` is not a python package but linux tool, so remove it from requirements.txt