### PR TITLE
Update Rocky Linux guest OS fullname mapping

### DIFF
--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -59,7 +59,9 @@
 
         # Map Other Linux
         - include_tasks: otherlinux_fullname_map.yml
-          when: guest_os_ansible_distribution not in ["RedHat", "SLES", "SLED", "CentOS", "OracleLinux", "Ubuntu", "Debian", "Amazon", "VMware Photon OS", "FreeBSD", "AlmaLinux", "Rocky"]
+          when:
+            - guest_os_ansible_distribution not in ["RedHat", "CentOS", "OracleLinux", "AlmaLinux", "Rocky", "Amazon"]
+            - guest_os_ansible_distribution not in ["SLES", "SLED", "Ubuntu", "Debian", "VMware Photon OS", "FreeBSD"]
 
         # Validate guest OS fullname in guestinfo
         - include_tasks: validate_os_fullname.yml

--- a/linux/check_os_fullname/rocky_fullname_map.yml
+++ b/linux/check_os_fullname/rocky_fullname_map.yml
@@ -1,17 +1,40 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Map Rocky Linux when ESXi version > 7.0.3 and VMware Tools version > 11.3.0
-- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 later and VMTools 11.3.0 later"
+# Map Rocky Linux when ESXi version > 7.0.3 and VMware Tools version >= 12.0.0
+- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 later and VMTools 12.0.0 or later"
   ansible.builtin.set_fact:
     guest_fullname: "Rocky Linux ({{ guest_os_bit }})"
   when:
     - esxi_version is version('7.0.3', '>')
-    - vmtools_version is version('11.3.0', '>')
+    - vmtools_version is version('12.0.0', '>=')
 
-# Map Rocky Linux when ESXi version <= 7.0.3 or VMware Tools version <= 11.3.0
-- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 and earlier, or VMTools 11.3.0 and earlier"
+- name: "Check Rocky Linux open-vm-tools version"
+  block:
+    - include_tasks: ../utils/get_installed_package_info.yml
+      vars:
+        package_name: "open-vm-tools"
+
+    - name: "Ignore known issue about Rocky Linux guest fullname"
+      block:
+        - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
+          ansible.builtin.debug:
+            msg:
+              - "The guest fullname get by Rocky Linux built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect. Ignore this known issue."
+          tags:
+            - known_issue
+
+        - meta: end_host
+      when:
+        - package_info is defined
+        - package_info.Release is defined
+        - package_info.Release == "1.el8" or package_info.Release == "1.el9"
+        - package_info.Vendor is defined and 'Rocky' in package_info.Vendor
+  when: vmtools_version is version('11.3.5', '=')
+
+# Map Rocky Linux when ESXi version <= 7.0.3 or VMware Tools version <= 11.3.5 (not built-in 11.3.5)
+- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 and earlier, or VMTools 11.3.5 or earlier"
   include_tasks: otherlinux_fullname_map.yml
   when: >
     esxi_version is version('7.0.3', '<=') or
-    vmtools_version is version('11.3.0', '<=')
+    vmtools_version is version('11.3.5', '<=')

--- a/linux/check_os_fullname/rocky_fullname_map.yml
+++ b/linux/check_os_fullname/rocky_fullname_map.yml
@@ -16,24 +16,3 @@
     esxi_version is version('7.0.3', '<=') or
     vmtools_version is version('12.0.0', '<')
 
-- name: "Ignore known issue about Rocky Linux guest fullname"
-  block:
-    - include_tasks: ../utils/get_installed_package_info.yml
-      vars:
-        package_name: "open-vm-tools"
-
-    - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
-      ansible.builtin.debug:
-        msg:
-          - "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect, which is always same as VM's guest OS version."
-          - "The expected guest fullname should be {{ ', or '.join(guest_fullname) }}. Ignore this known issue."
-          - "Please refer to https://github.com/rocky-linux/rockylinux.org/issues/422"
-      tags:
-        - known_issue
-      when:
-        - package_info is defined
-        - package_info.Release is defined
-        - package_info.Release == "1.el8" or package_info.Release == "1.el9"
-        - package_info.Vendor is defined and 'Rocky' in package_info.Vendor
-  when: vmtools_version is version('11.3.5', '=')
-

--- a/linux/check_os_fullname/rocky_fullname_map.yml
+++ b/linux/check_os_fullname/rocky_fullname_map.yml
@@ -9,22 +9,27 @@
     - esxi_version is version('7.0.3', '>')
     - vmtools_version is version('12.0.0', '>=')
 
-- name: "Check Rocky Linux open-vm-tools version"
+# Map Rocky Linux when ESXi version <= 7.0.3 or VMware Tools version < 12.0.0
+- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 and earlier, or VMTools 12.0.0 earlier"
+  include_tasks: otherlinux_fullname_map.yml
+  when: >
+    esxi_version is version('7.0.3', '<=') or
+    vmtools_version is version('12.0.0', '<')
+
+- name: "Ignore known issue about Rocky Linux guest fullname"
   block:
     - include_tasks: ../utils/get_installed_package_info.yml
       vars:
         package_name: "open-vm-tools"
 
-    - name: "Ignore known issue about Rocky Linux guest fullname"
-      block:
-        - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
-          ansible.builtin.debug:
-            msg:
-              - "The guest fullname get by Rocky Linux built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect. Ignore this known issue."
-          tags:
-            - known_issue
-
-        - meta: end_host
+    - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
+      ansible.builtin.debug:
+        msg:
+          - "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect, which is always same as VM's guest OS version."
+          - "The expected guest fullname should be {{ ', or '.join(guest_fullname) }}. Ignore this known issue."
+          - "Please refer to https://github.com/rocky-linux/rockylinux.org/issues/422"
+      tags:
+        - known_issue
       when:
         - package_info is defined
         - package_info.Release is defined
@@ -32,9 +37,3 @@
         - package_info.Vendor is defined and 'Rocky' in package_info.Vendor
   when: vmtools_version is version('11.3.5', '=')
 
-# Map Rocky Linux when ESXi version <= 7.0.3 or VMware Tools version <= 11.3.5 (not built-in 11.3.5)
-- name: "Set guest_fullname variable for Rocky Linux on ESXi 7.0.3 and earlier, or VMTools 11.3.5 or earlier"
-  include_tasks: otherlinux_fullname_map.yml
-  when: >
-    esxi_version is version('7.0.3', '<=') or
-    vmtools_version is version('11.3.5', '<=')

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -20,6 +20,29 @@
       - guestinfo_guest_id
     fail_msg: "Guest ID in guest info is '{{ guestinfo_guest_id }}', which should be a valid value firstly."
 
+- name: "Known issue about Rocky Linux guest fullname"
+  block:
+    - include_tasks: ../utils/get_installed_package_info.yml
+      vars:
+        package_name: "open-vm-tools"
+
+    - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
+      ansible.builtin.debug:
+        msg:
+          - "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect, which is always same as VM's guest OS version."
+          - "The expected guest fullname should be {{ ', or '.join(guest_fullname) }}. Ignore this known issue."
+          - "Please refer to https://github.com/rocky-linux/rockylinux.org/issues/422"
+      tags:
+        - known_issue
+      when:
+        - package_info is defined
+        - package_info.Release is defined
+        - package_info.Release == "1.el8" or package_info.Release == "1.el9"
+        - package_info.Vendor is defined and 'Rocky' in package_info.Vendor
+  when:
+    - guest_os_ansible_distribution == 'Rocky'
+    - vmtools_version is version('11.3.5', '=')
+
 - block:
     - name: "Assert Guest OS fullname is either {{ guest_fullname[0] }} or {{ guest_fullname[1] }}"
       ansible.builtin.assert:

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -6,9 +6,8 @@
 
 # If the guest os full name is unmapped and displays OS detailed data, test passed
 - block:
-    - ansible.builtin.debug:
-        msg: "guest OS detailed information is shown in guest OS full name, test passed"
-    - ansible.builtin.meta: end_host
+    - name: "guest OS detailed information is shown in guest OS full name, test passed"
+      ansible.builtin.meta: end_host
   when:
     - (esxi_version is version('6.7.0', '==') and (esxi_update_version | int < 2)) or (esxi_version is version('7.0.0', '=='))
     - unmapped_os_fullname is defined and unmapped_os_fullname
@@ -29,9 +28,9 @@
     - name: "Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5"
       ansible.builtin.debug:
         msg:
-          - "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-{{ package_info.Release }} is incorrect, which is always same as VM's guest OS version."
+          - "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-{{ package_info.Release }} is always same as VM's guest OS version."
           - "The expected guest fullname should be {{ ', or '.join(guest_fullname) }}. Ignore this known issue."
-          - "Please refer to https://github.com/rocky-linux/rockylinux.org/issues/422"
+          - "Please refer to https://bugs.rockylinux.org/view.php?id=200"
       tags:
         - known_issue
       when:


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Rocky Linux built-in open-vm-tools 11.3.5-1.el8 or 11.3.5-1.el9 can't well recognize the guest full name as Other 4.x Linux (64-bit) or Other 5.x Linux (64-bit). They modified open-vm-tools source code which leads unexpected behavior at recognizing guest full name. The guest full name is always same as guest OS version selection in VM's settings.

It requires Rocky Linux fix it in their own open-vm-tools 11.3.5

In this fix, the test case will fail if the guest full name is not Other N.x Linux (64-bit) when Rocky Linux has built-in OVT 11.3.5, but a known_issue is been tagged, so that user can identify it easily.
```
2022-08-18 08:34:40,018 | Known Issue in Play [check_os_fullname] ********************

2022-08-18 08:34:40,018 | TASK [check_os_fullname][Known issue - ignore incorrect guest fullname with Rocky Linux built-in OVT 11.3.5] 
task path: /home/worker/workspace/Ansible_Regression_RockyLinux_9.x/ansible-vsphere-gos-validation/linux/check_os_fullname/validate_os_fullname.yml:28
ok: [localhost] => {
    "msg": [
        "The guest fullname of Rocky Linux with built-in open-vm-tools 11.3.5-1.el9 is always same as VM's guest OS version.",
        "The expected guest fullname should be Other 5.x or later Linux (64-bit), or Other 5.x Linux (64-bit). Ignore this known issue.",
        "Please refer to https://bugs.rockylinux.org/view.php?id=200"
    ]
}

+-------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                          |
|                           | bitness='64'                                |
|                           | distroName='Rocky Linux'                    |
|                           | distroVersion='9.0'                         |
|                           | familyName='Linux'                          |
|                           | kernelVersion='5.14.0-70.13.1.el9_0.x86_64' |
|                           | prettyName='Rocky Linux 9.0 (Blue Onyx)'    |
+-------------------------------------------------------------------------+


Test Results (Total: 1, Failed: 1, Elapsed Time: 00:01:55)
+------------------------------------------+
| Name              |   Status | Exec Time |
+------------------------------------------+
| check_os_fullname | * Failed | 00:01:08  |
+------------------------------------------+
```