### PR TITLE
[Windows] Fix ping target issue after network adapter disconnected

### DIFF
--- a/windows/utils/win_ping_target.yml
+++ b/windows/utils/win_ping_target.yml
@@ -45,7 +45,7 @@
         win_ping_target_result: False
       when: >
         (win_powershell_cmd_output.rc != 0) or
-        (win_powershell_cmd_output.stdout | regex_findall('unreachable') | length == 3)
+        (win_powershell_cmd_output.stdout | regex_findall('unreachable') | length >= 1)
   when:
     - win_powershell_cmd_output is defined
     - win_powershell_cmd_output.rc is defined


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>
Ping target result after network adapter disconnected, not all returned host unreachable.
```
TASK [Display the powershell commmand result] **********************************
task path: /home/worker/workspace/Ansible_Windows_11_70U1_SATA_E1000E_EFI/ansible-vsphere-gos-validation/windows/utils/win_execute_cmd.yml:47
ok: [localhost] => {
    "win_powershell_cmd_output": {
        "changed": true,
        "cmd": "ping -n 3 -S 192.168.192.142 192.168.192.1",
        "delta": "0:00:06.219994",
        "end": "2022-06-06 10:45:00.932719",
        "failed": false,
        "rc": 0,
        "start": "2022-06-06 10:44:54.712724",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "\r\nPinging 192.168.192.1 from 192.168.192.142 with 32 bytes of data:\r\nGeneral failure.\r\nGeneral failure.\r\nReply from 192.168.192.142: Destination host unreachable.\r\n\r\nPing statistics for 192.168.192.1:\r\n    Packets: Sent = 3, Received = 1, Lost = 2 (66% loss),\r\n",
        "stdout_lines": [
            "",
            "Pinging 192.168.192.1 from 192.168.192.142 with 32 bytes of data:",
            "General failure.",
            "General failure.",
            "Reply from 192.168.192.142: Destination host unreachable.",
            "",
            "Ping statistics for 192.168.192.1:",
            "    Packets: Sent = 3, Received = 1, Lost = 2 (66% loss),"
        ]
    }
}
```