### PR TITLE
Replace test result 'No Run' with 'Skipped' for test cases to be skipped

### DIFF
--- a/common/skip_test_case.yml
+++ b/common/skip_test_case.yml
@@ -6,16 +6,16 @@
 #   skip_msg: The message for skipping reason
 #   skip_reason: The reason to skip the test case, which could be:
 #      * Blocked: Test case dependency is not meet, e.g. no VMtools or no VC for GOSC testing
-#      * Not Supported: tested function is not supported by the OS.
-#      * Not Applicable: tested function is not applicable. e.g. enable secureboot on BIOS VM
-#      * No Run: test case is not executed. e.g. deploy_vm on existing VM.
+#      * Not Supported: Tested function is not supported by the OS.
+#      * Not Applicable: Tested function is not applicable. e.g. enable secureboot on BIOS VM
+#      * Skipped: Test case doesn't need to run. e.g deploy_vm when new_vm is false.
 #
 - name: "Validate test result"
   ansible.builtin.assert:
     that:
       - skip_reason is defined
-      - skip_reason in ['Blocked', 'Not Supported', 'Not Applicable', 'No Run']
-    fail_msg: "skip_reason can be 'Blocked', 'Not Supported', 'Not Applicable', or 'No Run'"
+      - skip_reason in ['Blocked', 'Not Supported', 'Not Applicable', 'Skipped']
+    fail_msg: "skip_reason can be 'Blocked', 'Not Supported', 'Not Applicable', or 'Skipped'"
 
 - name: "Skip testcase: {{ ansible_play_name }}, reason: {{ skip_reason }}"
   ansible.builtin.fail:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -13,7 +13,7 @@
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
         skip_reason: "Skipped"
-      when: new_vm is undefined or (not new_vm|bool)
+      when: new_vm is undefined or (not new_vm | bool)
 
     - name: "Set current test case log path on local machine"
       ansible.builtin.set_fact:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -12,7 +12,7 @@
     - include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
-        skip_reason: "No Run"
+        skip_reason: "Skipped"
       when: new_vm is undefined or (not new_vm|bool)
 
     - name: "Set current test case log path on local machine"

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -35,7 +35,7 @@
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case because vmtools_is_installed is {{ vmtools_is_installed | default('undefined') }}, update_vmtools is {{ update_vmtools | default(false) }}"
-            skip_reason: "No Run"
+            skip_reason: "Skipped"
           when: >
             (vmtools_is_installed is defined and
             vmtools_is_installed and

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -34,12 +34,9 @@
         # VM has open-vm-tools installed and update_vmtools is set false
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Skip test case because vmtools_is_installed is {{ vmtools_is_installed | default('undefined') }}, update_vmtools is {{ update_vmtools | default(false) }}"
+            skip_msg: "Test case '{{ ansible_play_name }}' is skipped because update_vmtools is set to: {{ update_vmtools }}"
             skip_reason: "Skipped"
-          when: >
-            (vmtools_is_installed is defined and
-            vmtools_is_installed and
-            not update_vmtools)
+          when: not update_vmtools | bool
 
         # Initialize variables
         - name: "Initialize variables for installing open-vm-tools"

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -297,8 +297,8 @@ windows_has_inbox_driver: true
 # 'vmtools_url_path' takes precedence over 'vmtools_iso_path'.
 #
 vmtools_esxi_bundled: false
-vmtools_url_path: "https://packages.vmware.com/tools/releases/11.3.5/windows/VMware-tools-windows-11.3.5-18557794.iso"
-# vmtools_iso_path: "[datastore1] VMware/VMTools/11.1.5/VMware-tools-windows-11.1.5-16596746.iso"
+vmtools_url_path: "https://packages.vmware.com/tools/releases/12.1.0/windows/VMware-tools-windows-12.1.0-20219665.iso"
+# vmtools_iso_path: "[datastore1] VMware/VMTools/12.1.0/VMware-tools-windows-12.1.0-20219665.iso"
 
 # 3. memory_hot_add_basic
 # Maximum memory size in MB of VM when doing memory hotadd test. Used in Linux testing

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -17,7 +17,7 @@
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
         skip_reason: "Skipped"
-      when: new_vm is undefined or not new_vm|bool
+      when: new_vm is undefined or not new_vm | bool
 
     - block:
         - name: "Set current test case log path on local machine"

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -16,7 +16,7 @@
     - include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
-        skip_reason: "No Run"
+        skip_reason: "Skipped"
       when: new_vm is undefined or not new_vm|bool
 
     - block:

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -39,7 +39,7 @@
         - include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"
-            skip_reason: "Blocked"
+            skip_reason: "Skipped"
           when:
             - vmtools_is_installed is defined
             - vmtools_is_installed | bool

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -38,7 +38,7 @@
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"
+            skip_msg: "Test case '{{ ansible_play_name }}' is skipped because VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"
             skip_reason: "Skipped"
           when:
             - vmtools_is_installed is defined

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -38,12 +38,9 @@
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is skipped because VMware tools is installed, update VMware tools is set to: {{ update_vmtools }}"
+            skip_msg: "Test case '{{ ansible_play_name }}' is skipped because update_vmtools is set to: {{ update_vmtools }}"
             skip_reason: "Skipped"
-          when:
-            - vmtools_is_installed is defined
-            - vmtools_is_installed | bool
-            - not update_vmtools | bool
+          when: not update_vmtools | bool
 
         # Get ESXi host bundled VMware tools ISO path
         - block:


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
When new_vm=false, deploy_vm will be skipped, so changing its test result to 'Skipped' is more proper.
When update_vmtools=false, ovt_verify_install/wintools_complete_install_verify will be skipped, so changing its test result to 'Skipped' is more proper.