### PR TITLE
Fix: lossed file extension

### DIFF
--- a/linux/guest_customization/check_dns.yml
+++ b/linux/guest_customization/check_dns.yml
@@ -118,7 +118,7 @@
         - include_tasks: ../../common/vm_guest_file_operation.yml
           vars:
             operation: "fetch_file"
-            src_path: "/tmp/systemd_resolve_status"
+            src_path: "/tmp/systemd_resolve_status.txt"
             dest_path: "{{ current_test_log_folder }}/systemd_resolve_status.txt"
 
         - name: "Set fact of guest systemd resolve status"


### PR DESCRIPTION
The systemd-resolve output is stored in /tmp/systemd_resolve_status.txt on the guest machine but at next step playbook tries to download /tmp/systemd_resolve_status (without extension) to controller host. This issue makes impossible to pass GOS tests on Ubuntu hosts.