### PR TITLE
Workaround for rescan deleted LSILogic disk in Flatcar and Ubuntu 22.04

### DIFF
--- a/linux/deploy_vm/ubuntu/reconfigure_ubuntu_ova_vm.yml
+++ b/linux/deploy_vm/ubuntu/reconfigure_ubuntu_ova_vm.yml
@@ -76,6 +76,11 @@
 - include_tasks: ../utils/shutdown.yml
 
 - include_tasks: ../../common/vm_remove_serial_port.yml
+  when:
+    - vm_hardware_version_num is defined
+    - vm_hardware_version_num | int > 10
+    - vm_serial_port_file_path is defined
+    - vm_serial_port_file_path
 
 - fail:
     msg: "Failed to remove serial port from VM"

--- a/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
+++ b/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
@@ -18,12 +18,13 @@
 
 - include_tasks: wait_device_list_changed.yml
   vars:
-    wait_device_list: "{{ old_device_list }}"
-    wait_device_diff: 1
+    device_list_before_change: "{{ old_device_list }}"
+    wait_device_state: "present"
 
-- name: "Set fact of new device list"
+- name: "Set fact of new device list and new device name"
   set_fact:
     new_device_list: "{{ device_list_after_change }}"
+    new_device_name: "{{ device_list_after_change | difference(old_device_list) }}"
 
 # Create new partition for new disk
 - include_tasks: prepare_new_disk.yml
@@ -38,5 +39,6 @@
 
 - include_tasks: wait_device_list_changed.yml
   vars:
-    wait_device_list: "{{ new_device_list }}"
-    wait_device_diff: -1
+    device_list_before_change: "{{ new_device_list }}"
+    wait_device_name: "{{ new_device_name }}"
+    wait_device_state: "absent"

--- a/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
+++ b/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
@@ -24,7 +24,7 @@
 - name: "Set fact of new device list and new device name"
   set_fact:
     new_device_list: "{{ device_list_after_change }}"
-    new_device_name: "{{ device_list_after_change | difference(old_device_list) }}"
+    new_device_name: "{{ (device_list_after_change | difference(old_device_list))[0] }}"
 
 # Create new partition for new disk
 - include_tasks: prepare_new_disk.yml

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -53,16 +53,25 @@
         - block:
             - include_tasks: ../../common/get_system_info.yml
 
-            - name: "Delete the removed SCSI disk"
+            - name: "Set fact of removed disk {{ wait_device_name }}"
+              set_fact:
+                guest_ansible_device: >
+                  {{  
+                    guest_system_info.ansible_devices | 
+                    dict2items |
+                    selectattr('key', 'equalto', wait_device_name) |
+                    items2dict
+                  }}  
+
+            - name: "Delete the removed SCSI disk {{ wait_device_name }}"
               shell: "echo 1 > /sys/block/{{ wait_device_name }}/device/delete"
               ignore_errors: True
               delegate_to: "{{ vm_guest_ip }}"
               when:
-                - guest_system_info is defined
-                - guest_system_info.ansible_devices is defined
-                - guest_system_info.ansible_devices[wait_device_name] is defined
-                - guest_system_info.ansible_devices[wait_device_name].size is defined
-                - guest_system_info.ansible_devices[wait_device_name].size == "0.00 Bytes"
+                - guest_ansible_device is defined
+                - guest_ansible_device[wait_device_name] is defined
+                - guest_ansible_device[wait_device_name].size is defined
+                - guest_ansible_device[wait_device_name].size == "0.00 Bytes"
           when: wait_device_state | lower == 'absent'
       when: >
         ('Flatcar' in guest_os_ansible_distribution or

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -3,9 +3,22 @@
 ---
 # Wait for a device state is present or absent
 # Parameters:
-#   wait_device_list: The devices list
-#   wait_device_diff: The difference length of device list, like  1 or -1.
+#   device_list_before_change: The devices list before change
+#   wait_device_state: 'present' for new added device
+#                      'absent' for removed device
+#   wait_device_name: The devices name which should be absent.
+#                     Required when wait_device_state is absent.
 #
+- name: "Check wait_device_state is correct"
+  assert:
+    that:
+      - wait_device_state is defined
+      - wait_device_state | lower in ['present', 'absent']
+    fail_msg: "Invalid wait_device_state value '{{ wait_device_state }}', the expected value is 'present' or 'absent'"
+
+- name: "Initialize the difference length of device list with device present or absent"
+  set_fact:
+    wait_device_diff: "{% if wait_device_state | lower == 'present' %}1{% else %}-1{% endif %}"
 
 # Rescan SCSI bus
 - block:
@@ -28,6 +41,24 @@
             for i in `find /sys/ -iname rescan`;do echo 1 >$i; done;
             for i in `find /sys/ -iname scan`;do echo "- - -" >$i; done;
           delegate_to: "{{ vm_guest_ip }}"
+
+        - block:
+            - include_tasks: ../../common/get_system_info.yml
+              vars:
+                filter: ["ansible_devices"]
+
+            - name: "Delete the removed SCSI disk"
+              shell: "echo 1 > /sys/block/{{ wait_device_name }}/device/delete"
+              ignore_errors: True
+              delegate_to: "{{ vm_guest_ip }}"
+              when:
+                - get_system_info_result is defined
+                - get_system_info_result.ansible_facts is defined
+                - get_system_info_result.ansible_facts.ansible_devices is defined
+                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name] is defined
+                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name].size is defined
+                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name].size == "0.00 Bytes"
+          when: wait_device_state | lower == 'absent'
       when: "'Flatcar' in guest_os_ansible_distribution"
   when: new_disk_ctrl_type == 'lsilogic'
 
@@ -77,15 +108,16 @@
   set_fact:
     device_list_after_change: []
 
-- name: "Wait for new device to be {% if wait_device_diff == 1 %}present{% else %}absent{% endif %}"
+- name: "Wait for device to be {{ wait_device_state | lower }}"
   shell: "lsblk -o NAME,TYPE --nodeps| grep disk | awk '{print $1}'"
   delegate_to: "{{ vm_guest_ip }}"
   register: lsblk_result
   until:
     - lsblk_result.stdout_lines is defined
-    - (lsblk_result.stdout_lines | length) - (wait_device_list | length) == wait_device_diff
+    - (lsblk_result.stdout_lines | length) - (device_list_before_change | length) == (wait_device_diff | int)
   delay: 5
   retries: 10
+  ignore_errors: True
   ignore_unreachable: True
 
 - name: "Guest OS unreachable"
@@ -95,6 +127,22 @@
     - lsblk_result is defined
     - lsblk_result.unreachable is defined
     - lsblk_result.unreachable
+
+# Check device list changed
+- block:
+    - name: "Check new device to be present"
+      fail:
+        msg: "New device is not recognized in guest OS."
+      when: wait_device_state | lower == 'present'
+
+    - name: "Check {{ wait_device_name }} to be absent"
+      fail:
+        msg: "{{ wait_device_name }} has been removed but still can be detected by guest OS."
+      when: wait_device_state | lower == 'absent'
+  when: >
+    (lsblk_result is undefined or
+     lsblk_result.stdout_lines is undefined or
+     (lsblk_result.stdout_lines | length) - (device_list_before_change | length) != (wait_device_diff | int))
 
 - name: "Set fact of new device list after change"
   set_fact:

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -14,7 +14,7 @@
     that:
       - wait_device_state is defined
       - wait_device_state | lower in ['present', 'absent']
-    fail_msg: "Invalid wait_device_state value '{{ wait_device_state }}', the expected value is 'present' or 'absent'"
+    fail_msg: "Invalid wait_device_state value '{{ wait_device_state | default('undefined') }}', the expected value is 'present' or 'absent'"
 
 - name: "Check wait_device_name is set for absent device"
   assert:
@@ -24,11 +24,11 @@
     fail_msg: "wait_device_name is missing for waiting device absent"
   when: wait_device_state | lower == 'absent'
 
-- name: "Initialize the difference length of device list with device present or absent"
+- name: "Initialize the difference length of device list with device {{ wait_device_state | lower }}"
   set_fact:
     wait_device_diff: "{% if wait_device_state | lower == 'present' %}1{% else %}-1{% endif %}"
 
-# Rescan SCSI bus
+# Rescan SCSI bus when hot adding/removing LSILogic disk
 - block:
     - block:
         - name: "Rescan all scsi devices"
@@ -41,7 +41,9 @@
           when:
             - rescan_scsi_result is defined
             - rescan_scsi_result.stdout_lines
-      when: "'Flatcar' not in guest_os_ansible_distribution"
+      when:
+        - "'Flatcar' not in guest_os_ansible_distribution"
+        - not (guest_os_ansible_distribution == "Ubuntu" and guest_os_ansible_distribution_ver == "22.04")
 
     - block:
         - name: "Rescan all hard disks"
@@ -63,7 +65,7 @@
                     items2dict
                   }}  
 
-            - name: "Delete the removed SCSI disk {{ wait_device_name }}"
+            - name: "Rescan the deleted SCSI disk '{{ wait_device_name }}'"
               shell: "echo 1 > /sys/block/{{ wait_device_name }}/device/delete"
               ignore_errors: True
               delegate_to: "{{ vm_guest_ip }}"
@@ -154,7 +156,7 @@
 
     - name: "Check {{ wait_device_name }} to be absent"
       fail:
-        msg: "{{ wait_device_name }} has been removed but still can be detected by guest OS."
+        msg: "Disk '{{ wait_device_name }}' has been removed but still can be detected by guest OS."
       when: wait_device_state | lower == 'absent'
   when: >
     (lsblk_result is undefined or

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -16,6 +16,14 @@
       - wait_device_state | lower in ['present', 'absent']
     fail_msg: "Invalid wait_device_state value '{{ wait_device_state }}', the expected value is 'present' or 'absent'"
 
+- name: "Check wait_device_name is set for absent device"
+  assert:
+    that:
+      - wait_device_name is defined
+      - wait_device_name 
+    fail_msg: "wait_device_name is missing for waiting device absent"
+  when: wait_device_state | lower == 'absent'
+
 - name: "Initialize the difference length of device list with device present or absent"
   set_fact:
     wait_device_diff: "{% if wait_device_state | lower == 'present' %}1{% else %}-1{% endif %}"
@@ -44,22 +52,22 @@
 
         - block:
             - include_tasks: ../../common/get_system_info.yml
-              vars:
-                filter: ["ansible_devices"]
 
             - name: "Delete the removed SCSI disk"
               shell: "echo 1 > /sys/block/{{ wait_device_name }}/device/delete"
               ignore_errors: True
               delegate_to: "{{ vm_guest_ip }}"
               when:
-                - get_system_info_result is defined
-                - get_system_info_result.ansible_facts is defined
-                - get_system_info_result.ansible_facts.ansible_devices is defined
-                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name] is defined
-                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name].size is defined
-                - get_system_info_result.ansible_facts.ansible_devices[wait_device_name].size == "0.00 Bytes"
+                - guest_system_info is defined
+                - guest_system_info.ansible_devices is defined
+                - guest_system_info.ansible_devices[wait_device_name] is defined
+                - guest_system_info.ansible_devices[wait_device_name].size is defined
+                - guest_system_info.ansible_devices[wait_device_name].size == "0.00 Bytes"
           when: wait_device_state | lower == 'absent'
-      when: "'Flatcar' in guest_os_ansible_distribution"
+      when: >
+        ('Flatcar' in guest_os_ansible_distribution or
+         (guest_os_ansible_distribution == "Ubuntu" and
+          guest_os_ansible_distribution_ver == "22.04"))
   when: new_disk_ctrl_type == 'lsilogic'
 
 - block:


### PR DESCRIPTION
Fix #199 
In Flatcar 3033.2.0 and later versions, deleted LSILogic disk still can be shown in output of `lsblk`. 
In Ubuntu 22.04, rescan-scsi-bus.sh would remove all SCSI block devices, not only the removed LSILogic disk.

This workaround would check the deleted disk size and then mark it as deleted.

```
+-------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                  |
|                           | bitness='64'                                                        |
|                           | buildNumber='2022-05-27-1432'                                       |
|                           | distroName='Flatcar Container Linux by Kinvolk'                     |
|                           | distroVersion='3033.3.1'                                            |
|                           | familyName='Linux'                                                  |
|                           | kernelVersion='5.10.118-flatcar'                                    |
|                           | prettyName='Flatcar Container Linux by Kinvolk 3033.3.1 (LTS 2022)' |
+-------------------------------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 2, Elapsed Time: 00:40:47)
+-----------------------------------------------+
| Name                     | Status | Exec Time |
+-----------------------------------------------+
| deploy_flatcar_ova       | Passed | 00:04:00  |
| lsilogic_vhba_device_ops | Passed | 00:02:47  |
+-----------------------------------------------+
```

