### PR TITLE
Tag known issues and collect them into known_issues.log

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,41 +1,15 @@
 # Known issues
 There are some known issues about Ansible VMware modules used in this project, VMware tools, or guest OS. Please file an issue to this project when you hit any failure in the testing but not listed here.
 
-## Ansible modules
-1. community.vmware.vmware_deploy_ovf
-* Failure: Router VM deployment will fail if there are more than one standalone ESXi hosts in the same datacenter. 
-* Issue link: https://github.com/ansible-collections/community.vmware/issues/670
-* Workaround: Please install the community.vmware collection containing the fix, or comment out below 4 test cases in gosv_testcase_list.yml.
-* Affected test cases:
-```
-network_device_ops/e1000e_network_device_ops.yml
-network_device_ops/vmxnet3_network_device_ops.yml
-guest_customization/gosc_perl_staticip.yml
-guest_customization/gosc_cloudinit_staticip.yml
-```
-
-2. community.vmware module
-* Failure: VMware module will fail with error 'virtual machine has already been deleted or has not been completely created' due to one VM is deleted while executing find VM in datacenter, e.g., vmware_vm_shell module.    
-* Issue link: https://github.com/ansible-collections/community.vmware/issues/732
-* Workaround: Please wait for the fix, or make sure not deleting VMs while the test is running.
-* Affected test cases: Testing will fail if any of the task failed due to this issue.
-
 ## Guest OS
-1. Ubuntu 18.04 and later
-* Failure: Configured DNS search domains in guest OS customization spec will not be set correctly in guest OS after cloud-init GOSC with DHCP network configuration.
-* Workaround: not available
-* Affected test cases:
-```
-guest_customization/gosc_cloudinit_dhcp.yml
-```
-2. SLE 15 SP2
+1. SLE 15 SP2
 * Failure: Get error when using 'zypper' module due to 'ImportError' when using Python2.
 * Workaround: Set 'vm_python' parameter in 'vars/test.yml' to correct Python3 path, e.g., '/usr/bin/python3'.
 
 * Failure: Get error 'A general system error occurred: vix error codes = (1, 4294967291).' while executing common/vm_shell_in_guest.yml.
 * Workaround: Configure vmtoolsd to use common authentication mechanism using PAM. See https://kb.vmware.com/s/article/78251.
 
-3. Windows 10 or Windows Server
+2. Windows 10 or Windows Server
 * Failure: Get error when removing NVMe controller from VM with error message "The guest operating system did not respond to a hot-remove request for device nvme1 in a timely manner.".
 * Workaround: not available
 * Affected test cases:
@@ -43,7 +17,7 @@ guest_customization/gosc_cloudinit_dhcp.yml
 vhba_hot_add_remove/nvme_vhba_device_ops.yml
 ```
 
-4. VMware Photon OS 3.x
+3. VMware Photon OS 3.x
 * Failure: After reinstalling open-vm-tools 11.2.5, the VGAuthService cann't be started successfully due to xmlsec1 version mismatch
 * Workaround: Manually upgrade xmlsec1 package by running command 'tdnf install xmlsec1', and then reboot Photon OS.
 * Affected test cases:
@@ -59,15 +33,7 @@ guest_customization/gosc_cloudinit_dhcp.yml
 guest_customization/gosc_cloudinit_staticip.yml
 ```
 
-5. VMware Photon OS 4.0
-* Failure: When hot adding or removing NVMe disk to existing controller, VMware Photon OS cannot detect NVMe disk changes.
-* Workaround: not available
-* Affected test cases:
-```
-vhba_hot_add_remove/nvme_vhba_device_ops.yml
-```
-
-6. SLES 15 SP1 and later
+4. SLES 15 SP1 and later
 * Failure: Perl GOSC would fail to customize DNS servers and search domains on vSphere 6.5 and 6.7. See https://kb.vmware.com/s/article/70682.
 * Workaround: Upgrade vSphere to 6.5 U3, 6.7 U3 or 7.0 and later.
 ```
@@ -75,7 +41,7 @@ guest_customization/gosc_perl_dhcp.yml
 guest_customization/gosc_perl_staticip.yml
 ```
 
-7. Windows 11
+5. Windows 11
 * Failure: Guest customization test cases would fail with SYSPREP error "Package Microsoft.OneDriveSync_21180.905.7.0_neutral__8wekyb3d8bbwe was installed for a user, but not provisioned for all users. This package will not function properly in the sysprep image." due to the known Windows issue.
 * Workaround: Uninstall OneDrive in guest OS.
 ```

--- a/linux/guest_customization/linux_gosc_verify.yml
+++ b/linux/guest_customization/linux_gosc_verify.yml
@@ -55,7 +55,9 @@
 
     - name: "Ignore DNS customization failures when performing cloud-init GOSC with DHCP IP on Ubuntu"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: DNS customization failed due to https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1776452. Ignore this failure.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: DNS customization failed due to https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1776452. Ignore this knonwn issue.'] }}"
+      tags:
+        - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)
 
     - name: "Update failed customization items"
@@ -76,7 +78,9 @@
 
     - name: "cloud-init GOSC with static IP couldn't set default gateway"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. See https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved. Ignore this failure.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. See https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved. Ignore this knonwn issue.'] }}"
+      tags:
+        - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)
 
     - name: "Update failed customization items"
@@ -95,7 +99,9 @@
 
     - name: "GOSC doesn't send complete state code to vmware.log when vCenter Server version is 6.5 U3 and earlier"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: No GOSC complete state keyword in vmware.log from vCenter Server 6.5 U3 and earlier. Ignore this failure.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: No GOSC complete state keyword in vmware.log from vCenter Server 6.5 U3 and earlier. Ignore this known issue.'] }}"
+      tags:
+        - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)
 
     - name: "Update failed customization items"

--- a/linux/guest_customization/linux_gosc_verify.yml
+++ b/linux/guest_customization/linux_gosc_verify.yml
@@ -78,7 +78,7 @@
 
     - name: "cloud-init GOSC with static IP couldn't set default gateway"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. See https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved. Ignore this knonwn issue.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. Ignore this knonwn issue.', 'Please refer to https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved.'] }}"
       tags:
         - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)

--- a/linux/guest_customization/linux_gosc_verify.yml
+++ b/linux/guest_customization/linux_gosc_verify.yml
@@ -53,9 +53,9 @@
       set_fact:
         ignored_gosc_failed_items: ['dns_servers_success', 'dns_suffix_success']
 
-    - name: "Ignore DNS customization failures when performing cloud-init GOSC with DHCP IP on Ubuntu"
+    - name: "Known issue - ignore cloud-init GOSC failure on DNS"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: DNS customization failed due to https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1776452. Ignore this knonwn issue.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['DNS customization failed due to https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1776452. Ignore this knonwn issue.'] }}"
       tags:
         - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)
@@ -76,9 +76,9 @@
       set_fact:
         ignored_gosc_failed_items: ['guest_gateway_success']
 
-    - name: "cloud-init GOSC with static IP couldn't set default gateway"
+    - name: "Known issue - ignore cloud-init GOSC failure on default gateway"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. Ignore this knonwn issue.', 'Please refer to https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['Default gateway customization failure has been fixed on vCenter Server 6.5 U3 and 6.7U2. Ignore this knonwn issue.', 'Please refer to https://docs.vmware.com/en/VMware-vSphere/6.5/rn/vsphere-vcenter-server-65u3-release-notes.html#guest-os-issues-resolved and https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u2-release-notes.html#guest-os-issues-resolved.'] }}"
       tags:
         - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)
@@ -97,9 +97,9 @@
       set_fact:
         ignored_gosc_failed_items: ['gosc_state_keyword_found']
 
-    - name: "GOSC doesn't send complete state code to vmware.log when vCenter Server version is 6.5 U3 and earlier"
+    - name: "Known issue - ignore no GOSC complete state code"
       debug:
-        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['WARNING: No GOSC complete state keyword in vmware.log from vCenter Server 6.5 U3 and earlier. Ignore this known issue.'] }}"
+        msg: "{{ (gosc_validation_errors | dict2items | selectattr('key', 'in', ignored_gosc_failed_items) | map(attribute='value') | flatten) + ['There is no GOSC complete state keyword in vmware.log when performing GOSC from vCenter Server 6.5 U3 or earlier. Ignore this known issue.'] }}"
       tags:
         - known_issue
       when: (gosc_failed_items | length) > (gosc_failed_items | difference(ignored_gosc_failed_items) | length)

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -20,7 +20,7 @@
   assert:
     that:
       - wait_device_name is defined
-      - wait_device_name 
+      - wait_device_name
     fail_msg: "wait_device_name is missing for waiting device absent"
   when: wait_device_state | lower == 'absent'
 
@@ -58,12 +58,12 @@
             - name: "Set fact of removed disk {{ wait_device_name }}"
               set_fact:
                 guest_ansible_device: >
-                  {{  
-                    guest_system_info.ansible_devices | 
+                  {{
+                    guest_system_info.ansible_devices |
                     dict2items |
                     selectattr('key', 'equalto', wait_device_name) |
                     items2dict
-                  }}  
+                  }}
 
             - name: "Rescan the deleted SCSI disk '{{ wait_device_name }}'"
               shell: "echo 1 > /sys/block/{{ wait_device_name }}/device/delete"
@@ -104,8 +104,9 @@
       when: new_vm is undefined or not new_vm | bool
 
     - block:
-        - debug:
-            msg:  
+        - name: "Ignore NVMe known issue"
+          debug:
+            msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
               - "VM's boot disk controller is not NVMe, so it needs to unload and reload nvme driver to see NVMe device changes."
               - "Please refer to https://kb.vmware.com/s/article/2147574."
@@ -118,8 +119,9 @@
       when: vm_boot_disk_ctrl_type != 'nvme'
 
     - block:
-        - debug:
-            msg: 
+        - name: "Ignore NVMe known issue"
+          debug:
+            msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
               - "VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes."
               - "Please refer to https://kb.vmware.com/s/article/2147574."

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -105,7 +105,9 @@
 
     - block:
         - debug:
-            msg: "VM's boot disk controller is not NVMe controller, so unload and reload nvme driver to see NVMe device changes."
+            msg: "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue. VM's boot disk controller is not NVMe, so it needs to unload and reload nvme driver to see NVMe device changes. See https://kb.vmware.com/s/article/2147574."
+          tags:
+            - known_issue
 
         - name: "Unload and reload nvme driver"
           shell: "rmmod nvme && modprobe nvme"
@@ -114,7 +116,9 @@
 
     - block:
         - debug:
-            msg: "VM's boot disk controller is NVMe controller, so reboot OS to see NVMe device changes."
+            msg: "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue. VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes. See https://kb.vmware.com/s/article/2147574."
+          tags:
+            - known_issue
 
         - include_tasks: ../utils/vm_reboot.yml
       when: vm_boot_disk_ctrl_type == 'nvme'

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -104,11 +104,11 @@
       when: new_vm is undefined or not new_vm | bool
 
     - block:
-        - name: "Ignore NVMe known issue"
+        - name: "Known issue - workaround of detecting NVMe device changes"
           debug:
             msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
-              - "VM's boot disk controller is not NVMe, so it needs to unload and reload nvme driver to see NVMe device changes."
+              - "VM's boot disk controller is not NVMe, so unload and reload nvme driver to see NVMe device changes as a workaround."
               - "Please refer to https://kb.vmware.com/s/article/2147574."
           tags:
             - known_issue
@@ -119,11 +119,11 @@
       when: vm_boot_disk_ctrl_type != 'nvme'
 
     - block:
-        - name: "Ignore NVMe known issue"
+        - name: "Known issue - workaround of detecting NVMe device changes"
           debug:
             msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
-              - "VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes."
+              - "VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes as a workaround."
               - "Please refer to https://kb.vmware.com/s/article/2147574."
           tags:
             - known_issue

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -105,7 +105,10 @@
 
     - block:
         - debug:
-            msg: "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue. VM's boot disk controller is not NVMe, so it needs to unload and reload nvme driver to see NVMe device changes. See https://kb.vmware.com/s/article/2147574."
+            msg:  
+              - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
+              - "VM's boot disk controller is not NVMe, so it needs to unload and reload nvme driver to see NVMe device changes."
+              - "Please refer to https://kb.vmware.com/s/article/2147574."
           tags:
             - known_issue
 
@@ -116,7 +119,10 @@
 
     - block:
         - debug:
-            msg: "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue. VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes. See https://kb.vmware.com/s/article/2147574."
+            msg: 
+              - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
+              - "VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes."
+              - "Please refer to https://kb.vmware.com/s/article/2147574."
           tags:
             - known_issue
 

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -375,14 +375,16 @@ class CallbackModule(CallbackBase):
 
         if 'known_issue' in str(task_tags) and 'msg' in result._result:
             self._display.display("TAGS: known_issue", color=C.COLOR_VERBOSE)
-            log_header = ""
             if 'known_issue' not in self._play_tasks_cache:
-                self._play_tasks_cache['known_issue'] = [task_path]
-                log_header = self._banner("Known Issue in Play [{}]".format(current_play))
-                self.write_to_logfile(self.known_issues_log, log_header)
-            else:
+                self._play_tasks_cache['known_issue'] = []
+                self.write_to_logfile(self.known_issues_log, current_play + ":\n")
+
+            if task_path and task_path not in self._play_tasks_cache['known_issue']:
                 self._play_tasks_cache['known_issue'].append(task_path)
-            self.add_logger_file_handler(self.known_issues_log)
+                if isinstance(result._result['msg'], list):
+                    self.write_to_logfile(self.known_issues_log, "  {}\n".format('\n  '.join(result._result['msg']))) 
+                else:
+                    self.write_to_logfile(self.known_issues_log, "  {}\n".format(str(result._result['msg'])))
 
         # Add logger handler for failed tasks
         if log_failed_tasks:
@@ -405,10 +407,7 @@ class CallbackModule(CallbackBase):
 
         self.logger.info(msg)
 
-        # Remove logger handler for known issues and failed tasks
-        if 'known_issue' in str(task_tags) and 'msg' in result._result:
-            self.remove_logger_file_handler(self.known_issues_log)
-
+        # Remove logger handler for failed tasks
         if log_failed_tasks:
             self.remove_logger_file_handler(self.failed_tasks_log)
 

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -190,6 +190,7 @@ class CallbackModule(CallbackBase):
         self.testrun_log_dir = None
         self.full_debug_log = "full_debug.log"
         self.failed_tasks_log = "failed_tasks.log"
+        self.known_issues_log = "known_issues.log"
         self.test_results_log = "results.log"
         self.test_results_yml = "test_results.yml"
         self.os_release_info_file = None
@@ -300,6 +301,7 @@ class CallbackModule(CallbackBase):
                            loop_item=None,
                            ignore_errors=False):
         task = result._task
+        task_tags = task._attributes['tags']
         prefix = self._task_type_cache.get(task._uuid, 'TASK')
 
         # Use cached task name
@@ -364,6 +366,10 @@ class CallbackModule(CallbackBase):
         if ignore_errors:
             msg += "\n...ignoring"
             log_failed_tasks = False
+
+        if 'known_issue' in str(task_tags) and 'msg' in result._result:
+            known_issues = "{}: {}".format(self._play_name, result._result['msg'])
+            self.write_to_logfile(self.known_issues_log, known_issues)
 
         # Add logger handler for failed tasks
         if log_failed_tasks:

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -375,16 +375,15 @@ class CallbackModule(CallbackBase):
 
         if 'known_issue' in str(task_tags) and 'msg' in result._result:
             self._display.display("TAGS: known_issue", color=C.COLOR_VERBOSE)
+            log_header = ""
             if 'known_issue' not in self._play_tasks_cache:
                 self._play_tasks_cache['known_issue'] = []
-                self.write_to_logfile(self.known_issues_log, current_play + ":\n")
+                log_header = self._banner("Known Issue in Play [{}]".format(current_play))
+                self.write_to_logfile(self.known_issues_log, log_header)
 
             if task_path and task_path not in self._play_tasks_cache['known_issue']:
                 self._play_tasks_cache['known_issue'].append(task_path)
-                if isinstance(result._result['msg'], list):
-                    self.write_to_logfile(self.known_issues_log, "  {}\n".format('\n  '.join(result._result['msg']))) 
-                else:
-                    self.write_to_logfile(self.known_issues_log, "  {}\n".format(str(result._result['msg'])))
+                self.add_logger_file_handler(self.known_issues_log)
 
         # Add logger handler for failed tasks
         if log_failed_tasks:
@@ -407,7 +406,10 @@ class CallbackModule(CallbackBase):
 
         self.logger.info(msg)
 
-        # Remove logger handler for failed tasks
+        # Remove logger handler for known issues and failed tasks
+        if 'known_issue' in str(task_tags) and 'msg' in result._result:
+            self.remove_logger_file_handler(self.known_issues_log)
+
         if log_failed_tasks:
             self.remove_logger_file_handler(self.failed_tasks_log)
 

--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -35,7 +35,9 @@
         - include_tasks: ../../common/vm_get_guest_info.yml
         
         - debug:
-            msg: "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c, ignore this known issue, please refer to https://kb.vmware.com/s/article/86517."
+            msg:
+              - "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c. Ignore this known issue."
+              - "Please refer to https://kb.vmware.com/s/article/86517."
           tags:
             - known_issue
           when:

--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -34,7 +34,8 @@
         # Get guest fullname from VM guest info
         - include_tasks: ../../common/vm_get_guest_info.yml
         
-        - debug:
+        - name: "Known issue - ignore incorrect guestID of Windows 11"
+          debug:
             msg:
               - "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c. Ignore this known issue."
               - "Please refer to https://kb.vmware.com/s/article/86517."

--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -35,7 +35,9 @@
         - include_tasks: ../../common/vm_get_guest_info.yml
         
         - debug:
-            msg: "guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c, ignore this known issue, please refer to https://kb.vmware.com/s/article/86517."
+            msg: "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c, ignore this known issue, please refer to https://kb.vmware.com/s/article/86517."
+          tags:
+            - known_issue
           when:
             - not guestinfo_guest_id
             - esxi_version is defined and esxi_version

--- a/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
+++ b/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
@@ -14,6 +14,8 @@
 - block:
     - debug:
         msg: "'disk.EnableUUID = TRUE' is not in VM vmx file, ignore this known issue on ESXi 7.0U3c with guestID '{{ vm_guest_id }}'."
+      tags:
+        - known_issue
       when: not vm_advanced_settings[0].key in vm_extra_config
   when:
     - esxi_version is defined and esxi_version

--- a/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
+++ b/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
@@ -12,7 +12,8 @@
 
 # Known issue on Windows Server 2022 guest ID on ESXi 7.0U3c build, fixed in ESXi 7.0U3d
 - block:
-    - debug:
+    - name: "Known issue - ignore missing disk.EnableUUID = TRUE"
+      debug:
         msg: "'disk.EnableUUID = TRUE' is not in VM vmx file, ignore this known issue on ESXi 7.0U3c with guestID '{{ vm_guest_id }}'."
       tags:
         - known_issue

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
@@ -17,7 +17,9 @@
 - block:
     - name: "WORKAROUND" 
       debug:
-        msg: "Disable/re-enable NVMe controller is a workaround for hotadd disk to existing NVMe controller due to hotadd/remove disk is not supported when NVMe Spec v1.0 is emulated"
+        msg: "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue, and disable/re-enable NVMe controller as a workaround for hot adding disk to existing NVMe controller."
+      tags:
+        - known_issue
     - include_tasks: disable_enable_nvme_device.yml
   when:
     - test_disk_controller_type == 'nvme'

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
@@ -15,9 +15,9 @@
 # When hotadd a NVMe disk to existing controller, disable and re-enable NVMe
 # controller device in guest OS, then new disk can be recognized
 - block:
-    - name: "WORKAROUND" 
+    - name: "WORKAROUND"
       debug:
-        msg: 
+        msg:
           - "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue."
           - "Disable/re-enable NVMe controller as a workaround for hot adding disk to existing NVMe controller."
       tags:

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
@@ -17,7 +17,9 @@
 - block:
     - name: "WORKAROUND" 
       debug:
-        msg: "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue, and disable/re-enable NVMe controller as a workaround for hot adding disk to existing NVMe controller."
+        msg: 
+          - "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue."
+          - "Disable/re-enable NVMe controller as a workaround for hot adding disk to existing NVMe controller."
       tags:
         - known_issue
     - include_tasks: disable_enable_nvme_device.yml

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
@@ -15,7 +15,7 @@
 # When hotadd a NVMe disk to existing controller, disable and re-enable NVMe
 # controller device in guest OS, then new disk can be recognized
 - block:
-    - name: "WORKAROUND"
+    - name: "Known issue - workaround of hot adding NVMe disk"
       debug:
         msg:
           - "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue."

--- a/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
@@ -17,9 +17,11 @@
 
 # Restart guest when hot removed disk is nvme disk
 - block:
-    - name: "WORKAROUND"
+    - name: "Known issue - workaround of hot removing NVMe disk"
       debug:
-        msg: "Hot-remove NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue, and restart guest as a workaround for hot removing disk from the NVMe controller."
+        msg:
+          - "Hot-remove NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue."
+          - "Restart guest as a workaround for hot removing disk from the NVMe controller."
       tags:
         - known_issue
     - include_tasks: ../utils/win_shutdown_restart.yml

--- a/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
@@ -19,7 +19,7 @@
 - block:
     - name: "WORKAROUND"
       debug:
-        msg: "Restart guest is a workaround for hot remove NVMe disk due to hotadd/remove disk is not supported when NVMe Spec v1.0 is emulated"
+        msg: "Hot-remove NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue, and restart guest as a workaround for hot removing disk from the NVMe controller."
     - include_tasks: ../utils/win_shutdown_restart.yml
       vars:
         set_win_power_state: "restart"

--- a/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml
@@ -20,6 +20,8 @@
     - name: "WORKAROUND"
       debug:
         msg: "Hot-remove NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue, and restart guest as a workaround for hot removing disk from the NVMe controller."
+      tags:
+        - known_issue
     - include_tasks: ../utils/win_shutdown_restart.yml
       vars:
         set_win_power_state: "restart"


### PR DESCRIPTION
Add tag `known_issue` to debug message which describes a known issue, and collect them in log plugin.

Example `known_issues.log`:
```

2022-08-08 10:02:54,008 | Known Issue in Play [check_os_fullname] ********************

2022-08-08 10:02:54,008 | TASK [check_os_fullname][Known issue - ignore incorrect guestID of Windows 11] 
task path: /home/worker/workspace/Ansible_Regression_Windows_11_64/ansible-vsphere-gos-validation/windows/check_os_fullname/check_os_fullname.yml:37
ok: [localhost] => {
    "msg": [
        "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c. Ignore this known issue.",
        "Please refer to https://kb.vmware.com/s/article/86517."
    ]
}

2022-08-08 10:05:05,008 | Known Issue in Play [nvme_vhba_device_ops] *****************

2022-08-08 10:05:05,008 | TASK [nvme_vhba_device_ops][Known issue - workaround of hot adding NVMe disk] 
task path: /home/worker/workspace/Ansible_Regression_Windows_11_64/ansible-vsphere-gos-validation/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml:18
ok: [localhost] => {
    "msg": [
        "Hot-add NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue.",
        "Disable/re-enable NVMe controller as a workaround for hot adding disk to existing NVMe controller."
    ]
}

2022-08-08 10:06:20,008 | TASK [nvme_vhba_device_ops][Known issue - workaround of hot removing NVMe disk] 
task path: /home/worker/workspace/Ansible_Regression_Windows_11_64/ansible-vsphere-gos-validation/windows/vhba_hot_add_remove/hotremove_vm_disk_ctrl.yml:20
ok: [localhost] => {
    "msg": [
        "Hot-remove NVMe disk is not supported on Windows VM when NVMe Spec v1.0 is emulated. Ignore this known issue.",
        "Restart guest as a workaround for hot removing disk from the NVMe controller."
    ]
}
```

```

2022-08-08 10:06:40,008 | Known Issue in Play [gosc_cloudinit_dhcp] ******************

2022-08-08 10:06:40,008 | TASK [gosc_cloudinit_dhcp][Known issue - ignore cloud-init GOSC failure on DNS] 
task path: /home/worker/workspace/Ansible_Regression_Ubuntu_22.04_Server_OVA/ansible-vsphere-gos-validation/linux/guest_customization/linux_gosc_verify.yml:56
ok: [localhost] => {
    "msg": [
        "VM DNS domain search domains are  ['eng.vmware.com', 'nimbus.eng.vmware.com', 'vmware.com'] not expected search domains ['test.com', 'gosc.test.com']",
        "DNS customization failed due to https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1776452. Ignore this knonwn issue."
    ]
}

2022-08-08 10:07:28,008 | Known Issue in Play [nvme_vhba_device_ops] *****************

2022-08-08 10:07:28,008 | TASK [nvme_vhba_device_ops][Known issue - workaround of detecting NVMe device changes] 
task path: /home/worker/workspace/Ansible_Regression_Ubuntu_22.04_Server_OVA/ansible-vsphere-gos-validation/linux/vhba_hot_add_remove/wait_device_list_changed.yml:107
ok: [localhost] => {
    "msg": [
        "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is 18. Ignore this known issue.",
        "VM's boot disk controller is not NVMe, so unload and reload nvme driver to see NVMe device changes as a workaround.",
        "Please refer to https://kb.vmware.com/s/article/2147574."
    ]
}
```