### PR TITLE
Fix Photon 3 OVA deploy failure and package installation failures

### DIFF
--- a/autoinstall/Photon/ks.cfg
+++ b/autoinstall/Photon/ks.cfg
@@ -7,7 +7,7 @@
     "disk": "/dev/{{ boot_disk_name }}",
     "packagelist_file": "packages_ova.json",
     "arch": "x86_64",
-    "additional_packages": ["vim","gawk","sudo"],
+    "additional_packages": ["vim","gawk","sudo","tar"],
     "install_linux_esx": true,
     "eject_cdrom": true,
     "postinstall": [
@@ -19,8 +19,8 @@
 {% endif %}
         "tdnf --disablerepo=photon-updates install -y sg3_utils tar",
         "sed -r -i 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
-        "sed -r -i 's/^#?DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf"
-        "sed -r -i 's/^#?DNSOverTLS=.*/DNSOverTLS=no/' /etc/systemd/resolved.conf"
+        "sed -r -i 's/^#?DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf",
+        "sed -r -i 's/^#?DNSOverTLS=.*/DNSOverTLS=no/' /etc/systemd/resolved.conf",
         "systemctl stop iptables",
         "systemctl disable iptables",
         "echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0"

--- a/autoinstall/Photon/ks.cfg
+++ b/autoinstall/Photon/ks.cfg
@@ -19,8 +19,6 @@
 {% endif %}
         "tdnf --disablerepo=photon-updates install -y sg3_utils tar",
         "sed -r -i 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
-        "sed -r -i 's/^#?DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf",
-        "sed -r -i 's/^#?DNSOverTLS=.*/DNSOverTLS=no/' /etc/systemd/resolved.conf",
         "systemctl stop iptables",
         "systemctl disable iptables",
         "echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0"

--- a/autoinstall/Photon/ks.cfg
+++ b/autoinstall/Photon/ks.cfg
@@ -19,6 +19,8 @@
 {% endif %}
         "tdnf --disablerepo=photon-updates install -y sg3_utils tar",
         "sed -r -i 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
+        "sed -r -i 's/^#?DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf"
+        "sed -r -i 's/^#?DNSOverTLS=.*/DNSOverTLS=no/' /etc/systemd/resolved.conf"
         "systemctl stop iptables",
         "systemctl disable iptables",
         "echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -217,6 +217,16 @@
       vars:
         vm_power_state_set: 'powered-on'
   rescue:
+    # Collect cloud-init logs for Ubuntu
+    - include_tasks: ../../common/vm_get_power_state.yml
+    - block:
+        - include_tasks: ../../common/vm_get_vmtools_status.yml
+        - include_tasks: ../utils/collect_cloudinit_logs.yml
+      when:
+        - vm_power_state_get is defined
+        - vm_power_state_get == "poweredOn"
+        - unattend_install_conf is match('Ubuntu')
+
     - include_tasks: ../../common/test_rescue.yml
       vars:
         exit_testing_when_fail: True

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -136,7 +136,12 @@
       when: nfs_mount_dir is defined and nfs_mount_dir
 
     # Collect cloud-init logs for deploying Ubuntu and Photon OVA
-    - include_tasks: ../utils/collect_cloudinit_logs.yml
+    - include_tasks: ../../common/vm_get_power_state.yml
+    - block:
+        - include_tasks: ../../common/vm_get_vmtools_status.yml
+        - include_tasks: ../utils/collect_cloudinit_logs.yml
       when:
+        - vm_power_state_get is defined
+        - vm_power_state_get == "poweredOn"
         - ova_guest_os_type is defined
         - ova_guest_os_type in ['photon', 'ubuntu']

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -134,3 +134,9 @@
             local_path: "{{ nfs_mount_dir }}"
             del_local_file_ignore_errors: True
       when: nfs_mount_dir is defined and nfs_mount_dir
+
+    # Collect cloud-init logs for deploying Ubuntu and Photon OVA
+    - include_tasks: ../utils/collect_cloudinit_logs.yml
+      when:
+        - ova_guest_os_type is defined
+        - ova_guest_os_type in ['photon', 'ubuntu']

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -28,11 +28,11 @@ users:
 
 # Workaround for root password setting when shadow version is 4.6-5 and earlier
 bootcmd:
-  - [ `printf $(rpm -q shadow | grep -E -o "[0-9]+(\.[0-9]+)+-[0-9]+")"\n4.6-6\n" | sort | head -n 1` != "4.6-6" ] && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
+  - shadow_version=$(rpm -q shadow | grep -E -o "[0-9]+(\.[0-9]+)+-[0-9]+"); [ $(printf "$shadow_version\n4.6-6\n" | sort | head -n 1) != "4.6-6" ] && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
 
 runcmd:
-  - [ `printf $(grep VERSION= /etc/os-release | grep -E -o "[0-9]+\.[0-9]+")"\n4.0\n" | sort | head -n 1 | cut -d '.' -f 1` -ge 4 ] && systemctl start sshd.socket
   - [systemctl, stop, iptables]
   - [systemctl, disable, iptables]
   - [systemctl, disable, chronyd]
   - [systemctl, disable, chrony-wait]
+  - os_version=$(grep VERSION= /etc/os-release | grep -E -o "[0-9]+\.[0-9]+"); [ $(printf "$os_version\n4.0\n" | sort | head -n 1 | cut -d '.' -f 1) -ge 4 ] && systemctl start sshd.socket

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -31,7 +31,6 @@ bootcmd:
   - /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
 
 runcmd:
-  - [systemctl, start, sshd.socket]
   - [systemctl, stop, iptables]
   - [systemctl, disable, iptables]
   - [systemctl, disable, chronyd]

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -7,7 +7,6 @@ packages:
   - sg3_utils
   - chrony
   - tar
-  - gawk
 
 ssh_pwauth: yes
 disable_root: false
@@ -32,6 +31,7 @@ bootcmd:
   - [ `printf $(rpm -q shadow | grep -E -o "[0-9]+(\.[0-9]+)+-[0-9]+")"\n4.6-6\n" | sort | head -n 1` != "4.6-6" ] && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
 
 runcmd:
+  - [ `printf $(grep VERSION= /etc/os-release | grep -E -o "[0-9]+\.[0-9]+")"\n4.0\n" | sort | head -n 1 | cut -d '.' -f 1` -ge 4 ] && systemctl start sshd.socket
   - [systemctl, stop, iptables]
   - [systemctl, disable, iptables]
   - [systemctl, disable, chronyd]

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -28,7 +28,7 @@ users:
 {% endif %}
 
 bootcmd:
-  - /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
+  - grep 'VERSION="3.0"' /etc/os-release && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
 
 runcmd:
   - [systemctl, stop, iptables]

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -27,8 +27,9 @@ users:
       - {{ ssh_public_key }}
 {% endif %}
 
+# Workaround for root password setting when shadow version is 4.6-5 and earlier
 bootcmd:
-  - grep 'VERSION="3.0"' /etc/os-release && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
+  - [ `printf $(rpm -q shadow | grep -E -o "[0-9]+(\.[0-9]+)+-[0-9]+")"\n4.6-6\n" | sort | head -n 1` != "4.6-6" ] && /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
 
 runcmd:
   - [systemctl, stop, iptables]

--- a/linux/deploy_vm/templates/photon-user-data.j2
+++ b/linux/deploy_vm/templates/photon-user-data.j2
@@ -27,6 +27,9 @@ users:
       - {{ ssh_public_key }}
 {% endif %}
 
+bootcmd:
+  - /bin/sed -E -i 's/^root:([^:]+):.*$/root:\1:17532:0:99999:0:::/' /etc/shadow
+
 runcmd:
   - [systemctl, start, sshd.socket]
   - [systemctl, stop, iptables]

--- a/linux/guest_customization/check_gosc_log.yml
+++ b/linux/guest_customization/check_gosc_log.yml
@@ -51,19 +51,7 @@
   when: gosc_workflow == "cloud-init"
 
 # Collect all cloud-init logs and userdata for cloud-init GOSC or Photon OS
-- block:
-    # Collect cloud-init logs
-    - include_tasks: ../../common/vm_shell_in_guest.yml
-      vars:
-        vm_shell_cmd: "/usr/bin/cloud-init"
-        vm_shell_args: "collect-logs -u -t /tmp/cloud-init.tar.gz"
-        vm_shell_out: ""
-
-    - include_tasks: ../../common/vm_guest_file_operation.yml
-      vars:
-        operation: "fetch_file"
-        src_path: "/tmp/cloud-init.tar.gz"
-        dest_path: "{{ current_test_log_folder }}/cloud-init.tar.gz"
+- include_tasks: ../utils/collect_cloudinit_logs.yml
   when: >
     (gosc_workflow == "cloud-init") or
     (guest_os_ansible_distribution == "VMware Photon OS")

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -18,6 +18,9 @@
         - (new_vm is undefined) or (not new_vm | bool)
         - vmtools_is_running
 
+    # Photon OS needs to disable DNSSEC and DNSOverTLS while connecting online repo
+    - include_tasks: ../utils/set_dns.yml
+
     # Update photon repo cache
     - include_tasks: ../utils/repo_update.yml
       vars:

--- a/linux/utils/collect_cloudinit_logs.yml
+++ b/linux/utils/collect_cloudinit_logs.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Collect cloud-init logs at deploying OVA or guest customization
+- name: "Initialize the cloud-init logs archive path in guest OS"
+  set_fact:
+    cloudinit_logs_src_path: "/tmp/cloud-init_{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}.tar.gz"
+
+- name: "Set fact of cloud-init logs archive path at local"
+  set_fact:
+    cloudinit_logs_local_path: "{{ current_test_log_folder }}/{{ cloudinit_logs_src_path | basename }}"
+
+- block:
+    # Collect cloud-init logs
+    - include_tasks: ../../common/vm_shell_in_guest.yml
+      vars:
+        vm_shell_cmd: "/usr/bin/cloud-init"
+        vm_shell_args: "collect-logs -u -t {{ cloudinit_logs_src_path }}"
+        vm_shell_out: ""
+
+    - include_tasks: ../../common/vm_guest_file_operation.yml
+      vars:
+        operation: "fetch_file"
+        src_path: "{{ cloudinit_logs_src_path }}"
+        dest_path: "{{ cloudinit_logs_local_path }}"
+  when:
+    - vmtools_is_running is defined
+    - vmtools_is_running | bool
+
+- block:
+    - name: "Collect cloud-init logs"
+      shell: "/usr/bin/cloud-init collect-logs -u -t {{ cloudinit_logs_src_path }}"
+      delegate_to: "{{ vm_guest_ip }}"
+
+    - name: "Fetch cloud-init logs from guest OS"
+      fetch:
+        src: "{{ cloudinit_logs_src_path }}"
+        dest: "{{ cloudinit_logs_local_path }}"
+        flat: True
+      delegate_to: "{{ vm_guest_ip }}"
+  when:
+    - vmtools_is_running is undefined or not (vmtools_is_running | bool)
+    - vm_guest_ip is defined
+    - vm_guest_ip in groups['target_vm']

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -63,12 +63,6 @@
 
     - block:
         - name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
-          command: "tdnf update -y {{ package_name_str }}"
-          delegate_to: "{{ vm_guest_ip }}"
-          register: package_update_output
-          when: package_state == "latest"
-
-        - name: "{{ local_task_name }} on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
           command: "tdnf remove -y {{ package_name_str }}"
           delegate_to: "{{ vm_guest_ip }}"
           register: package_uninstall_output

--- a/linux/utils/repo_update.yml
+++ b/linux/utils/repo_update.yml
@@ -28,18 +28,21 @@
       delegate_to: "{{ vm_guest_ip }}"
       register: repo_update_result
 
-    - name: "Check OS packages updates status"
-      async_status:
-        jid: "{{ repo_update_result.ansible_job_id }}"
-      register: job_result
-      vars:
-        ansible_async_dir: /tmp/.ansible_async/
-      delegate_to: "{{ vm_guest_ip }}"
-      until: job_result.finished
-      retries: 20
-      delay: 15
-      ignore_errors: True
+    - block:
+        - name: "Check OS packages updates status"
+          async_status:
+            jid: "{{ repo_update_result.ansible_job_id }}"
+          register: job_result
+          vars:
+            ansible_async_dir: /tmp/.ansible_async/
+          delegate_to: "{{ vm_guest_ip }}"
+          until: job_result.finished
+          retries: 20
+          delay: 15
+          ignore_errors: True
+          when: repo_update_result.ansible_job_id is defined
 
-    - name: "Print check update result"
-      debug: var=repo_update_result
+        - name: "Print check update result"
+          debug: var=repo_update_result
+      when: repo_update_result is defined
   when: check_update_cmd is defined and check_update_cmd

--- a/linux/utils/repo_update.yml
+++ b/linux/utils/repo_update.yml
@@ -36,7 +36,7 @@
           vars:
             ansible_async_dir: /tmp/.ansible_async/
           delegate_to: "{{ vm_guest_ip }}"
-          until: job_result.finished
+          until: job_result.finished == 1
           retries: 20
           delay: 15
           ignore_errors: True
@@ -44,5 +44,7 @@
 
         - name: "Print check update result"
           debug: var=repo_update_result
-      when: repo_update_result is defined
+      when:
+        - repo_update_result is defined
+        - repo_update_result.finished is undefined or repo_update_result.finished != 1
   when: check_update_cmd is defined and check_update_cmd

--- a/linux/utils/service_operation.yml
+++ b/linux/utils/service_operation.yml
@@ -3,7 +3,7 @@
 # This task is used to enable/disable service
 # Parameters:
 #   service_name: The service name to be configured
-#   service_enabled: True of false to enable or disable service
+#   service_enabled: True or false to enable or disable service
 #   service_state: The service state: reloaded, restarted, started, or stopped
 #
 - name: "Validate service state"

--- a/linux/utils/set_dns.yml
+++ b/linux/utils/set_dns.yml
@@ -3,7 +3,7 @@
 ---
 # Photon OS needs to disable DNSSEC and DNSOverTLS while connecting online repo
 - block:
-    - include_tasks: ../../common/update_init_style_file.yml
+    - include_tasks: ../../common/update_ini_style_file.yml
       vars:
         file_path: "/etc/systemd/resolved.conf"
         section_name: "Resolve"

--- a/linux/utils/set_dns.yml
+++ b/linux/utils/set_dns.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Photon OS needs to disable DNSSEC and DNSOverTLS while connecting online repo
+- block:
+    - include_tasks: ../../common/update_init_style_file.yml
+      vars:
+        file_path: "/etc/systemd/resolved.conf"
+        section_name: "Resolve"
+        option_name: "{{ item[0] }}"
+        option_value: "{{ item[1] }}"
+      with_items:
+        - ["DNSSEC", "no"]
+        - ["DNSOverTLS", "no"]
+    - include_tasks: service_operation.yml
+      vars:
+        service_name: "systemd-resolved"
+        service_enabled: True
+        service_state: "restarted"
+  when:
+    - guest_os_ansible_distribution == "VMware Photon OS"
+    - guest_os_ansible_distribution_major_ver | int >= 3

--- a/linux/utils/set_dns.yml
+++ b/linux/utils/set_dns.yml
@@ -9,7 +9,7 @@
         section_name: "Resolve"
         option_name: "{{ item[0] }}"
         option_value: "{{ item[1] }}"
-      with_items:
+      with_list:
         - ["DNSSEC", "no"]
         - ["DNSOverTLS", "no"]
     - include_tasks: service_operation.yml
@@ -19,4 +19,4 @@
         service_state: "restarted"
   when:
     - guest_os_ansible_distribution == "VMware Photon OS"
-    - guest_os_ansible_distribution_major_ver | int >= 3
+    - guest_os_ansible_distribution_major_ver | int == 3


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
This PR fixed below issues:
1. Failed to set root password with cloud-init at deploying Photon 3 OVA image. The issue has been fixed in Photon 3 shadow-4.6-6, but this fix worked around it for Photon 3 OVA images using shadow-4.6-5 or earlier. Meanwhile, added tasks for collecting cloud-init logs after deploying Photon and Ubuntu OVA for cloud-init problems triage.
2. Installing packages in Photon 3 might fail with error like "Couldn't resolve host name" or "Couldn't connect server" at the first time of executing `tdnf install`. Ultimately the root cause of the issue was this.
https://github.com/vmware/photon/commit/5b4f598f0ef30984217229c8bada56ff806e96eb
And fix is https://github.com/vmware/photon/commit/838af600bcb81a04de31af6b692e8e37c146d0ab

Photon team provides a workaround solution, which is to modify "/etc/systemd/resolved.conf" file to disable TLS options.
Like below:
```
...
DNSSEC=no
DNSOverTLS=no
...
```
And then run: "systemctl restart systemd-resolved"
3. Photon 4 uses sshd.socket as default sshd service for listening SSH connections, but Photon 3 or earlier uses sshd.service as default service. So for Photon 4 or later, it needs to start the sshd.socket after cloud-init at first boot to open the SSH port.