### PR TITLE
Execute test_case_support_status.yml in test_setup when it exists

### DIFF
--- a/windows/check_efi_firmware/check_efi_firmware.yml
+++ b/windows/check_efi_firmware/check_efi_firmware.yml
@@ -14,16 +14,6 @@
   tasks:
     - block:
         - include_tasks: ../setup/test_setup.yml
-        - name: Check VM configured firmware type
-          include_tasks: ../../common/vm_get_config.yml
-          vars:
-            property_list: ['config.firmware']
-
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case '{{ ansible_play_name }}', VM firmware is not EFI: {{ vm_config.config.firmware }}"
-            skip_reason: "Not Applicable"
-          when: vm_config.config.firmware == "bios"
 
         - name: Set searching keyword in vmware.log
           set_fact:

--- a/windows/check_efi_firmware/test_case_support_status.yml
+++ b/windows/check_efi_firmware/test_case_support_status.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Check VM configured firmware type
+- include_tasks: ../../common/vm_get_config.yml
+  vars:
+    property_list: ['config.firmware']
+
+- include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: "Skip test case '{{ ansible_play_name }}', VM firmware is not EFI: {{ vm_config.config.firmware }}"
+    skip_reason: "Not Applicable"
+  when: vm_config.config.firmware == "bios"

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -9,7 +9,7 @@
   set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
     current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
-    current_testcase_path: "{{ main_playbook_path }}/Windows/{{ ansible_play_name }}"
+    current_testcase_path: "{{ main_playbook_path }}/windows/{{ ansible_play_name }}"
 
 - include_tasks: base_snapshot_check_revert.yml
 

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -9,12 +9,7 @@
   set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
     current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
-
-# Prepare router VM, vSwitch and portgroup
-- include_tasks: ../../common/network_testbed_setup.yml
-  when:
-    - deploy_router_vm is defined and deploy_router_vm | bool
-    - router_vm_deployed is undefined or not router_vm_deployed | bool
+    current_testcase_path: "{{ main_playbook_path }}/Windows/{{ ansible_play_name }}"
 
 - include_tasks: base_snapshot_check_revert.yml
 
@@ -25,10 +20,6 @@
 - include_tasks: ../utils/add_windows_host.yml
 - name: "Print VM guest IP address"
   debug: var=vm_guest_ip
-
-# Pause Windows Update
-- include_tasks: ../utils/win_pause_windows_update.yml
-  when: not base_snapshot_exists
 
 # Get VMware tools status and version
 - include_tasks: ../../common/vm_get_vmtools_status.yml
@@ -49,10 +40,6 @@
     - vmtools_is_running | bool
     - guestinfo_gathered is undefined or not guestinfo_gathered
 
-# Take base snapshot if not exist
-- include_tasks: create_base_snapshot.yml
-  when: not base_snapshot_exists
-
 # Skip test case run when VMware tools is required but not installed or not running
 - include_tasks: ../../common/skip_test_case.yml
   vars:
@@ -62,3 +49,24 @@
     - skip_test_no_vmtools is defined
     - skip_test_no_vmtools
     - not (vmtools_is_running is defined and vmtools_is_running | bool)
+
+# Check if test_case_support_status.yml file in test case folder
+- name: "Check if test_case_support_status.yml file exists"
+  stat:
+    path: "{{ current_testcase_path }}/test_case_support_status.yml"
+  register: tc_support_status_result
+- include_tasks: "{{ current_testcase_path }}/test_case_support_status.yml"
+  when:
+    - tc_support_status_result.stat is defined
+    - tc_support_status_result.stat.exists is defined
+    - tc_support_status_result.stat.exists
+
+# Take base snapshot if not exist
+- include_tasks: create_base_snapshot.yml
+  when: not base_snapshot_exists
+
+# Prepare router VM, vSwitch and portgroup
+- include_tasks: ../../common/network_testbed_setup.yml
+  when:
+    - deploy_router_vm is defined and deploy_router_vm | bool
+    - router_vm_deployed is undefined or not router_vm_deployed | bool

--- a/windows/setup/win_guest_reconfig.yml
+++ b/windows/setup/win_guest_reconfig.yml
@@ -1,6 +1,9 @@
 # Copyright 2021-2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+# Pause Windows Update
+- include_tasks: ../utils/win_pause_windows_update.yml
+
 # Disable sleep
 - include_tasks: ../utils/win_set_powercfg.yml
 


### PR DESCRIPTION
Fixes #288 
test_setup does below things:

1. check if base snapshot exists, if exists, revert to it.
2. get VM IP, get VM info, guest info, VMware tools info.
3. check VMware tools status if required.
4. check test case support status if test_case_support_status.yml exists in test case folder.

if 3 and 4 are all passed, 
5. take base snapshot if it does not exist.
6. network testbed setup if required.