### PR TITLE
[Windows] Add enable VBS when creating new VM

### DIFF
--- a/vars/test.yml
+++ b/vars/test.yml
@@ -158,8 +158,7 @@ vm_deploy_method: "iso"
 #
 datastore: "test-ds"
 
-# This parameter is required when 'new_vm' is set to true in Windows test case and
-# 'vm_deploy_method' is set to 'iso' in Linux test case.
+# This parameter is required when 'new_vm' is set to true and 'vm_deploy_method' is set to 'iso'.
 # For guest ID, please refer to:
 # https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
 # For Linux testing, when 'new_vm' is set to true and 'vm_deploy_method' is set to 'ova', if this
@@ -173,8 +172,7 @@ datastore: "test-ds"
 #
 guest_id: "centos8_64Guest"
 
-# Set below parameters when 'new_vm' is true in Windows testing and 'vm_deploy_method' is set
-# to 'iso' in Linux testing.
+# Set below parameters when 'new_vm' is true and 'vm_deploy_method' is set to 'iso'.
 secureboot_enabled: false
 memory_mb: 4096
 cpu_number: 2
@@ -193,6 +191,8 @@ cdrom_controller_type: "sata"
 # vm_network_name: "VM Network"
 # Add a virtual TPM device when creating new VM, default is false.
 virtual_tpm: false
+# For Windows only, to enable Virtualization Based Security when deploying a new Windows VM.
+enable_vbs: true
 
 # For adding virtual TPM device on VM, key provider must be configured on vCenter.
 # If key provider is already configured in your test environment, then no need to set these parameters.

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -192,7 +192,7 @@ cdrom_controller_type: "sata"
 # Add a virtual TPM device when creating new VM, default is false.
 virtual_tpm: false
 # For Windows only, to enable Virtualization Based Security when deploying a new Windows VM.
-enable_vbs: true
+enable_vbs: false
 
 # For adding virtual TPM device on VM, key provider must be configured on vCenter.
 # If key provider is already configured in your test environment, then no need to set these parameters.

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -109,4 +109,18 @@
   ansible.builtin.pause:
     minutes: 1
 - include_tasks: ../utils/add_windows_host.yml
+
+- name: "Enable VBS in guest OS"
+  block:
+    - include_tasks: ../utils/win_enable_vbs_guest.yml
+    # Get VBS status in guest OS
+    - include_tasks: ../utils/win_get_vbs_guest.yml
+    - name: "Check VBS and running security service status"
+      ansible.builtin.assert:
+        that:
+          - win_vbs_status_guest | int == 2
+          - "'2' in win_vbs_running_service"
+        fail_msg: "VBS is not running '{{ win_vbs_status_guest }}', or HVCI is not running '{{ win_vbs_running_service }}'."
+  when: enable_vbs is defined and enable_vbs | bool
+
 - include_tasks: detach_cdrom_iso.yml

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -45,17 +45,26 @@
     vm_exists: true
 
 # When firmware is EFI, configure force EFI setup once
-- block:
-    # Add virtual TPM device
-    - include_tasks: ../../common/vm_add_vtpm_device.yml
-      vars:
-        vc_cert_path: "{{ current_test_log_folder }}"
-      when: virtual_tpm is defined and virtual_tpm | bool
-    # Enable secureboot
-    - include_tasks: ../../common/vm_set_boot_options.yml
-      vars:
-        secure_boot_enabled_set: "{{ secureboot_enabled | default(false) }}"
-        enter_bios_setup: true
+- name: "Handle VM with EFI firmware"
+  block:
+    - name: "Set features on 64bit VM"
+      block:
+        # Add virtual TPM device
+        - include_tasks: ../../common/vm_add_vtpm_device.yml
+          vars:
+            vc_cert_path: "{{ current_test_log_folder }}"
+          when: virtual_tpm is defined and virtual_tpm | bool
+        # Enable secureboot
+        - include_tasks: ../../common/vm_set_boot_options.yml
+          vars:
+            secure_boot_enabled_set: "{{ secureboot_enabled | default(false) }}"
+            enter_bios_setup: true
+        # Enable VBS
+        - include_tasks: ../utils/win_enable_vbs_vm.yml
+          vars:
+            win_enable_vbs: true
+          when: enable_vbs is defined and enable_vbs | bool
+      when: guest_id is defined and "'64' in guest_id"
     - include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"

--- a/windows/vbs_enable_disable/vbs_enable_test.yml
+++ b/windows/vbs_enable_disable/vbs_enable_test.yml
@@ -1,13 +1,18 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check VM VBS status
-- include_tasks: ../../common/vm_get_vbs_status.yml
-- name: "Set fact of VM VBS current status before testing"
+- name: "Initialize the VBS status of VM and VBS status in guest OS"
   ansible.builtin.set_fact:
-    vm_vbs_status_before: "{{ vm_vbs_enabled | default(false) }}"
+    vm_vbs_enabled_before: false
+    guest_vbs_enabled_before: false
 
-- name: "VM VBS not enabled"
+# Get VM VBS status before enable
+- include_tasks: ../../common/vm_get_vbs_status.yml
+- name: "Set fact of VM VBS current status before enable"
+  ansible.builtin.set_fact:
+    vm_vbs_enabled_before: "{{ vm_vbs_enabled }}"
+
+- name: "VM VBS is not enabled"
   block:
     # Shutdown guest OS before enabling VBS on VM
     - include_tasks: ../utils/win_shutdown_restart.yml
@@ -29,13 +34,26 @@
           - vm_vbs_enabled is defined
           - vm_vbs_enabled | bool
         fail_msg: "VM VBS status is not enabled after enabling it."
-  when: not vm_vbs_status_before
+  when: not vm_vbs_enabled_before
 
-# Enable VBS in guest OS
-- include_tasks: ../utils/win_enable_vbs_guest.yml
+- name: "VM VBS is enabled"
+  block:
+    # Get VBS status in guest OS
+    - include_tasks: ../utils/win_get_vbs_guest.yml
+    - name: "Set fact of HVCI and VBS running status in guest before enable"
+      ansible.builtin.set_fact:
+        guest_vbs_enabled_before: true
+      when:
+        - win_vbs_status_guest | int == 2
+        - "'2' in win_vbs_running_service"
+  when: vm_vbs_enabled_before
 
-# Get VBS status in guest OS
-- include_tasks: ../utils/win_get_vbs_guest.yml
+# Enable VBS in guest OS if HVCI is not running or VBS is not running
+- name: "Enable VBS in guest OS"
+  block:
+    - include_tasks: ../utils/win_enable_vbs_guest.yml
+    - include_tasks: ../utils/win_get_vbs_guest.yml
+  when: not guest_vbs_enabled_before
 
 # SecurityServicesRunning: 2 means HVCI is running
 # VirtualizationBasedSecurityStatus: 2 means VBS is enabled and running


### PR DESCRIPTION
Signed-off-by: Diane Wang <dianew@vmware.com>

1. add a new parameter `enable_vbs` in vars/test.yml.
2. user can set this parameter if want to enable VBS when creating a new Windows VM.
3. VBS is also enabled in guest OS after OS is installed.