### PR TITLE
Print playbook name before task name

### DIFF
--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -310,7 +310,7 @@ class CallbackModule(CallbackBase):
         msg = ""
 
         # Set task banner
-        task_banner = self._banner("{} [{}]".format(prefix, task_name))
+        task_banner = self._banner("{} [{}][{}]".format(prefix, self._play_name, task_name))
         task_path = task.get_path()
         if task_path:
             task_banner += "task path: {}\n".format(task_path)


### PR DESCRIPTION
Fix #182 
Example output
```
2022-08-04 11:27:41,004 | TASK [main][Gathering Facts] *******************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/main.yml:5
ok: [localhost] => { 
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
            "10.117.16.35",
            "172.18.0.1",
            "172.17.0.1"
        ],  
```