### PR TITLE
[Windows] Add known issue of NVMe disk hot extend

### DIFF
--- a/windows/utils/win_get_disk_size.yml
+++ b/windows/utils/win_get_disk_size.yml
@@ -13,7 +13,7 @@
 - name: "Check required parameter"
   ansible.builtin.assert:
     that:
-      - win_disk_num is defined or win_disk_uid is defined
+      - (win_disk_num is defined and win_disk_num) or (win_disk_uid is defined and win_disk_uid)
     fail_msg: "win_disk_num or win_disk_uid parameter must be specified."
 
 - name: "Initialize the disk size to 0"

--- a/windows/utils/win_get_disk_size.yml
+++ b/windows/utils/win_get_disk_size.yml
@@ -1,21 +1,45 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get disk size in GB in Windows guest OS
+# Get disk size in GB in Windows guest OS.
+# One of parameters 'win_disk_num', 'win_disk_uid' must be set.
+# 'win_disk_num' takes precedence.
 # Parameters:
-#   win_disk_num: the disk number in guest OS,
-#     e.g., 0, 1, ...
+#   win_disk_num: the disk number in guest OS, e.g., 0, 1, ...
+#   win_disk_uid: the disk Unique ID in guest OS
 # Return:
 #   win_get_disk_size_gb
 #
+- name: "Check required parameter"
+  ansible.builtin.assert:
+    that:
+      - win_disk_num is defined or win_disk_uid is defined
+    fail_msg: "win_disk_num or win_disk_uid parameter must be specified."
+
+- name: "Initialize the disk size to 0"
+  ansible.builtin.set_fact:
+    win_get_disk_size_gb: 0
+
+- name: "Set powershell command to get size of disk '{{ win_disk_num }}'"
+  ansible.builtin.set_fact:
+    win_cmd_disk_size: "[math]::Round(((Get-Disk -Number {{ win_disk_num | int }}).Size)/1GB)"
+  when: win_disk_num is defined
+
+- name: "Set powershell command to get size of disk '{{ win_disk_uid }}'"
+  ansible.builtin.set_fact:
+    win_cmd_disk_size: "[math]::Round(((Get-Disk -UniqueId {{ win_disk_uid }}).Size)/1GB)"
+  when: win_disk_num is undefined and win_disk_uid is defined
+
 - include_tasks: win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "[math]::Round(((Get-Disk -Number {{ win_disk_num | int }}).Size)/1GB)"
+    win_powershell_cmd: "{{ win_cmd_disk_size }}"
 
-- name: Set fact of the disk size
+- name: "Set fact of the disk size"
   ansible.builtin.set_fact:
     win_get_disk_size_gb: "{{ win_powershell_cmd_output.stdout_lines[0] | int }}"
   when:
+    - win_powershell_cmd_output.stdout_lines is defined
     - win_powershell_cmd_output.stdout_lines | length != 0
-- ansible.builtin.debug:
-    msg: "Get disk '{{ win_disk_num }}' size in guest OS: {{ win_get_disk_size_gb }}"
+- name: "Display the disk size"
+  ansible.builtin.debug:
+    msg: "Get disk '{{ win_disk_uid if win_disk_uid is defined else win_disk_num }}' size in guest OS: {{ win_get_disk_size_gb }}"

--- a/windows/vhba_hot_add_remove/create_partition_raw_disk.yml
+++ b/windows/vhba_hot_add_remove/create_partition_raw_disk.yml
@@ -28,10 +28,6 @@
     src: "{{ diskpart_file_path }}"
     dest: "{{ current_test_log_folder }}/"
 
-- include_tasks: ../utils/win_get_raw_disk_num.yml
-- include_tasks: ../utils/win_get_disk_unique_id.yml
-  vars:
-    win_get_disk_uid_num: "{{ win_raw_disk_num }}"
 - include_tasks: ../utils/win_get_unused_drive_letter.yml
 - include_tasks: ../utils/win_get_set_disk_online.yml
   vars:

--- a/windows/vhba_hot_add_remove/enable_vm_nvme_spec13.yml
+++ b/windows/vhba_hot_add_remove/enable_vm_nvme_spec13.yml
@@ -15,9 +15,5 @@
 # Add extra config for VM
 - include_tasks: ../../common/vm_set_extra_config.yml
 
-# After VM power on, get VM IP address again in case IP changed
-- include_tasks: ../../common/vm_get_ip.yml
-  vars:
-    vm_get_ip_timeout: 600
-- include_tasks: ../utils/win_check_winrm.yml
-- include_tasks: ../utils/add_windows_host.yml
+# After VM power on in above common task, get VM IP address again in case IP changed
+- include_tasks: ../utils/win_update_inventory.yml

--- a/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
+++ b/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
@@ -69,7 +69,7 @@
 # Extend disk volume to the new size
 - include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "Resize-Partition -DriveLetter {{ drive_letter_new }} -PartitionNumber 1 -Size (Get-PartitionSupportedSize -DiskNumber 1).SizeMax"
+    win_powershell_cmd: "Resize-Partition -DriveLetter {{ drive_letter_new }} -Size (Get-PartitionSupportedSize -DriveLetter {{ drive_letter_new }}).SizeMax"
 
 # Get disk volume size in guest OS after extend
 - include_tasks: ../utils/win_get_disk_volume_size.yml

--- a/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
+++ b/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
@@ -30,13 +30,36 @@
     seconds: 10
 
 # Get disk size in guest OS after hot extend
-# By default the hotadded disk above is 'disk 1' in guest OS
 - include_tasks: ../utils/win_get_disk_size.yml
   vars:
-    win_disk_num: 1
+    win_disk_uid: "{{ win_disk_unique_id }}"
 - name: "Set fact of disk size after extend"
   ansible.builtin.set_fact:
     win_disk_size_after: "{{ win_get_disk_size_gb }}"
+
+- block:
+    - name: "Known issue - workaround of hot extend NVMe disk size"
+      ansible.builtin.debug:
+        msg:
+          - "Hot extended NVMe disk size is not recognized in Windows guest when NVMe Spec v1.3 is emulated. Ignore this known issue on ESXi version <= 8.0 GA build 20513097."
+          - "Restart guest OS as a workaround for hot extend NVMe disk size."
+      tags:
+        - known_issue
+    - include_tasks: ../utils/win_shutdown_restart.yml
+      vars:
+        set_win_power_state: "restart"
+    - include_tasks: ../utils/win_get_disk_size.yml
+      vars:
+        win_disk_uid: "{{ win_disk_unique_id }}"
+    - name: "Set fact of disk size after extend"
+      ansible.builtin.set_fact:
+        win_disk_size_after: "{{ win_get_disk_size_gb }}"
+  when:
+    - esxi_version is defined and esxi_version
+    - esxi_build is defined and esxi_build
+    - esxi_version is version('8.0.0', '<') or (esxi_version is version('8.0.0', '=') and esxi_build | int <= 20513097)
+    - win_disk_size_after | int == win_disk_volume_size_before | int
+
 - name: "Check disk size after hot extend"
   ansible.builtin.assert:
     that:
@@ -46,7 +69,7 @@
 # Extend disk volume to the new size
 - include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "Resize-Partition -DiskNumber 1 -PartitionNumber 1 -Size (Get-PartitionSupportedSize -DiskNumber 1).SizeMax"
+    win_powershell_cmd: "Resize-Partition -DriveLetter {{ drive_letter_new }} -PartitionNumber 1 -Size (Get-PartitionSupportedSize -DiskNumber 1).SizeMax"
 
 # Get disk volume size in guest OS after extend
 - include_tasks: ../utils/win_get_disk_volume_size.yml

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_existing_ctrl.yml
@@ -50,5 +50,10 @@
     success_msg: "Disk number increases 2 in guest OS after hotadding disks to new controller and existing controller."
     fail_msg: "Disk number not increase 2 after hotadding disks to new controller and existing controller, before hotadd: {{ disk_num_guest_before_hotadd }}, after hotadd: {{ disk_num_guest_after_hotadd2 }}"
 
+- include_tasks: ../utils/win_get_raw_disk_num.yml
+- include_tasks: ../utils/win_get_disk_unique_id.yml
+  vars:
+    win_get_disk_uid_num: "{{ win_raw_disk_num }}"
+
 # Initialize new disk and create disk partition in guest OS
 - include_tasks: create_partition_raw_disk.yml

--- a/windows/vhba_hot_add_remove/hotadd_vm_disk_new_ctrl.yml
+++ b/windows/vhba_hot_add_remove/hotadd_vm_disk_new_ctrl.yml
@@ -36,5 +36,10 @@
     success_msg: "Disk number increases 1 in guest OS"
     fail_msg: "Disk number not increase 1, before hotadd: {{ disk_num_guest_before_hotadd }}, after hotadd: {{ disk_num_guest_after_hotadd1 }}"
 
+- include_tasks: ../utils/win_get_raw_disk_num.yml
+- include_tasks: ../utils/win_get_disk_unique_id.yml
+  vars:
+    win_get_disk_uid_num: "{{ win_raw_disk_num }}"
+
 # Initialize new disk and create disk partition in guest OS
 - include_tasks: create_partition_raw_disk.yml


### PR DESCRIPTION
Signed-off-by: Diane Wang <dianew@vmware.com>

There is known issue of NVMe disk size hot extend, this issue will be fixed after vSphere 8.0 release. So add a workaround to restart guest OS in test case `vhba_hot_add_remove/nvme_disk_hot_extend_spec13`.