### PR TITLE
Fail check_inbox_driver for Oracle Linux 9.0 with UEK R7 with known issue

### DIFF
--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -134,14 +134,6 @@
                   - "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
               tags:
                 - known_issue
-
-            - name: "Remove vsock from inbox drivers filename checking when OracleLinux with kernel UEK R7"
-              ansible.builtin.set_fact:
-                inbox_drivers_filenames: >
-                  {{ inbox_drivers_filenames |
-                    dict2items |
-                    selectattr('key', '!=', 'vsock') |
-                    items2dict }}
           when:
             - guest_os_ansible_distribution == "OracleLinux"
             - guest_os_ansible_kernel == "5.15.0-0.30.19.el9uek.x86_64"


### PR DESCRIPTION
Check_inbox_driver should still fail until it's been fixed, so that we can keep tracking it. With the known_issues.log, users can identify it is a known issue, not a new issue.

Signed-off-by: Qi Zhang <qiz@vmware.com>

```
2022-08-19 04:13:20,019 | Failed at Play [check_inbox_driver] ************************

2022-08-19 04:13:20,019 | TASK [check_inbox_driver][Check inbox driver's filename is valid] 
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:141
failed: [localhost] => (item={'key': 'vsock', 'value': '(builtin)'}) => {
    "ansible_loop_var": "item",
    "assertion": "(item.value | basename) is match('.*\\.ko')",
    "changed": false,
    "evaluated_to": false,
    "item": {
        "key": "vsock",
        "value": "(builtin)"
    },
    "msg": "Invalid inbox driver vsock filename: (builtin)"
}

```
```

2022-08-19 04:13:20,019 | Known Issue in Play [check_inbox_driver] *******************

2022-08-19 04:13:20,019 | TASK [check_inbox_driver][Known issue - ignore failure of invalid vsock driver] 
task path: /home/worker/workspace/Ansible_Regression_OracleLinux_9.x/ansible-vsphere-gos-validation/linux/check_inbox_driver/get_inbox_drivers.yml:130
ok: [localhost] => {
    "msg": [
        "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue.",
        "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
    ]
}
```