### PR TITLE
[Linux] Upgrade OracleLinux 9.0 to latest UEK kernel

### DIFF
--- a/autoinstall/RHEL/8/server_without_GUI/ks.cfg
+++ b/autoinstall/RHEL/8/server_without_GUI/ks.cfg
@@ -53,8 +53,6 @@ java-1.8.0-openjdk
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 %end
 
-syspurpose --role="Red Hat Enterprise Linux Server" --sla="Premium" --usage="Production"
-
 %anaconda
 pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
 pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok

--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -130,7 +130,8 @@
             - name: "Known issue - ignore failure of invalid vsock driver"
               ansible.builtin.debug:
                 msg:
-                  - "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7. Ignore this known issue."
+                  - "The inbox driver vsock is missing in Oracle Linux 9.0 with kernel UEK R7 V5.15.0-0.30.19."
+                  - "The issue has been resolved in UEK R7 V5.15.0-2.52.3. Please upgrade to latest UEK R7 for resolution."
                   - "Please refer to https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884"
               tags:
                 - known_issue

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -147,7 +147,8 @@
       vars:
         vm_wait_log_name: "{{ vm_serial_port_output_file | basename }}"
         vm_wait_log_msg: "{{ autoinstall_complete_msg }}"
-        vm_wait_log_retries: 720
+        vm_wait_log_delay: 30
+        vm_wait_log_retries: 120
 
     - name: "Wait 60s for OS rebooting"
       ansible.builtin.pause:
@@ -193,6 +194,35 @@
         - transferred_unattend_iso is defined
         - transferred_unattend_iso
 
+    - name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
+      block:
+        - include_tasks: ../../common/vm_take_snapshot.yml
+          vars:
+            snapshot_name: "OL_9.0GA_UEK"
+
+        - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
+          ansible.builtin.set_fact:
+            ol9_uekr7_is_upgraded: false
+            ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
+
+        - include_tasks: ../utils/add_official_online_repo.yml
+        - name: "Update Oracle Linux 9.0 to latest UEK R7"
+          ansible.builtin.shell: "yum update --nogpgcheck -y"
+          register: ol9_uekr7_upgrade_result
+          delegate_to: "{{ vm_guest_ip }}"
+
+        - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
+          ansible.builtin.set_fact:
+            ol9_uekr7_is_upgraded: true
+          when:
+            - ol9_uekr7_upgrade_result is defined
+            - ol9_uekr7_upgrade_result.rc is defined
+            - ol9_uekr7_upgrade_result.rc == 0
+      when:
+        - guest_os_ansible_distribution == "OracleLinux"
+        - guest_os_ansible_distribution_ver == "9.0"
+        - "'uek' in guest_os_ansible_kernel"
+
     # Remove serial port
     - include_tasks: ../utils/shutdown.yml
 
@@ -217,6 +247,30 @@
     - include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'
+    
+    - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
+      block:
+        - include_tasks: ../../common/update_inventory.yml
+
+        # Refresh guest system info
+        - include_tasks: ../utils/get_linux_system_info.yml
+
+        - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
+          ansible.builtin.set_fact:
+            ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
+
+        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
+          ansible.builtin.assert:
+            that:
+              - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
+            fail_msg: >-
+              Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
+              version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
+              version is '{{ ol9_uekr7_after_upgrade }}'.
+      when:
+        - ol9_uekr7_is_upgraded is defined
+        - ol9_uekr7_is_upgraded
+
   rescue:
     # Collect cloud-init logs for Ubuntu
     - include_tasks: ../../common/vm_get_power_state.yml

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -104,30 +104,42 @@
   when: guest_os_ansible_distribution in ["CentOS", "Rocky"]
 
 - block:
-    - name: "Set default online repository for OracleLinux {{ guest_os_ansible_distribution_ver }}"
+    - name: "Set Oracle Linux online repository website"
       ansible.builtin.set_fact:
-        online_repos:
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_u{{ guest_os_ansible_distribution_minor_ver }}_base"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL7/{{ guest_os_ansible_distribution_minor_ver | int }}/base/$basearch/"
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR3"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL7/UEKR3/$basearch/"
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR4"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL7/UEKR4/$basearch/"
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR5"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL7/UEKR5/$basearch/"
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR6"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL7/UEKR6/$basearch/"
-      when: guest_os_ansible_distribution_major_ver | int < 8
+        oraclelinux_repo_url: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL{{ guest_os_ansible_distribution_major_ver }}"
 
     - name: "Set default online repository for OracleLinux {{ guest_os_ansible_distribution_ver }}"
       ansible.builtin.set_fact:
         online_repos:
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_u{{ guest_os_ansible_distribution_minor_ver }}_BaseOS"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL8/{{ guest_os_ansible_distribution_minor_ver | int }}/baseos/base//$basearch/"
-          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_AppStream"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL8/appstream/$basearch/"
+          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_u{{ guest_os_ansible_distribution_minor_ver }}_base"
+            baseurl: "{{ oraclelinux_repo_url }}/{{ guest_os_ansible_distribution_minor_ver | int }}/base/$basearch/"
+          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR3"
+            baseurl: "{{ oraclelinux_repo_url }}/UEKR3/$basearch/"
+          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR4"
+            baseurl: "{{ oraclelinux_repo_url }}/UEKR4/$basearch/"
+          - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR5"
+            baseurl: "{{ oraclelinux_repo_url }}/UEKR5/$basearch/"
           - name: "ol{{ guest_os_ansible_distribution_major_ver }}_UEKR6"
-            baseurl: "https://yum$ociregion.oracle.com/repo/OracleLinux/OL8/UEKR6/$basearch/"
+            baseurl: "{{ oraclelinux_repo_url }}/UEKR6/$basearch/"
+      when: guest_os_ansible_distribution_major_ver | int == 7
+
+    - name: "Set default online repository for OracleLinux {{ guest_os_ansible_distribution_ver }}"
+      block:
+        - name: "Set default UEK release packaged in OracleLinux {{ guest_os_ansible_distribution_ver }}"
+          ansible.builtin.set_fact:
+            oraclelinux_uek_release: |-
+              {%- if guest_os_ansible_distribution_major_ver == 8 -%}UEKR6
+              {%- else -%}UEKR7{%- endif -%}
+
+        - name: "Set default online repository for OracleLinux {{ guest_os_ansible_distribution_ver }}"
+          ansible.builtin.set_fact:
+            online_repos:
+              - name: "ol{{ guest_os_ansible_distribution_major_ver }}_u{{ guest_os_ansible_distribution_minor_ver }}_BaseOS"
+                baseurl: "{{ oraclelinux_repo_url }}/{{ guest_os_ansible_distribution_minor_ver | int }}/baseos/base/$basearch/"
+              - name: "ol{{ guest_os_ansible_distribution_major_ver }}_AppStream"
+                baseurl: "{{ oraclelinux_repo_url }}/appstream/$basearch/"
+              - name: "ol{{ guest_os_ansible_distribution_major_ver }}_{{ oraclelinux_uek_release }}"
+                baseurl: "{{ oraclelinux_repo_url }}/{{ oraclelinux_uek_release }}/$basearch/"
       when: guest_os_ansible_distribution_major_ver | int >= 8
 
     - include_tasks: add_repo_from_baseurl.yml

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -51,10 +51,12 @@ def extract_error_msg(json_obj):
                         if 'rc' in json_obj and str(json_obj['rc']) != '':
                             message += ': ' + str(json_obj['rc'])
                         if 'stderr_lines' in json_obj and len(json_obj['stderr_lines']) > 0:
-                            json_obj['stderr_lines'].remove("")
+                            if "" in json_obj['stderr_lines']:
+                                json_obj['stderr_lines'].remove("")
                             message += '\n' + '\n'.join(json_obj['stderr_lines']).strip()
                         elif 'stdout_lines' in json_obj and len(json_obj['stdout_lines']) > 0:
-                            json_obj['stdout_lines'].remove("")
+                            if "" in json_obj['stderr_lines']:
+                                json_obj['stdout_lines'].remove("")
                             message += '\n' + '\n'.join(json_obj['stdout_lines']).strip()
 
                 elif isinstance(value, list):


### PR DESCRIPTION
Oracle Linux 9.0 GA release doesn't have vsock and vmw_vsock_vmci_transport modules, see https://bugzilla.oracle.com/bugzilla/show_bug.cgi?id=17884. The issue has been fixed in latest UEK R7 kernel V5.15.0-2.52.3. OS lead requested to upgrade UEK R7 after autoinstall so that latest UEK R7 can be tested. 

Meanwhile, 
1. Removed 'syspurpose' command from ks.cfg as OracleLinux 9.0 doesn't support.
2. Increased the delay and reduced the retries for searching autoinstall complete message.
3. Fixed plugin exception