### PR TITLE
Check Windows VM VBS enablement status only on 64bit VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This project supports below scenarios for end-to-end guest OS validation testing
 
 | Guest OS types/versions                         | Automatic install from ISO image | Deploy from ova template | Existing VM and installed guest OS |
 | :---------------------------------------------- | :------------------------------: | :----------------------: | :--------------------------------: |
-| Red Hat Enterprise Linux 7.x, 8.x          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Red Hat Enterprise Linux 7.x, 8.x, 9.0          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Oracle Linux 7.x, 8.x                           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
@@ -89,10 +89,10 @@ This project supports below scenarios for end-to-end guest OS validation testing
 Note: This supported guest OS list is used for this project only. For guest OS support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).
 
 ### Docker images
-* Latest (Release v1.3):
+* Latest (Release v2.0):
   * projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:latest
-* Release v1.3:
-  * projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v1.3
+* Release v2.0:
+  * projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.0
 
 Launch testing using Docker image
 1. Execute below commands in your machine

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -39,7 +39,7 @@ releases:
       - Fix remove PackageKit package from SLED issue.
       - Fix snapshot is not quiesced snapshot issue for Windows in test case check_quiesce_snapshot.
       - Fix to use source IP address to ping target in Windows guest.
-      - Fix ping target result is success when host unreachable issue for Windows.
+      - Fix Windows issue of ping target is unreachable but the ping result is success.
       - Fix testing exit when VM unreachable in specific task issue for Ubuntu.
       new_testcases:
       - windows/check_inbox_driver/check_inbox_driver.yml  
@@ -47,7 +47,15 @@ releases:
       path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.0
       Ansible: ansible-core 2.13.0
       Python: 3.10.0
-      community.vmware: 2.4.0
+      Ansible collections:
+      - ansible.netcommon: 3.0.0
+      - ansible.posix: 1.4.0
+      - ansible.utils: 2.6.1
+      - ansible.windows: 1.10.0
+      - community.crypto: 2.3.1
+      - community.general: 5.0.0
+      - community.vmware: 2.4.0
+      - community.windows: 1.10.0
     release_date: '2022-05-27'
   1.3:
     changes:

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -1,5 +1,54 @@
 ancestor: null
 releases:
+  2.0:
+    changes:
+      major_changes:
+      - Refine test case result types defination and add 2 new types "Not Supported" and "Not Applicable".
+      - Add a new parameter 'esxi_shell' in vars/test.yml and default is '/bin/sh' for adding ESXi host to inventory.
+      - Add a naw parameter 'virtual_tpm' in vars/test.yml for creating new VM with a virtual TPM device.
+      - Move network_testbed_setup tasks to the test case playbook when it's required.
+      - Change to use SATA controller by default for VM CDROM devices.
+      minor_changes:
+      - Add support Debian 10.x and 11.x guest OS auto install.
+      - Add common tasks 'esxi_get_hardware_versions.yml', 'esxi_get_guest_ids.yml' and 'esxi_get_guest_config_options.yml' to get VM hardware version and guest config options.
+      - If the OVT installed is not from Photon OS's repository, skip to run perl GOSC testing on it.
+      - Add OS fullname for AlmaLinux and Rocky Linux in check_os_fullname test case.
+      - Add a workaround for supporting create new VM with IDE boot disk controller.
+      - Change to use common task 'esxi_upload_datastore_file.yml' to avoid using delegate to ESXi host.
+      - Add 'gosc_support_matrix.yml' file to filter supported vCenter version for guest OS.
+      - Change to use connection plugin psrp as the default connection method for Windows VM.
+      - Change to exit testing when ovt_verify_install test case failed for Linux testing.
+      - Add checking image approved keyword in vmware.log after VM deploy when secure boot is enabled.
+      - Move check WinBSOD in vmware.log for Windows after guest OS is unreachable.
+      - Add collect VM vmware.log when test case failed.
+      - Add check reported guestID in guest info in Linux and Windows test case check_os_fullname.
+      - Add gather vmw_pvrdma and ptp_vmw driver info in Linux test case check_inbox_driver.
+      - Remove xorriso package from requirement.txt and add it to README.
+      - Remove ignored failed loop task from failed_tasks.log.
+      - Add ignore_unreachable to true in Windows task which is delegate to guest OS.
+      bugfixes:
+      - Fix VM IP address change causing test case memory_hot_add_basic failure issue.
+      - Fix CentOS online repository URL changing issue.
+      - Fix serial port not removed issue after Ubuntu ova deployment.
+      - Fix template openwrt_19.07.2_x86.ova deployment issue on vSphere 6.5.
+      - Fix check_os_fullname test case failure for Windows 11 VM and add ignore known issue.
+      - Fix failure caused by Flatcar distribution name change.
+      - Fix failed to install sg3-utils package in Debian issue.
+      - Ignore known issue for Windows Server 2022 in test case check_quiesce_snapshot.
+      - Fix mounting VMware tools iso failure issue for existing Windows VM with SATA CDROM.
+      - Fix remove PackageKit package from SLED issue.
+      - Fix snapshot is not quiesced snapshot issue for Windows in test case check_quiesce_snapshot.
+      - Fix to use source IP address to ping target in Windows guest.
+      - Fix ping target result is success when host unreachable issue for Windows.
+      - Fix testing exit when VM unreachable in specific task issue for Ubuntu.
+      new_testcases:
+      - windows/check_inbox_driver/check_inbox_driver.yml  
+    docker_image:
+      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.0
+      Ansible: ansible-core 2.13.0
+      Python: 3.10.0
+      community.vmware: 2.4.0
+    release_date: '2022-05-27'
   1.3:
     changes:
       bugfixes:

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -3,23 +3,23 @@ releases:
   2.0:
     changes:
       major_changes:
-      - Refine test case result types defination and add 2 new types "Not Supported" and "Not Applicable".
+      - Refine test case result types defination and add 3 new types "Not Supported", "Not Applicable" and "Blocked".
       - Add a new parameter 'esxi_shell' in vars/test.yml and default is '/bin/sh' for adding ESXi host to inventory.
-      - Add a naw parameter 'virtual_tpm' in vars/test.yml for creating new VM with a virtual TPM device.
+      - Add a new parameter 'virtual_tpm' in vars/test.yml for creating new VM with a virtual TPM device.
       - Move network_testbed_setup tasks to the test case playbook when it's required.
       - Change to use SATA controller by default for VM CDROM devices.
       minor_changes:
       - Add support Debian 10.x and 11.x guest OS auto install.
-      - Add common tasks 'esxi_get_hardware_versions.yml', 'esxi_get_guest_ids.yml' and 'esxi_get_guest_config_options.yml' to get VM hardware version and guest config options.
+      - Add new common tasks to get ESXi supported VM hardware versions, guest IDs and guest config options.
       - If the OVT installed is not from Photon OS's repository, skip to run perl GOSC testing on it.
       - Add OS fullname for AlmaLinux and Rocky Linux in check_os_fullname test case.
       - Add a workaround for supporting create new VM with IDE boot disk controller.
       - Change to use common task 'esxi_upload_datastore_file.yml' to avoid using delegate to ESXi host.
-      - Add 'gosc_support_matrix.yml' file to filter supported vCenter version for guest OS.
+      - Add 'gosc_support_matrix.yml' file to filter supported vCenter version or VMware tools version for guest OS.
       - Change to use connection plugin psrp as the default connection method for Windows VM.
       - Change to exit testing when ovt_verify_install test case failed for Linux testing.
       - Add checking image approved keyword in vmware.log after VM deploy when secure boot is enabled.
-      - Move check WinBSOD in vmware.log for Windows after guest OS is unreachable.
+      - Check WinBSOD keyword in vmware.log for Windows when guest OS is unreachable.
       - Add collect VM vmware.log when test case failed.
       - Add check reported guestID in guest info in Linux and Windows test case check_os_fullname.
       - Add gather vmw_pvrdma and ptp_vmw driver info in Linux test case check_inbox_driver.

--- a/common/vm_get_vbs_status.yml
+++ b/common/vm_get_vbs_status.yml
@@ -7,6 +7,6 @@
     property_list: ['config.flags.vbsEnabled']
 - name: Set fact of VM VBS enablement status
   set_fact:
-    vm_vbs_enanled: "{{ vm_config.config.flags.vbsEnabled if vm_config.config.flags.vbsEnabled else False }}"
+    vm_vbs_enabled: "{{ vm_config.config.flags.vbsEnabled if vm_config.config.flags.vbsEnabled else False }}"
 - debug:
-    msg: "VM VBS is enabled: {{ vm_vbs_enanled }}"
+    msg: "VM VBS is enabled: {{ vm_vbs_enabled }}"

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -16,15 +16,16 @@
   tasks:
     - block:
         - include_tasks: ../setup/test_setup.yml
-        
-        # Refer to KB article https://kb.vmware.com/s/article/52584
-        - include_tasks: ../../common/vm_get_vbs_status.yml
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case due to CPU hotadd not supported for VM with VBS enabled."
-            skip_reason: "Not Supported"
-          when:
-            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
+ 
+        - block:
+            # Refer to KB article https://kb.vmware.com/s/article/52584
+            - include_tasks: ../../common/vm_get_vbs_status.yml
+            - include_tasks: ../../common/skip_test_case.yml
+              vars:
+                skip_msg: "Skip test case due to CPU hotadd not supported for VM with VBS enabled."
+                skip_reason: "Not Supported"
+              when: vm_vbs_enabled is defined and vm_vbs_enabled | bool
+          when: guest_os_ansible_architecture == "64-bit"
 
         - name: Set fact of the initial CPU number and cores per socket
           set_fact:

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,16 +14,17 @@
   tasks:
     - block:
         - include_tasks: ../setup/test_setup.yml
-        
-        # Refer to KB article https://kb.vmware.com/s/article/52584
-        - include_tasks: ../../common/vm_get_vbs_status.yml
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
-            skip_reason: "Not Supported"
-          when:
-            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
-        
+ 
+        - block: 
+            # Refer to KB article https://kb.vmware.com/s/article/52584
+            - include_tasks: ../../common/vm_get_vbs_status.yml
+            - include_tasks: ../../common/skip_test_case.yml
+              vars:
+                skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
+                skip_reason: "Not Supported"
+              when: vm_vbs_enabled is defined and vm_vbs_enabled | bool
+          when: guest_os_ansible_architecture == "64-bit"
+
         - name: "Set fact of initial memory size 2048MB for 32bit client"
           set_fact:
             vm_initial_mem_mb: 2048
@@ -34,7 +35,15 @@
           set_fact:
             vm_initial_mem_mb: 4096
           when: guest_os_ansible_architecture == "64-bit"
+       
+        # Memory limit for 32bit Windows is 4GB:
+        # https://docs.microsoft.com/en-us/windows/win32/memory/memory-limits-for-windows-releases
+        - name: Set fact of memory hotadd list for 32bit Windows
+          set_fact:
+            memory_hotadd_size_list: [1024, 1024]
+          when: guest_os_ansible_architecture == "32-bit"
         - include_tasks: ../../linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
+          when: guest_os_ansible_architecture == "64-bit"
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -25,14 +25,17 @@
           when: vmtools_esxi_bundled is undefined
 
         # If VBS is enabled, will not install under development tools due to secureboot is enabled
-        - include_tasks: ../../common/vm_get_vbs_status.yml
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case due to under development VMware tools can not test on VM with VBS enabled."
-            skip_reason: "Not Applicable"
-          when:
-            - vm_vbs_enanled is defined and vm_vbs_enanled | bool
-            - is_development_tools is defined and is_development_tools | bool
+        - block:
+            - include_tasks: ../../common/vm_get_vbs_status.yml
+            - include_tasks: ../../common/skip_test_case.yml
+              vars:
+                skip_msg: "Skip test case due to under development VMware tools can not test on VM with VBS enabled."
+                skip_reason: "Not Applicable"
+              when:
+                - vm_vbs_enabled is defined and vm_vbs_enabled | bool
+                - is_development_tools is defined and is_development_tools | bool
+          when: guest_os_ansible_architecture == "64-bit"
+
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"


### PR DESCRIPTION
1. add changelogs for v2.0 release.
2. change to only check Windows VBS status for 64bit VM.
3. memory limit for 32bit Windows OS is 4GB, so change to set a static memory hotadd size list for 32bit Windows VM. 