### PR TITLE
Fix software selection for UOS Server 20 1050u1a

### DIFF
--- a/autoinstall/UOS/Server/20/1050a/ks.cfg
+++ b/autoinstall/UOS/Server/20/1050a/ks.cfg
@@ -41,13 +41,13 @@ firstboot --disable
 # System services
 services --enabled="chronyd"
 # System timezone
-timezone America/New_York --isUtc
+timezone America/New_York --utc
 
 # Reboot when the install is finished.
 reboot
 
 %packages
-@^graphical-server-environment-dde
+@Server with DDE
 open-vm-tools-desktop
 cloud-init
 java-1.8.0-openjdk

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -142,6 +142,15 @@
         - unattend_install_conf is defined
         - ('RHEL' in unattend_install_conf) or ('CentOS' in unattend_install_conf)
 
+    # For UnionTech OS Server, sendkey to boot screen
+    - include_tasks: ../../common/vm_guest_send_key.yml
+      vars:
+        keys_send:
+          - ENTER
+      when:
+        - unattend_install_conf is defined
+        - ('UOS' in unattend_install_conf)
+
     # Wait autoinstall complete message appear in serial port output file
     - include_tasks: ../../common/vm_wait_log_msg.yml
       vars:


### PR DESCRIPTION
Signed-off-by: Qi Zhang <qiz@vmware.com>
Environment name graphical-server-environment-dde can not be recognized in UOS Server 20 1050u1a, so replace it with "Server with DDE". And send ENTER key at boot screen to enter installation.