### PR TITLE
[Windows] Comment out get VM IP address task after deploying MS Windows template

### DIFF
--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -44,7 +44,8 @@
         
         - name: "Print VM guest IP address"
           debug: var=vm_guest_ip
-        
+          when: vm_guest_ip is defined
+
         # Take screenshot of VM after guest OS install
         - include_tasks: ../../common/vm_take_screenshot.yml
           vars:

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -46,7 +46,7 @@
     vm_power_state_set: "powered-on"
 - include_tasks: ../../common/vm_wait_guest_fullname.yml
 
-- include_tasks: ../../common/vm_get_ip_from_vmtools.yml
+# - include_tasks: ../../common/vm_get_ip_from_vmtools.yml
 
 # Copy script ConfigureRemotingForAnsible.ps1 to guest OS
 # - include_tasks: ../../common/vm_guest_file_operation.yml


### PR DESCRIPTION
Due to there are 2 network adapters available with network "VM Network", `vm_get_ip_from_vmtools.yml` returns error when try to get one available VM IP address, comment this task out for now since we'll not execute tasks in guest.