### PR TITLE
Answer question about serial port output file existence at VM powerr-on

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -34,6 +34,7 @@
 * vm_remove_serial_port.yml: Remove a serial port from VM
 * vm_add_remove_vtpm.yml: Add or remove vTPM device from VM
 * vm_add_vtpm_device.yml: Add key provider on vCenter then add new vTPM device to VM
+* vm_answer_question.yml: Answer question at VM power on
   
 ### Tasks for VM CPU or Memory settings
 * vm_enable_cpu_hotadd.yml: Enable VM CPU hotadd

--- a/common/vm_answer_question.yml
+++ b/common/vm_answer_question.yml
@@ -1,0 +1,38 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Answer question to unblock VM configurations
+# Parameters:
+#   vm_question: The guest question object
+#   vm_question_response: The response to the question. e.g. button.serial.file.overwrite
+#
+
+- block:
+    - debug:
+        msg:
+          - "VM has a question to answer:"
+          - "Question message id is: {{ vm_question.message[0].id }}"
+          - "Question message text is: {{ vm_question.message[0].text }}"
+          - "Response choices are: {{ vm_question.choice.choiceInfo | map(attribute='summary') }}"
+    
+    - name: "Answer VM question '{{ vm_question.message[0].id }}'"
+      vmware_guest_powerstate:
+        validate_certs: "{{ validate_certs | default(False) }}"
+        hostname: "{{ vsphere_host_name }}"
+        username: "{{ vsphere_host_user }}"
+        password: "{{ vsphere_host_user_password }}"
+        folder: "{{ vm_folder }}"
+        name: "{{ vm_name }}"
+        state: "powered-on"
+        state_change_timeout: 300
+        answer:
+          - question: "{{ vm_question.message[0].id }}"
+            response: "{{ vm_question_response }}"
+      register: vm_answer_question_result
+  when:
+    - vm_question is defined
+    - vm_question.message is defined
+    - vm_question.message | length > 0
+    - vm_question.choice is defined
+    - vm_question.choice.choiceInfo is defined 
+    - vm_question.choice.choiceInfo | length > 0

--- a/common/vm_set_power_state.yml
+++ b/common/vm_set_power_state.yml
@@ -72,7 +72,6 @@
       {% else %}Failed to set VM power state to {{ vm_power_state_set | lower }}{% endif %}
   when: >
     vm_change_power_state is undefined or
-    vm_change_power_state.instance is undefined or
     vm_change_power_state.failed is defined and vm_change_power_state.failed | bool
 
 - name: Display the result of changing VM power state

--- a/common/vm_set_power_state.yml
+++ b/common/vm_set_power_state.yml
@@ -42,6 +42,38 @@
     state: "{{ vm_power_state_set }}"
     state_change_timeout: 300
   register: vm_change_power_state
+  ignore_errors: True
+
+# Replace serial port output file at power on
+- block:
+    - include_tasks: vm_answer_question.yml
+      vars:
+        vm_question: "{{ vm_change_power_state.instance.guest_question }}"
+        vm_question_response: "button.serial.file.overwrite"
+
+    - name: "Set fact of the result of changing VM power state"
+      set_fact:
+        vm_change_power_state: "{{ vm_answer_question_result }}"
+      when:
+        - vm_answer_question_result is defined
+        - vm_answer_question_result
+  when:
+    - vm_power_state_set | lower == 'powered-on'
+    - vm_change_power_state is defined
+    - vm_change_power_state.instance is defined
+    - vm_change_power_state.instance.guest_question is defined
+    - vm_change_power_state.instance.guest_question.message is defined
+    - vm_change_power_state.instance.guest_question.message | length > 0
+    - vm_change_power_state.instance.guest_question.message[0].id == "msg.serial.file.open"
+
+- fail:
+    msg: >
+      {% if vm_change_power_state is defined and vm_change_power_state.msg is defined %}{{ vm_change_power_state.msg }}
+      {% else %}Failed to set VM power state to {{ vm_power_state_set | lower }}{% endif %}
+  when: >
+    vm_change_power_state is undefined or
+    vm_change_power_state.instance is undefined or
+    vm_change_power_state.failed is defined and vm_change_power_state.failed | bool
 
 - name: Display the result of changing VM power state
   debug: var=vm_change_power_state


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>

```
TASK [Set VM power state to 'powered-on'] *******************************************************************************
task path: ansible-vsphere-gos-validation/common/vm_set_power_state.yml:34
fatal: [localhost]: FAILED! => {
    "answer": null,
    "changed": true,
    "instance": {
        "advanced_settings": {
        ...
        },
        "annotation": "",
        "current_snapshot": null,
        "customvalues": {},
        "guest_consolidation_needed": false,
        "guest_question": {
            "_vimtype": "vim.vm.QuestionInfo",
            "choice": {
                "_vimtype": "vim.option.ChoiceOption",
                "choiceInfo": [
                    {
                        "_vimtype": "vim.ElementDescription",
                        "key": "0",
                        "label": "button.serial.file.append",
                        "summary": "Append"
                    },
                    {
                        "_vimtype": "vim.ElementDescription",
                        "key": "1",
                        "label": "button.serial.file.overwrite",
                        "summary": "Replace"
                    },
                    {
                        "_vimtype": "vim.ElementDescription",
                        "key": "2",
                        "label": "button.serial.file.cancel",
                        "summary": "Cancel"
                    }
                ],
                "defaultIndex": 0,
                "valueIsReadonly": null
            },
            "id": "1175004",
            "message": [
                {
                    "_vimtype": "vim.vm.Message",
                    "argument": [
                        "serial.log"
                    ],
                    "id": "msg.serial.file.open",
                    "text": "The serial port output file \"serial.log\" already exists. Do you want to replace it with new content or append new content to the end of the file?"
                }
            ],
            "text": "The serial port output file \"serial.log\" already exists. Do you want to replace it with new content or append new content to the end of the file?"
        },
        ...
    },
    "msg": "The serial port output file \"serial.log\" already exists. Do you want to replace it with new content or append new content to the end of the file?"
}
...ignoring
Read vars_file '../../vars/test.yml'

TASK [include_tasks] ****************************************************************************************************
task path: ansible-vsphere-gos-validation/common/vm_set_power_state.yml:49
Read vars_file '../../vars/test.yml'
redirecting (type: modules) ansible.builtin.vmware_guest_powerstate to community.vmware.vmware_guest_powerstate
included: ansible-vsphere-gos-validation/tests/unit_tests/../../common/vm_answer_question.yml for localhost
Read vars_file '../../vars/test.yml'
Read vars_file '../../vars/test.yml'

TASK [debug] ************************************************************************************************************
task path: ansible-vsphere-gos-validation/common/vm_answer_question.yml:11
ok: [localhost] => {
    "msg": [
        "VM has a question to answer:",
        "Question message id is: msg.serial.file.open",
        "Question message text is: The serial port output file \"serial.log\" already exists. Do you want to replace it with new content or append new content to the end of the file?",
        "Response choices are: ['Append', 'Replace', 'Cancel']"
    ]
}
Read vars_file '../../vars/test.yml'
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: qiz
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /tmp `"&& mkdir "` echo /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816 `" && echo ansible-tmp-1654782983.2379313-514753-272990477388816="` echo /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816 `" ) && sleep 0'
redirecting (type: modules) ansible.builtin.vmware_guest_powerstate to community.vmware.vmware_guest_powerstate
Using module file /home/qiz/.ansible/collections/ansible_collections/community/vmware/plugins/modules/vmware_guest_powerstate.py
<127.0.0.1> PUT /home/qiz/.ansible/tmp/ansible-local-51467997v7209u/tmpaud20275 TO /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816/AnsiballZ_vmware_guest_powerstate.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816/ /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816/AnsiballZ_vmware_guest_powerstate.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816/AnsiballZ_vmware_guest_powerstate.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /tmp/ansible-tmp-1654782983.2379313-514753-272990477388816/ > /dev/null 2>&1 && sleep 0'

TASK [Answer VM question 'msg.serial.file.open'] ************************************************************************
task path: ansible-vsphere-gos-validation/common/vm_answer_question.yml:18
changed: [localhost] => {
    "answer": [
        {
            "question": "msg.serial.file.open",
            "response": "button.serial.file.overwrite"
        }
    ],
    "changed": true,
    "instance": {
        "advanced_settings": {
        ....
        },
   ...
    },
    "invocation": {
        "module_args": {
            "answer": [
                {
                    "question": "msg.serial.file.open",
                    "response": "button.serial.file.overwrite"
                }
            ],
            ...
        }
    }
}
Read vars_file '../../vars/test.yml'
TASK [Set fact of the result of changing VM power state] ****************************************************************
task path: ansible-vsphere-gos-validation/common/vm_set_power_state.yml:54
ok: [localhost] => {
    "ansible_facts": {
        "vm_change_power_state": {
            "answer": [
                {
                    "question": "msg.serial.file.open",
                    "response": "button.serial.file.overwrite"
                }
            ],
            "changed": true,
            "failed": false,
            "instance": {
                ...
            }
        }
    },
    "changed": false
}
Read vars_file '../../vars/test.yml'
Read vars_file '../../vars/test.yml'

TASK [Display the result of changing VM power state] ********************************************************************
task path: ansible-vsphere-gos-validation/common/vm_set_power_state.yml:78
ok: [localhost] => {
    "vm_change_power_state": {
        "answer": [
            {
                "question": "msg.serial.file.open",
                "response": "button.serial.file.overwrite"
            }
        ],
        "changed": true,
        "failed": false,
        "instance": {
            ...
        }
    }
}
```