### PR TITLE
Fix list union issue

### DIFF
--- a/linux/device_list/vm_get_devices_with_label.yml
+++ b/linux/device_list/vm_get_devices_with_label.yml
@@ -25,7 +25,7 @@
 
     - name: "Search all devices with label {{ device_label }}"
       set_fact:
-        vm_devices_with_label: "{{ vm_devices_with_label }} + [{{ item }}]"
+        vm_devices_with_label: "{{ vm_devices_with_label + [item] }}"
       with_items: "{{ vm_config.config.hardware.device }}"
       when: "device_label in item.deviceInfo.label"
 


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Fix the list union issue:
```
2022-05-23 15:13:56,023 | Failed at Play [device_list] *******************************

2022-05-23 15:13:56,023 | TASK [Check device has correct status reported] ************
task path: /home/worker/workspace/Ansible_Regression_AlmaLinux_8.x/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml:80
fatal: [localhost]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'str object' has no attribute 'connectable'\n\nThe error appears to be in '/home/worker/workspace/Ansible_Regression_AlmaLinux_8.x/ansible-vsphere-gos-validation/linux/device_list/device_connection_validate.yml': line 80, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Check device has correct status reported\n  ^ here\n"
}
```