### PR TITLE
Fix Ubuntu sshd service name for setting TCPKeepAlive

### DIFF
--- a/common/vm_wait_expected_snapshot.yml
+++ b/common/vm_wait_expected_snapshot.yml
@@ -7,7 +7,7 @@
 #   expected_snapshot_wait_time (optional): the time in seconds to wait for
 #     expected snapshot, default value is 30.
 #
-- name: "Get snapshot facts until current is '{{ snapshot_name }}'"
+- name: "Get snapshot facts until current is '{{ expected_snapshot_name }}'"
   community.vmware.vmware_guest_snapshot_info:
     hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"

--- a/linux/utils/ssh_keep_alive.yml
+++ b/linux/utils/ssh_keep_alive.yml
@@ -28,27 +28,16 @@
       vars:
         service_name: "sshd"
 
-    - name: "Found {{ service_info.name }}, update sshd service info with it"
-      ansible.builtin.set_fact:
-        sshd_service_info: "{{ service_info }}"
-      when:
-        - service_info
-        - service_info.name is defined
-        - service_info.name
-        - service_info.state is defined
-        - service_info.state == "running"
-
     - name: "Not found sshd service, try to get ssh service info"
       include_tasks: get_service_info.yml
       vars:
         service_name: "ssh"
       when: >
-        service_info is undefined or
         not service_info or
         service_info.name is undefined or
         not service_info.name or
         service_info.state is undefined or
-        service_info.state != "running"
+        service_info.state != "running" 
 
     - name: "Found {{ service_info.name }}, update sshd service info with it"
       ansible.builtin.set_fact:
@@ -64,10 +53,6 @@
       assert:
         that:
           - sshd_service_info
-          - sshd_service_info.name is defined
-          - sshd_service_info.name
-          - service_info.state is defined
-          - service_info.state == "running"
         fail_msg: "Failed to find sshd or ssh service in guest OS"
 
     - name: "Restart {{ sshd_service_info.name }}"

--- a/linux/utils/ssh_keep_alive.yml
+++ b/linux/utils/ssh_keep_alive.yml
@@ -42,6 +42,13 @@
       include_tasks: get_service_info.yml
       vars:
         service_name: "ssh"
+      when: >
+        service_info is undefined or
+        not service_info or
+        service_info.name is undefined or
+        not service_info.name or
+        service_info.state is undefined or
+        service_info.state != "running"
 
     - name: "Found {{ service_info.name }}, update sshd service info with it"
       ansible.builtin.set_fact:
@@ -53,7 +60,7 @@
         - service_info.state is defined
         - service_info.state == "running"
 
-    - name: "Check sshd service exists"
+    - name: "Check sshd or ssh service exists"
       assert:
         that:
           - sshd_service_info

--- a/linux/utils/ssh_keep_alive.yml
+++ b/linux/utils/ssh_keep_alive.yml
@@ -1,21 +1,78 @@
 # Copyright 2021-2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+- name: "Initialize sshd service info and config file"
+  ansible.builtin.set_fact:
+    sshd_service_info: ""
+    sshd_config_file: "/etc/ssh/sshd_config"
+
+- name: "Check sshd configure file status"
+  ansible.builtin.stat:
+    path: "{{ sshd_config_file }}"
+  register: sshd_config_stat_result
+  delegate_to: "{{ vm_guest_ip }}"
+
 # Modify sshd config to keep connection alive
-- name: Set TCPKeepAlive=yes in /etc/ssh/sshd_config
-  ansible.builtin.replace:
-    path: /etc/ssh/sshd_config
-    regexp: "^#?TCPKeepAlive .*"
-    replace: "TCPKeepAlive yes"
-  register: replacement
-  delegate_to: "{{ vm_guest_ip }}"
+- name: "Modify sshd config to keep connection alive"
+  block:
+    - name: "Set TCPKeepAlive=yes in /etc/ssh/sshd_config"
+      ansible.builtin.replace:
+        path: "{{ sshd_config_file }}"
+        regexp: "^#?TCPKeepAlive .*"
+        replace: "TCPKeepAlive yes"
+      register: replacement
+      delegate_to: "{{ vm_guest_ip }}"
 
-- name: "Restart sshd service"
-  ansible.builtin.service:
-    name: sshd
-    state: restarted
-  register: restart_sshd_result
-  delegate_to: "{{ vm_guest_ip }}"
+    - name: "Get sshd service info"
+      include_tasks: get_service_info.yml
+      vars:
+        service_name: "sshd"
 
-- name: "Service restart result"
-  ansible.builtin.debug: var=restart_sshd_result
+    - name: "Found {{ service_info.name }}, update sshd service info with it"
+      ansible.builtin.set_fact:
+        sshd_service_info: "{{ service_info }}"
+      when:
+        - service_info
+        - service_info.name is defined
+        - service_info.name
+        - service_info.state is defined
+        - service_info.state == "running"
+
+    - name: "Not found sshd service, try to get ssh service info"
+      include_tasks: get_service_info.yml
+      vars:
+        service_name: "ssh"
+
+    - name: "Found {{ service_info.name }}, update sshd service info with it"
+      ansible.builtin.set_fact:
+        sshd_service_info: "{{ service_info }}"
+      when:
+        - service_info
+        - service_info.name is defined
+        - service_info.name
+        - service_info.state is defined
+        - service_info.state == "running"
+
+    - name: "Check sshd service exists"
+      assert:
+        that:
+          - sshd_service_info
+          - sshd_service_info.name is defined
+          - sshd_service_info.name
+          - service_info.state is defined
+          - service_info.state == "running"
+        fail_msg: "Failed to find sshd or ssh service in guest OS"
+
+    - name: "Restart {{ sshd_service_info.name }}"
+      ansible.builtin.service:
+        name: "{{ sshd_service_info.name }}"
+        state: restarted
+      register: restart_sshd_result
+      delegate_to: "{{ vm_guest_ip }}"
+
+    - name: "Print {{ sshd_service_info.name }} restart result"
+      ansible.builtin.debug: var=restart_sshd_result
+  when:
+    - sshd_config_stat_result is defined
+    - sshd_config_stat_result.stat is defined
+    - sshd_config_stat_result.stat.exists | default(false)

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -31,7 +31,7 @@
 # Rescan SCSI bus when hot adding/removing LSILogic disk
 - name: "Handle LSILogic disk"
   block:
-    - name: "Rescan in guest expect Flatcar and Ubuntu 22.04"
+    - name: "Rescan scsi devices in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
       block:
         - name: "Rescan all scsi devices"
           ansible.builtin.command: "/usr/bin/rescan-scsi-bus.sh -a -r"
@@ -45,9 +45,10 @@
             - rescan_scsi_result.stdout_lines
       when:
         - "'Flatcar' not in guest_os_ansible_distribution"
-        - not (guest_os_ansible_distribution == "Ubuntu" and guest_os_ansible_distribution_ver == "22.04")
+        - not (guest_os_ansible_distribution == "Ubuntu" and
+               guest_os_ansible_distribution_major_ver == "22")
 
-    - name: "Rescan in guest for Flatcar and Ubuntu 22.04"
+    - name: "Rescan scsi devices in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
       block:
         - name: "Rescan all hard disks"
           ansible.builtin.shell: |
@@ -81,7 +82,7 @@
       when: >
         ('Flatcar' in guest_os_ansible_distribution or
          (guest_os_ansible_distribution == "Ubuntu" and
-          guest_os_ansible_distribution_ver == "22.04"))
+          guest_os_ansible_distribution_major_ver == "22"))
   when: new_disk_ctrl_type == 'lsilogic'
 
 - name: "Handle NVMe disk"


### PR DESCRIPTION
Ubuntu 22.10 changed sshd service name to ssh.service not sshd.service any more. This fix checked sshd.service existence firstly. If it doesn't exist, check ssh.service, and then use the existing one  to restart sshd service.
Besides, lsilogic_vhba_device_ops still fails with Ubuntu 22.10, so change the SCSI rescan method for both 22.04 and 22.10.