### PR TITLE
Add inbox drivers's filename checking in check_inbox_driver

### DIFF
--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -12,16 +12,6 @@
   vars_files:
     - "{{ testing_vars_file | default('../../vars/test.yml') }}"
   vars:
-    inbox_drivers:
-      - vmxnet3
-      - vmw_vmci
-      - vsock
-      - vmw_vsock_vmci_transport
-      - vmw_pvscsi
-      - vmw_balloon
-      - vmwgfx
-      - vmw_pvrdma
-      - ptp_vmw
   tasks:
     - name: "Initialized inbox drivers' versions dict"
       set_fact:
@@ -32,28 +22,7 @@
           vars:
             skip_test_no_vmtools: False
 
-        - name: "Get OS Release for SUSE"
-          set_fact:
-            inbox_drivers_versions: >-
-              {{
-                inbox_drivers_versions |
-                combine({'Release': 'SLE ' ~ guest_os_ansible_distribution_major_ver ~ ' SP' ~ guest_os_ansible_distribution_minor_ver})
-              }}
-          when: guest_os_ansible_distribution in ['SLES', 'SLED']
-
-        - name: "Get OS Release for RHEL"
-          set_fact:
-            inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'Release': 'RHEL ' ~ guest_os_ansible_distribution_ver}) }}"
-          when: guest_os_ansible_distribution == "RedHat"
-
-        - name: "Get OS Release for {{ guest_os_ansible_distribution }}"
-          set_fact:
-            inbox_drivers_versions: >-
-              {{
-                inbox_drivers_versions |
-                combine({'Release': guest_os_ansible_distribution ~ ' ' ~ guest_os_ansible_distribution_ver})
-              }}
-          when: guest_os_ansible_distribution not in ['SLES', 'SLED', "RedHat"]
+        - include_tasks: get_os_release.yml
 
         - name: "Get OS kernel version"
           set_fact:
@@ -83,173 +52,26 @@
             - cloudinit_version is defined
             - cloudinit_version
 
-        - name: "Get drivers version in VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
-          block:
-            - name: "Check driver version"
-              shell: "if [ -e /sys/module/{{ driver }}/version ]; then cat /sys/module/{{ driver }}/version ; fi"
-              with_items: "{{ inbox_drivers }}"
-              loop_control:
-                loop_var: driver
-              register: photon_drivers
-              no_log: True
-              delegate_to: "{{ vm_guest_ip }}"
+        # Get Xorg version
+        - include_tasks: get_xorg_version.yml
 
-            - name: Set fact of driver version dict
-              set_fact:
-                inbox_drivers_versions: >-
-                  {{
-                    inbox_drivers_versions |
-                    combine(photon_drivers.results |
-                            selectattr('stdout', 'defined') |
-                            selectattr('stdout', '!=', '') |
-                            items2dict(key_name='driver', value_name='stdout'))
-                  }}
-          when:
-            - guest_os_ansible_distribution == "VMware Photon OS"
-            - guest_os_ansible_distribution_major_ver | int < 4
+        # Get Linux inbox drivers
+        - include_tasks: get_inbox_drivers.yml
 
-        - name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
-          block:
-            - name: "Get module information of inbox drivers"
-              command: "modinfo {{ module_name }}"
-              register: modinfo_result
-              delegate_to: "{{ vm_guest_ip }}"
-              ignore_errors: True
-              loop: "{{ inbox_drivers }}"
-              loop_control:
-                loop_var: module_name
-
-            - name: "Set fact of found inbox driver modules"
-              set_fact:
-                builtin_modules: "{{ modinfo_result.results | selectattr('rc', 'equalto', 0) }}"
-
-            - name: "Set fact of inbox driver version with its version"
-              set_fact:
-                inbox_drivers_versions: >
-                  {{ inbox_drivers_versions |
-                     combine({item.module_name:''.join(item.stdout_lines |
-                                                        select('match', 'version:', ignorecase=True)) |
-                              regex_replace('version:\s*', '')})
-                  }}
-              with_items: "{{ builtin_modules }}"
-
-            - name: "Set fact of inbox driver version with its srcversion"
-              set_fact:
-                inbox_drivers_versions: >
-                  {{ inbox_drivers_versions |
-                     combine({item.module_name:''.join(item.stdout_lines |
-                                                        select('match', 'srcversion:', ignorecase=True)) |
-                              regex_replace('srcversion:\s*', '')})
-                  }}
-              when: >
-                item.module_name not in inbox_drivers_versions or
-                not inbox_drivers_versions[item.module_name]
-              with_items: "{{ builtin_modules }}"
-
-            - name: "Set fact of inbox driver version with its vermagic"
-              set_fact:
-                inbox_drivers_versions: >
-                  {{ inbox_drivers_versions |
-                     combine({item.module_name:''.join(item.stdout_lines |
-                                                        select('match', 'vermagic:', ignorecase=True)) |
-                              regex_replace('vermagic:\s*', '')})
-                  }}
-              when: >
-                item.module_name not in inbox_drivers_versions or
-                not inbox_drivers_versions[item.module_name]
-              with_items: "{{ builtin_modules }}"
-          when: >
-            (guest_os_ansible_distribution != "VMware Photon OS") or
-            (guest_os_ansible_distribution == "VMware Photon OS" and
-            guest_os_ansible_distribution_major_ver | int >= 4)
-
-        # If the driver is not found in guest OS, set its version to 'N/A'
-        - name: "Update fact of inbox driver version dict to set not found driver version with 'N/A'"
-          set_fact:
-            inbox_drivers_versions: >-
-              {{
-                inbox_drivers_versions |
-                combine({module_name: 'N/A'})
-              }}
-          loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
-          loop_control:
-            loop_var: module_name
-
-        - name: "Check whether Xorg server is installed"
-          command: "which Xorg"
-          register: which_xorg_server
-          failed_when: False
-          delegate_to: "{{ vm_guest_ip }}"
-
-        - block:
-            - name: "Check Xorg server"
-              command: "Xorg -version"
-              register: xorg_version_result
-              failed_when: False
-              delegate_to: "{{ vm_guest_ip }}"
-
-            - block:
-                - name: "Get Xorg server version"
-                  set_fact:
-                    xorg_version: "{{ xorg_version_result.stderr_lines | select('match','X.Org X Server') }}"
-
-                - name: "Collect Xorg server version"
-                  set_fact:
-                     inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xorg server': xorg_version[0].split()[-1] }) }}"
-                  when: xorg_version and xorg_version | length > 0
-              when:
-                - xorg_version_result.rc is defined
-                - xorg_version_result.rc == 0
-                - xorg_version_result.stderr_lines is defined
-                - xorg_version_result.stderr_lines | length > 0
-
-            - name: "Initialize VMware video driver package name"
-              set_fact:
-                video_driver_pkg_name: |-
-                  {%- if guest_os_family == "RedHat" -%}xorg-x11-drv-vmware
-                  {%- elif guest_os_family == "Suse" -%}xf86-video-vmware
-                  {%- else -%}{%- endif -%}
-
-            - block:
-                - name: "Looking for VMware video driver package"
-                  shell: "dpkg -l xserver-xorg-video-vmware* | grep xserver-xorg-video-vmware"
-                  failed_when: False
-                  register: vmware_video_package_result
-                  delegate_to: "{{ vm_guest_ip }}"
-
-                - name: "Get VMware video driver package name"
-                  set_fact:
-                    video_driver_pkg_name: "{{ vmware_video_package_result.stdout.split()[1] }}"
-                  when:
-                    - vmware_video_package_result.rc is defined
-                    - vmware_video_package_result.rc == 0
-                    - vmware_video_package_result.stdout is defined
-                    - vmware_video_package_result.stdout
-              when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
-
-            - block:
-                - include_tasks: ../utils/get_installed_package_info.yml
-                  vars:
-                    package_name: "{{ video_driver_pkg_name }}"
-
-                - name: "Get the VMware video driver version"
-                  set_fact:
-                    inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xf86-video-vmware': package_info.Version.split(':')[-1] }) }}"
-                  when:
-                    - package_info.Version is defined
-                    - package_info.Version
-              when: video_driver_pkg_name
-          when:
-            - which_xorg_server is defined
-            - which_xorg_server.rc is defined
-            - which_xorg_server.rc == 0
-
+      rescue:
+        - include_tasks: ../../common/test_rescue.yml
+      always:
         - name: "Print inbox drivers versions"
           debug: var=inbox_drivers_versions
 
+        - name: "Create test case log direcotry"
+          include_tasks: ../../common/create_directory.yml
+          vars:
+            dir_path: "{{ current_test_log_folder }}"
+
         - name: "Set fact of the output file path"
           set_fact:
-            os_release_info_file_path: "{{ testrun_log_path }}/{{ inbox_drivers_versions['Release'].replace(' ','-') | lower }}.json"
+            os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace(' ','-') | lower }}.json"
 
         - name: "The inbox drivers versions will be dump to a json file"
           debug: var=os_release_info_file_path
@@ -258,5 +80,3 @@
           copy:
             dest: "{{ os_release_info_file_path }}"
             content: "{{ [inbox_drivers_versions] | to_nice_json }}"
-      rescue:
-        - include_tasks: ../../common/test_rescue.yml

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -8,24 +8,24 @@
 #
 - name: check_inbox_driver
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   vars_files:
     - "{{ testing_vars_file | default('../../vars/test.yml') }}"
   vars:
   tasks:
     - name: "Initialized inbox drivers' versions dict"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_versions: {}
 
     - block:
         - include_tasks: ../setup/test_setup.yml
           vars:
-            skip_test_no_vmtools: False
+            skip_test_no_vmtools: false
 
         - include_tasks: get_os_release.yml
 
         - name: "Get OS kernel version"
-          set_fact:
+          ansible.builtin.set_fact:
             inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'kernel': guest_os_ansible_kernel}) }}"
 
         - name: "Get open-vm-tools version"
@@ -33,12 +33,12 @@
             - include_tasks: ../utils/get_vmware_toolbox_cmd_path.yml
 
             - name: "Check open-vm-tools version"
-              command: "{{ vmware_toolbox_cmd_path }} -v"
+              ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} -v"
               register: ovt_version
               delegate_to: "{{ vm_guest_ip }}"
 
             - name: "Collect open-vm-tools version"
-              set_fact:
+              ansible.builtin.set_fact:
                 inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'open-vm-tools': ovt_version.stdout}) }}"
           when: vmtools_is_ovt is defined and vmtools_is_ovt
 
@@ -46,7 +46,7 @@
         - include_tasks: ../utils/cloudinit_pkg_check.yml
 
         - name: "Collect cloud-init version"
-          set_fact:
+          ansible.builtin.set_fact:
             inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'cloud-init': cloudinit_version}) }}"
           when:
             - cloudinit_version is defined
@@ -62,7 +62,7 @@
         - include_tasks: ../../common/test_rescue.yml
       always:
         - name: "Print inbox drivers versions"
-          debug: var=inbox_drivers_versions
+          ansible.builtin.debug: var=inbox_drivers_versions
 
         - name: "Create test case log direcotry"
           include_tasks: ../../common/create_directory.yml
@@ -70,13 +70,14 @@
             dir_path: "{{ current_test_log_folder }}"
 
         - name: "Set fact of the output file path"
-          set_fact:
+          ansible.builtin.set_fact:
             os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace(' ','-') | lower }}.json"
 
         - name: "The inbox drivers versions will be dump to a json file"
-          debug: var=os_release_info_file_path
+          ansible.builtin.debug: var=os_release_info_file_path
 
         - name: "Dump inbox drivers versions"
-          copy:
+          ansible.builtin.copy:
             dest: "{{ os_release_info_file_path }}"
             content: "{{ [inbox_drivers_versions] | to_nice_json }}"
+            mode: '0644'

--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -1,0 +1,190 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Set fact of mandatory and optional inbox drivers"
+  set_fact:
+    mandatory_drivers:
+      - vmxnet3
+      - vmw_vmci
+      - vsock
+      - vmw_vsock_vmci_transport
+      - vmw_pvscsi
+      - vmw_balloon
+    optional_drivers:
+      - vmw_vsock_virtio_transport_common
+      - vmw_pvrdma
+      - ptp_vmw
+
+- name: "Update mandatory inbox drivers when guest OS has GUI"
+  set_fact:
+    mandatory_drivers: "{{ mandatory_drivers + ['vmwgfx'] }}"
+  when: guest_os_with_gui is defined and guest_os_with_gui | bool
+
+- name: "Update optional inbox drivers when guest OS has no GUI"
+  set_fact:
+    optional_drivers: "{{ optional_drivers + ['vmwgfx'] }}"
+  when: guest_os_with_gui is undefined or not (guest_os_with_gui | bool)
+
+- name: "Set fact of all inbox drivers to check"
+  set_fact:
+    inbox_drivers: "{{ mandatory_drivers + optional_drivers }}"
+
+- name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+  block:
+    - name: "Check driver version"
+      shell: "if [ -e /sys/module/{{ driver }}/version ]; then cat /sys/module/{{ driver }}/version ; fi"
+      with_items: "{{ inbox_drivers }}"
+      loop_control:
+        loop_var: driver
+      register: photon_drivers
+      no_log: True
+      delegate_to: "{{ vm_guest_ip }}"
+
+    - name: Set fact of driver version dict
+      set_fact:
+        inbox_drivers_versions: >-
+          {{
+            inbox_drivers_versions |
+            combine(photon_drivers.results |
+                    selectattr('stdout', 'defined') |
+                    selectattr('stdout', '!=', '') |
+                    items2dict(key_name='driver', value_name='stdout'))
+          }}
+  when:
+    - guest_os_ansible_distribution == "VMware Photon OS"
+    - guest_os_ansible_distribution_major_ver | int < 4
+
+- name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+  block:
+    - name: "Get module information of inbox drivers"
+      command: "modinfo {{ module_name }}"
+      register: modinfo_result
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: True
+      loop: "{{ inbox_drivers }}"
+      loop_control:
+        loop_var: module_name
+
+    - name: "Set fact of found inbox driver modules"
+      set_fact:
+        builtin_modules: "{{ modinfo_result.results | selectattr('rc', 'equalto', 0) }}"
+
+    - name: "Set fact of inbox driver version with its version"
+      set_fact:
+        inbox_drivers_versions: >
+          {{ inbox_drivers_versions |
+             combine({item.module_name:''.join(item.stdout_lines |
+                                                select('match', 'version:', ignorecase=True)) |
+                      regex_replace('version:\s*', '')})
+          }}
+      with_items: "{{ builtin_modules }}"
+
+    - name: "Set fact of inbox driver version with its srcversion"
+      set_fact:
+        inbox_drivers_versions: >
+          {{ inbox_drivers_versions |
+             combine({item.module_name:''.join(item.stdout_lines |
+                                                select('match', 'srcversion:', ignorecase=True)) |
+                      regex_replace('srcversion:\s*', '')})
+          }}
+      when: >
+        item.module_name not in inbox_drivers_versions or
+        not inbox_drivers_versions[item.module_name]
+      with_items: "{{ builtin_modules }}"
+
+    - name: "Set fact of inbox driver version with its vermagic"
+      set_fact:
+        inbox_drivers_versions: >
+          {{ inbox_drivers_versions |
+             combine({item.module_name:''.join(item.stdout_lines |
+                                                select('match', 'vermagic:', ignorecase=True)) |
+                      regex_replace('vermagic:\s*', '')})
+          }}
+      when: >
+        item.module_name not in inbox_drivers_versions or
+        not inbox_drivers_versions[item.module_name]
+      with_items: "{{ builtin_modules }}"
+
+    - name: "Initialize fact of inbox driver filename"
+      set_fact:
+        inbox_drivers_filenames: {}
+
+    - name: "Update fact of inbox driver filename"
+      set_fact:
+        inbox_drivers_filenames: >
+          {{ inbox_drivers_filenames |
+             combine({item.module_name:''.join(item.stdout_lines |
+                                                select('match', 'filename:', ignorecase=True)) |
+                      regex_replace('filename:\s*', '')})
+          }}
+      with_items: "{{ builtin_modules }}"
+
+    - name: "Print inbox drivers' filenames"
+      debug: var=inbox_drivers_filenames
+
+    # Photon OS inbox drivers are built in kernel, so here only checks other Linux OS
+    - name: "Check inbox drivers filenames"
+      block:
+         - name: "Check inbox driver's filename is valid"
+           assert:
+             that:
+               - (item.value | basename) is match('.*\.ko')
+             fail_msg: "Invalid inbox driver {{ item.key }} filename: {{ item.value }}"
+           with_dict: "{{ inbox_drivers_filenames }}"
+
+         - name: "Check inbox driver's file exits"
+           stat:
+             path: "{{ item.value }}"
+           delegate_to: "{{ vm_guest_ip }}"
+           with_dict: "{{ inbox_drivers_filenames }}"
+           register: stat_drivers_filenames
+
+         - name: "Check all inbox drivers' filenames exist"
+           assert:
+             that:
+               - stat_driver_filename.stat is defined
+               - stat_driver_filename.stat.exists is defined
+               - stat_driver_filename.stat.exists
+             fail_msg: "Inbox driver file {{ stat_driver_filename.stat.path }} doesn't exist"
+           with_items: "{{ stat_drivers_filenames.results }}"
+           loop_control:
+             loop_var: stat_driver_filename
+      when: guest_os_ansible_distribution != "VMware Photon OS"
+  when: >
+    not (guest_os_ansible_distribution == "VMware Photon OS" and
+    guest_os_ansible_distribution_major_ver | int < 4)
+
+# If the driver is not found in guest OS, set its version to 'N/A'
+- name: "Update fact of inbox driver version dict to set not found driver version with 'N/A'"
+  set_fact:
+    inbox_drivers_versions: >-
+      {{
+        inbox_drivers_versions |
+        combine({module_name: 'N/A'})
+      }}
+  loop: "{{ inbox_drivers | difference(inbox_drivers_versions.keys()) }}"
+  loop_control:
+    loop_var: module_name
+
+- name: "Check all mandatory inbox drivers exists in {{ guest_os_ansible_distribution }}"
+  assert:
+    that:
+      - inbox_drivers_versions[item]
+      - inbox_drivers_versions[item] != 'N/A'
+    fail_msg: "Inbox driver {{ item }} is missing in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+  with_items: "{{ mandatory_drivers }}"
+  when: >
+    not (guest_os_ansible_distribution == "VMware Photon OS" and
+    guest_os_ansible_distribution_major_ver | int >= 4)
+
+# Photon OS 4 inbox driver vmw_balloon doesn't have version information or filename
+- name: "Check all mandatory inbox drivers exists in {{ guest_os_ansible_distribution }}"
+  assert:
+    that:
+      - inbox_drivers_versions[item]
+      - inbox_drivers_versions[item] != 'N/A'
+    fail_msg: "Inbox driver {{ item }} is missing in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+  with_items: "{{ mandatory_drivers | difference(['vmw_balloon']) }}"
+  when:
+    - guest_os_ansible_distribution == "VMware Photon OS"
+    - guest_os_ansible_distribution_major_ver | int >= 4

--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -125,6 +125,23 @@
     # Photon OS inbox drivers are built in kernel, so here only checks other Linux OS
     - name: "Check inbox drivers filenames"
       block:
+        - name: "Do not check vsock driver in OracleLinux with kernel UEK R7 due to known issue"
+          block:
+            - name: "Known issue - ignore failure of invalid vsock driver"
+              debug:
+                msg:
+                  - "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue."
+                  - "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
+              tags:
+                - known_issue
+
+            - name: "Remove vsock from inbox drivers filename checking when OracleLinux with kernel UEK R7"
+              set_fact:
+                inbox_drivers_filenames:  "{{ inbox_drivers_filenames | dict2items | selectattr('key', '!=', 'vsock') | items2dict }}"
+          when:
+            - guest_os_ansible_distribution == "OracleLinux"
+            - guest_os_ansible_kernel == "5.15.0-0.30.19.el9uek.x86_64"
+
          - name: "Check inbox driver's filename is valid"
            assert:
              that:

--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 - name: "Set fact of mandatory and optional inbox drivers"
-  set_fact:
+  ansible.builtin.set_fact:
     mandatory_drivers:
       - vmxnet3
       - vmw_vmci
@@ -16,32 +16,32 @@
       - ptp_vmw
 
 - name: "Update mandatory inbox drivers when guest OS has GUI"
-  set_fact:
+  ansible.builtin.set_fact:
     mandatory_drivers: "{{ mandatory_drivers + ['vmwgfx'] }}"
   when: guest_os_with_gui is defined and guest_os_with_gui | bool
 
 - name: "Update optional inbox drivers when guest OS has no GUI"
-  set_fact:
+  ansible.builtin.set_fact:
     optional_drivers: "{{ optional_drivers + ['vmwgfx'] }}"
   when: guest_os_with_gui is undefined or not (guest_os_with_gui | bool)
 
 - name: "Set fact of all inbox drivers to check"
-  set_fact:
+  ansible.builtin.set_fact:
     inbox_drivers: "{{ mandatory_drivers + optional_drivers }}"
 
 - name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
   block:
     - name: "Check driver version"
-      shell: "if [ -e /sys/module/{{ driver }}/version ]; then cat /sys/module/{{ driver }}/version ; fi"
+      ansible.builtin.shell: "if [ -e /sys/module/{{ driver }}/version ]; then cat /sys/module/{{ driver }}/version ; fi"
       with_items: "{{ inbox_drivers }}"
       loop_control:
         loop_var: driver
       register: photon_drivers
-      no_log: True
+      no_log: true
       delegate_to: "{{ vm_guest_ip }}"
 
     - name: Set fact of driver version dict
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_versions: >-
           {{
             inbox_drivers_versions |
@@ -57,34 +57,34 @@
 - name: "Get drivers version in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
   block:
     - name: "Get module information of inbox drivers"
-      command: "modinfo {{ module_name }}"
+      ansible.builtin.command: "modinfo {{ module_name }}"
       register: modinfo_result
       delegate_to: "{{ vm_guest_ip }}"
-      ignore_errors: True
+      ignore_errors: true
       loop: "{{ inbox_drivers }}"
       loop_control:
         loop_var: module_name
 
     - name: "Set fact of found inbox driver modules"
-      set_fact:
+      ansible.builtin.set_fact:
         builtin_modules: "{{ modinfo_result.results | selectattr('rc', 'equalto', 0) }}"
 
     - name: "Set fact of inbox driver version with its version"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_versions: >
           {{ inbox_drivers_versions |
              combine({item.module_name:''.join(item.stdout_lines |
-                                                select('match', 'version:', ignorecase=True)) |
+                                                select('match', 'version:', ignorecase=true)) |
                       regex_replace('version:\s*', '')})
           }}
       with_items: "{{ builtin_modules }}"
 
     - name: "Set fact of inbox driver version with its srcversion"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_versions: >
           {{ inbox_drivers_versions |
              combine({item.module_name:''.join(item.stdout_lines |
-                                                select('match', 'srcversion:', ignorecase=True)) |
+                                                select('match', 'srcversion:', ignorecase=true)) |
                       regex_replace('srcversion:\s*', '')})
           }}
       when: >
@@ -93,11 +93,11 @@
       with_items: "{{ builtin_modules }}"
 
     - name: "Set fact of inbox driver version with its vermagic"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_versions: >
           {{ inbox_drivers_versions |
              combine({item.module_name:''.join(item.stdout_lines |
-                                                select('match', 'vermagic:', ignorecase=True)) |
+                                                select('match', 'vermagic:', ignorecase=true)) |
                       regex_replace('vermagic:\s*', '')})
           }}
       when: >
@@ -106,21 +106,21 @@
       with_items: "{{ builtin_modules }}"
 
     - name: "Initialize fact of inbox driver filename"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_filenames: {}
 
     - name: "Update fact of inbox driver filename"
-      set_fact:
+      ansible.builtin.set_fact:
         inbox_drivers_filenames: >
           {{ inbox_drivers_filenames |
              combine({item.module_name:''.join(item.stdout_lines |
-                                                select('match', 'filename:', ignorecase=True)) |
+                                                select('match', 'filename:', ignorecase=true)) |
                       regex_replace('filename:\s*', '')})
           }}
       with_items: "{{ builtin_modules }}"
 
     - name: "Print inbox drivers' filenames"
-      debug: var=inbox_drivers_filenames
+      ansible.builtin.debug: var=inbox_drivers_filenames
 
     # Photon OS inbox drivers are built in kernel, so here only checks other Linux OS
     - name: "Check inbox drivers filenames"
@@ -128,7 +128,7 @@
         - name: "Do not check vsock driver in OracleLinux with kernel UEK R7 due to known issue"
           block:
             - name: "Known issue - ignore failure of invalid vsock driver"
-              debug:
+              ansible.builtin.debug:
                 msg:
                   - "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue."
                   - "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
@@ -136,36 +136,40 @@
                 - known_issue
 
             - name: "Remove vsock from inbox drivers filename checking when OracleLinux with kernel UEK R7"
-              set_fact:
-                inbox_drivers_filenames:  "{{ inbox_drivers_filenames | dict2items | selectattr('key', '!=', 'vsock') | items2dict }}"
+              ansible.builtin.set_fact:
+                inbox_drivers_filenames: >
+                  {{ inbox_drivers_filenames |
+                    dict2items |
+                    selectattr('key', '!=', 'vsock') |
+                    items2dict }}
           when:
             - guest_os_ansible_distribution == "OracleLinux"
             - guest_os_ansible_kernel == "5.15.0-0.30.19.el9uek.x86_64"
 
-         - name: "Check inbox driver's filename is valid"
-           assert:
-             that:
-               - (item.value | basename) is match('.*\.ko')
-             fail_msg: "Invalid inbox driver {{ item.key }} filename: {{ item.value }}"
-           with_dict: "{{ inbox_drivers_filenames }}"
+        - name: "Check inbox driver's filename is valid"
+          ansible.builtin.assert:
+            that:
+              - (item.value | basename) is match('.*\.ko')
+            fail_msg: "Invalid inbox driver {{ item.key }} filename: {{ item.value }}"
+          with_dict: "{{ inbox_drivers_filenames }}"
 
-         - name: "Check inbox driver's file exits"
-           stat:
-             path: "{{ item.value }}"
-           delegate_to: "{{ vm_guest_ip }}"
-           with_dict: "{{ inbox_drivers_filenames }}"
-           register: stat_drivers_filenames
+        - name: "Check inbox driver's file exits"
+          stat:
+            path: "{{ item.value }}"
+          delegate_to: "{{ vm_guest_ip }}"
+          with_dict: "{{ inbox_drivers_filenames }}"
+          register: stat_drivers_filenames
 
-         - name: "Check all inbox drivers' filenames exist"
-           assert:
-             that:
-               - stat_driver_filename.stat is defined
-               - stat_driver_filename.stat.exists is defined
-               - stat_driver_filename.stat.exists
-             fail_msg: "Inbox driver file {{ stat_driver_filename.stat.path }} doesn't exist"
-           with_items: "{{ stat_drivers_filenames.results }}"
-           loop_control:
-             loop_var: stat_driver_filename
+        - name: "Check all inbox drivers' filenames exist"
+          ansible.builtin.assert:
+            that:
+              - stat_driver_filename.stat is defined
+              - stat_driver_filename.stat.exists is defined
+              - stat_driver_filename.stat.exists
+            fail_msg: "Inbox driver file {{ stat_driver_filename.stat.path }} doesn't exist"
+          with_items: "{{ stat_drivers_filenames.results }}"
+          loop_control:
+            loop_var: stat_driver_filename
       when: guest_os_ansible_distribution != "VMware Photon OS"
   when: >
     not (guest_os_ansible_distribution == "VMware Photon OS" and
@@ -173,7 +177,7 @@
 
 # If the driver is not found in guest OS, set its version to 'N/A'
 - name: "Update fact of inbox driver version dict to set not found driver version with 'N/A'"
-  set_fact:
+  ansible.builtin.set_fact:
     inbox_drivers_versions: >-
       {{
         inbox_drivers_versions |
@@ -184,7 +188,7 @@
     loop_var: module_name
 
 - name: "Check all mandatory inbox drivers exists in {{ guest_os_ansible_distribution }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - inbox_drivers_versions[item]
       - inbox_drivers_versions[item] != 'N/A'
@@ -196,7 +200,7 @@
 
 # Photon OS 4 inbox driver vmw_balloon doesn't have version information or filename
 - name: "Check all mandatory inbox drivers exists in {{ guest_os_ansible_distribution }}"
-  assert:
+  ansible.builtin.assert:
     that:
       - inbox_drivers_versions[item]
       - inbox_drivers_versions[item] != 'N/A'

--- a/linux/check_inbox_driver/get_os_release.yml
+++ b/linux/check_inbox_driver/get_os_release.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 - name: "Get OS Release for SUSE"
-  set_fact:
+  ansible.builtin.set_fact:
     inbox_drivers_versions: >-
       {{
         inbox_drivers_versions |
@@ -11,12 +11,12 @@
   when: guest_os_ansible_distribution in ['SLES', 'SLED']
 
 - name: "Get OS Release for RHEL"
-  set_fact:
+  ansible.builtin.set_fact:
     inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'Release': 'RHEL ' ~ guest_os_ansible_distribution_ver}) }}"
   when: guest_os_ansible_distribution == "RedHat"
 
 - name: "Get OS Release for {{ guest_os_ansible_distribution }}"
-  set_fact:
+  ansible.builtin.set_fact:
     inbox_drivers_versions: >-
       {{
         inbox_drivers_versions |

--- a/linux/check_inbox_driver/get_os_release.yml
+++ b/linux/check_inbox_driver/get_os_release.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Get OS Release for SUSE"
+  set_fact:
+    inbox_drivers_versions: >-
+      {{
+        inbox_drivers_versions |
+        combine({'Release': 'SLE ' ~ guest_os_ansible_distribution_major_ver ~ ' SP' ~ guest_os_ansible_distribution_minor_ver})
+      }}
+  when: guest_os_ansible_distribution in ['SLES', 'SLED']
+
+- name: "Get OS Release for RHEL"
+  set_fact:
+    inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'Release': 'RHEL ' ~ guest_os_ansible_distribution_ver}) }}"
+  when: guest_os_ansible_distribution == "RedHat"
+
+- name: "Get OS Release for {{ guest_os_ansible_distribution }}"
+  set_fact:
+    inbox_drivers_versions: >-
+      {{
+        inbox_drivers_versions |
+        combine({'Release': guest_os_ansible_distribution ~ ' ' ~ guest_os_ansible_distribution_ver})
+      }}
+  when: guest_os_ansible_distribution not in ['SLES', 'SLED', "RedHat"]

--- a/linux/check_inbox_driver/get_xorg_version.yml
+++ b/linux/check_inbox_driver/get_xorg_version.yml
@@ -1,0 +1,71 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Check whether Xorg server is installed"
+  command: "which Xorg"
+  register: which_xorg_server
+  failed_when: False
+  delegate_to: "{{ vm_guest_ip }}"
+
+- block:
+    - name: "Check Xorg server"
+      command: "Xorg -version"
+      register: xorg_version_result
+      failed_when: False
+      delegate_to: "{{ vm_guest_ip }}"
+
+    - block:
+        - name: "Get Xorg server version"
+          set_fact:
+            xorg_version: "{{ xorg_version_result.stderr_lines | select('match','X.Org X Server') }}"
+
+        - name: "Collect Xorg server version"
+          set_fact:
+             inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xorg server': xorg_version[0].split()[-1] }) }}"
+          when: xorg_version and xorg_version | length > 0
+      when:
+        - xorg_version_result.rc is defined
+        - xorg_version_result.rc == 0
+        - xorg_version_result.stderr_lines is defined
+        - xorg_version_result.stderr_lines | length > 0
+
+    - name: "Initialize VMware video driver package name"
+      set_fact:
+        video_driver_pkg_name: |-
+          {%- if guest_os_family == "RedHat" -%}xorg-x11-drv-vmware
+          {%- elif guest_os_family == "Suse" -%}xf86-video-vmware
+          {%- else -%}{%- endif -%}
+
+    - block:
+        - name: "Looking for VMware video driver package"
+          shell: "dpkg -l xserver-xorg-video-vmware* | grep xserver-xorg-video-vmware"
+          failed_when: False
+          register: vmware_video_package_result
+          delegate_to: "{{ vm_guest_ip }}"
+
+        - name: "Get VMware video driver package name"
+          set_fact:
+            video_driver_pkg_name: "{{ vmware_video_package_result.stdout.split()[1] }}"
+          when:
+            - vmware_video_package_result.rc is defined
+            - vmware_video_package_result.rc == 0
+            - vmware_video_package_result.stdout is defined
+            - vmware_video_package_result.stdout
+      when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
+
+    - block:
+        - include_tasks: ../utils/get_installed_package_info.yml
+          vars:
+            package_name: "{{ video_driver_pkg_name }}"
+
+        - name: "Get the VMware video driver version"
+          set_fact:
+            inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xf86-video-vmware': package_info.Version.split(':')[-1] }) }}"
+          when:
+            - package_info.Version is defined
+            - package_info.Version
+      when: video_driver_pkg_name
+  when:
+    - which_xorg_server is defined
+    - which_xorg_server.rc is defined
+    - which_xorg_server.rc == 0

--- a/linux/check_inbox_driver/get_xorg_version.yml
+++ b/linux/check_inbox_driver/get_xorg_version.yml
@@ -2,26 +2,27 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 - name: "Check whether Xorg server is installed"
-  command: "which Xorg"
+  ansible.builtin.command: "which Xorg"
   register: which_xorg_server
-  failed_when: False
+  changed_when: false
+  failed_when: false
   delegate_to: "{{ vm_guest_ip }}"
 
 - block:
     - name: "Check Xorg server"
-      command: "Xorg -version"
+      ansible.builtin.command: "Xorg -version"
       register: xorg_version_result
-      failed_when: False
+      failed_when: false
       delegate_to: "{{ vm_guest_ip }}"
 
     - block:
         - name: "Get Xorg server version"
-          set_fact:
+          ansible.builtin.set_fact:
             xorg_version: "{{ xorg_version_result.stderr_lines | select('match','X.Org X Server') }}"
 
         - name: "Collect Xorg server version"
-          set_fact:
-             inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xorg server': xorg_version[0].split()[-1] }) }}"
+          ansible.builtin.set_fact:
+            inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xorg server': xorg_version[0].split()[-1] }) }}"
           when: xorg_version and xorg_version | length > 0
       when:
         - xorg_version_result.rc is defined
@@ -30,7 +31,7 @@
         - xorg_version_result.stderr_lines | length > 0
 
     - name: "Initialize VMware video driver package name"
-      set_fact:
+      ansible.builtin.set_fact:
         video_driver_pkg_name: |-
           {%- if guest_os_family == "RedHat" -%}xorg-x11-drv-vmware
           {%- elif guest_os_family == "Suse" -%}xf86-video-vmware
@@ -38,13 +39,13 @@
 
     - block:
         - name: "Looking for VMware video driver package"
-          shell: "dpkg -l xserver-xorg-video-vmware* | grep xserver-xorg-video-vmware"
-          failed_when: False
+          ansible.builtin.shell: "dpkg -l xserver-xorg-video-vmware* | grep xserver-xorg-video-vmware"
+          failed_when: false
           register: vmware_video_package_result
           delegate_to: "{{ vm_guest_ip }}"
 
         - name: "Get VMware video driver package name"
-          set_fact:
+          ansible.builtin.set_fact:
             video_driver_pkg_name: "{{ vmware_video_package_result.stdout.split()[1] }}"
           when:
             - vmware_video_package_result.rc is defined
@@ -59,7 +60,7 @@
             package_name: "{{ video_driver_pkg_name }}"
 
         - name: "Get the VMware video driver version"
-          set_fact:
+          ansible.builtin.set_fact:
             inbox_drivers_versions: "{{ inbox_drivers_versions | combine({'xf86-video-vmware': package_info.Version.split(':')[-1] }) }}"
           when:
             - package_info.Version is defined


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Tested with Oracle Linux 9.0 and failed as expected:
```
[
    {
        "Release": "OracleLinux 9.0",
        "cloud-init": "21.1",
        "kernel": "5.15.0-0.30.19.el9uek.x86_64",
        "open-vm-tools": "11.3.5.31214 (build-18557794)",
        "vmw_balloon": "ECD69D409A352515CC15B45",
        "vmw_pvrdma": "F0092285123462CEC485ECB",
        "vmw_pvscsi": "1.0.7.0-k",
        "vmw_vmci": "1.1.6.0-k",
        "vmw_vsock_virtio_transport_common": "1EEE6DF92F445D52FF1FB8F",
        "vmw_vsock_vmci_transport": "1.0.5.0-k",
        "vmwgfx": "2.19.0.0",
        "vmxnet3": "1.6.0.0-k",
        "vsock": "1.0.2.0-k",
        "xf86-video-vmware": "13.2.1",
        "xorg server": "1.20.11"
    }
]
```

Known issue:
```

TASK [Print inbox drivers' filenames] ******************************************
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:122
ok: [localhost] => {
    "inbox_drivers_filenames": {
        "vmw_balloon": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/misc/vmw_balloon.ko.xz",
        "vmw_pvrdma": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/infiniband/hw/vmw_pvrdma/vmw_pvrdma.ko.xz",
        "vmw_pvscsi": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/scsi/vmw_pvscsi.ko.xz",
        "vmw_vmci": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/misc/vmw_vmci/vmw_vmci.ko.xz",
        "vmw_vsock_virtio_transport_common": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko.xz",
        "vmw_vsock_vmci_transport": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/net/vmw_vsock/vmw_vsock_vmci_transport.ko.xz",
        "vmwgfx": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/gpu/drm/vmwgfx/vmwgfx.ko.xz",
        "vmxnet3": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/net/vmxnet3/vmxnet3.ko.xz",
        "vsock": "(builtin)"
    }
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Known issue - ignore failure of invalid vsock driver] ********************
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:130
ok: [localhost] => {
    "msg": [
        "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue.",
        "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
    ]
}
TAGS: known_issue
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'

TASK [Remove vsock from inbox drivers filename checking when OracleLinux with kernel UEK R7] ***
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:138
ok: [localhost] => {
    "ansible_facts": {
        "inbox_drivers_filenames": {
            "vmw_balloon": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/misc/vmw_balloon.ko.xz",
            "vmw_pvrdma": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/infiniband/hw/vmw_pvrdma/vmw_pvrdma.ko.xz",
            "vmw_pvscsi": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/scsi/vmw_pvscsi.ko.xz",
            "vmw_vmci": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/misc/vmw_vmci/vmw_vmci.ko.xz",
            "vmw_vsock_virtio_transport_common": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko.xz",
            "vmw_vsock_vmci_transport": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/net/vmw_vsock/vmw_vsock_vmci_transport.ko.xz",
            "vmwgfx": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/gpu/drm/vmwgfx/vmwgfx.ko.xz",
            "vmxnet3": "/lib/modules/5.15.0-0.30.19.el9uek.x86_64/kernel/drivers/net/vmxnet3/vmxnet3.ko.xz"
        }
    },
    "changed": false
}
```

```
2022-08-15 05:25:46,015 | Known Issue in Play [check_inbox_driver] *******************

2022-08-15 05:25:46,015 | TASK [check_inbox_driver][Known issue - ignore failure of invalid vsock driver] 
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:130
ok: [localhost] => {
    "msg": [
        "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue.",
        "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
    ]
}
```

```
+--------------------------------------------------------------------------+
| Guest OS Distribution     | OracleLinux 9.0 x86_64                       |
+--------------------------------------------------------------------------+
| VMTools Version           | 11.3.5 (build-18557794)                      |
+--------------------------------------------------------------------------+
| CloudInit Version         | 21.1                                         |
+--------------------------------------------------------------------------+
| GUI Installed             | True                                         |
+--------------------------------------------------------------------------+
| Config Guest Id           | oracleLinux9_64Guest                         |
+--------------------------------------------------------------------------+
| GuestInfo Guest Id        | oracleLinux9_64Guest                         |
+--------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Oracle Linux 9 (64-bit)                      |
+--------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                   |
+--------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                           |
|                           | bitness='64'                                 |
|                           | distroName='Oracle Linux Server'             |
|                           | distroVersion='9.0'                          |
|                           | familyName='Linux'                           |
|                           | kernelVersion='5.15.0-0.30.19.el9uek.x86_64' |
|                           | prettyName='Oracle Linux Server 9.0'         |
+--------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:02:01)
+-----------------------------------------+
| Name               | Status | Exec Time |
+-----------------------------------------+
| check_inbox_driver | Passed | 00:01:38  |
+-----------------------------------------+
```