### PR TITLE
Add vm_folder for deploying OVF templates

### DIFF
--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -9,6 +9,7 @@
     validate_certs: "{{ validate_certs | default(False) }}"
     datacenter: "{{ vsphere_host_datacenter }}"
     datastore: "{{ deploy_datastore }}"
+    folder: "{{ vm_folder }}"
     networks: "{{ ovf_networks | default({'VM Network': 'VM Network'}) }}"
     ovf: "{{ ovf_path }}"
     name: "{{ ovf_vm_name }}"


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Add vm_folder in common task ovf_deploy.yml to specify which vm folder will the new OVF template be deployed.