### PR TITLE
[Windows] Change to use pvscsi driver in VMware tools 11.3.5

### DIFF
--- a/windows/deploy_vm/get_pvscsi_driver.yml
+++ b/windows/deploy_vm/get_pvscsi_driver.yml
@@ -4,36 +4,47 @@
 # This task is used for getting VMware PVSCSI driver from the
 # downloaded VMware tools installation package from this path:
 # https://packages.vmware.com/tools/releases/latest/windows
+# Notes:
+# 2022-05-26, change to use VMware tools 11.3.5 due to there are
+# some changes from VMware tools 12.0.0 for pvscsi driver.
 #
 - name: Set fact of the guest OS bitness
   set_fact:
     win_vmtools_bit: "{{ 'amd64' if guest_id is search('64') else 'i386' }}"
-- name: Set fact of the latest VMware tools download URL
-  set_fact:
-    win_vmtools_url: "https://packages.vmware.com/tools/releases/latest/windows"
-- name: Get VMware tools ISO file URL for Windows
-  get_url:
-    url: "{{ win_vmtools_url }}"
-    dest: "{{ local_cache }}/windows_iso_page"
-    validate_certs: False
-    use_proxy: "{{ use_localhost_proxy | default(False) }}"
-  environment:
-    HTTPS_PROXY: "{{ http_proxy_localhost | default(omit) }}"
 
-- name: Get VMware tools ISO file name
-  command: "cat {{ local_cache }}/windows_iso_page"
-  register: get_vmtools_iso_file_result
-- name: Set fact of the full path of VMware tools ISO URL
+# - name: Set fact of the latest VMware tools download URL
+#   set_fact:
+#     win_vmtools_url: "https://packages.vmware.com/tools/releases/latest/windows"
+# - name: Get VMware tools ISO file URL for Windows
+#   get_url:
+#     url: "{{ win_vmtools_url }}"
+#     dest: "{{ local_cache }}/windows_iso_page"
+#     validate_certs: False
+#     use_proxy: "{{ use_localhost_proxy | default(False) }}"
+#   environment:
+#     HTTPS_PROXY: "{{ http_proxy_localhost | default(omit) }}"
+
+# - name: Get VMware tools ISO file name
+#   command: "cat {{ local_cache }}/windows_iso_page"
+#   register: get_vmtools_iso_file_result
+# - name: Set fact of the full path of VMware tools ISO URL
+#   set_fact:
+#     win_vmtools_iso: "{{ ((get_vmtools_iso_file_result.stdout | regex_findall('<A HREF=.*.iso'))[0].split('/')[1]) }}"
+
+- name: Set fact of the VMware tools download URL
   set_fact:
-    win_vmtools_iso: "{{ ((get_vmtools_iso_file_result.stdout | regex_findall('<A HREF=.*.iso'))[0].split('/')[1]) }}"
+    download_vmtools_url: "https://packages.vmware.com/tools/releases/11.3.5/windows/VMware-tools-windows-11.3.5-18557794.iso"
+- name: Set fact of the VMware tools ISO file name
+  set_fact:
+    win_vmtools_iso: "{{ download_vmtools_url.split('/')[-1] }}"
 - debug:
-    msg: "Will download VMware tools install ISO file from: {{ win_vmtools_url }}/{{ win_vmtools_iso }}, for '{{ win_vmtools_bit }}' guest"
+    msg: "Will download VMware tools install ISO file from: {{ download_vmtools_url }}, for '{{ win_vmtools_bit }}' guest OS"
 - name: Set fact of VMware tools ISO file path
   set_fact:
     download_vmtools_iso_path: "{{ local_cache }}/{{ win_vmtools_iso }}"
 - name: Download latest VMware tools ISO to local
   get_url:
-    url: "{{ win_vmtools_url }}/{{ win_vmtools_iso }}"
+    url: "{{ download_vmtools_url }}"
     dest: "{{ download_vmtools_iso_path }}"
     validate_certs: False
     use_proxy: "{{ use_localhost_proxy | default(False) }}"


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Start from VMware tools 12.0.0, there is new folder in VMware tools ISO package 'win10' for Windows 11 and Windows Server 2022. So here change to use pvscsi driver in VMware tools 11.3.5 'win8' folder for under testing guest OS to do installation on PVSCSI boot disk as a workaround.