### PR TITLE
[New Feature][Fedora] Support Fedora autoinstall

### DIFF
--- a/autoinstall/Fedora/36/Server/ks.cfg
+++ b/autoinstall/Fedora/36/Server/ks.cfg
@@ -38,7 +38,7 @@ network --hostname=localhost.localdomain
 
 # Install packages
 %packages
-@^graphical-server-environment
+open-vm-tools
 %end
 
 

--- a/autoinstall/Fedora/36/ks.cfg
+++ b/autoinstall/Fedora/36/ks.cfg
@@ -1,0 +1,76 @@
+#version=DEVEL
+# Use graphical install
+graphical
+
+# Use CDROM installation media
+cdrom
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+
+# System language
+lang en_US.UTF-8
+
+# License agreement
+eula --agreed
+
+
+# X Window System configuration information
+xconfig  --startxonboot
+# Do not run the Setup Agent on first boot
+firstboot --disable
+
+# Generated using Blivet version 3.5.0
+ignoredisk --only-use={{ boot_disk_name }}
+autopart
+# Partition clearing information
+clearpart --none --initlabel
+
+# System services
+services --enabled="chronyd"
+
+# System timezone
+timezone America/New_York --utc
+
+# Network
+network --bootproto=dhcp --ipv6=auto
+network --hostname=localhost.localdomain
+
+# Install packages
+%packages
+@^graphical-server-environment
+%end
+
+
+#Root password
+rootpw --iscrypted {{ vm_password_hash }}
+
+# Add SSH key
+sshkey --username=root "{{ ssh_public_key }}"
+
+{% if new_user is defined and new_user != 'root' %}
+user --name={{ new_user }} --password={{ vm_password_hash }} --groups=root,wheel --iscrypted --gecos="{{ new_user }}"
+sshkey --username={{ new_user }} "{{ ssh_public_key }}"
+{% endif %}
+
+# Reboot when the install is finished.
+reboot
+
+%post --interpreter=/usr/bin/bash --log=/root/ks-post.log
+if [ -f /etc/cloud/cloud.cfg ]; then
+    sed -i 's/^disable_root:.*/disable_root: false/' /etc/cloud/cloud.cfg
+    sed -i 's/^ssh_pwauth:.*/ssh_pwauth: yes/' /etc/cloud/cloud.cfg
+fi
+
+# Permit root login via SSH
+sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+{% if new_user is defined and new_user != 'root' %}
+# Add new user to sudoer
+echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
+# Enable autologin
+sed -i '/\[daemon\]/a AutomaticLogin={{ new_user }}' /etc/gdm/custom.conf
+sed -i '/\[daemon\]/a AutomaticLoginEnable=True' /etc/gdm/custom.conf
+{% endif %}
+echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
+%end

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -14,7 +14,7 @@
 13. For Debian 10.1x or 11.x unattend auto-install, please use file Debian/10/preseed.cfg.
 14. For UnionTech OS Server 20 1050a unattend auto-install, please use file UOS/Server/20/1050a/ks.cfg.
 15. For UnionTech OS Server 20 1050e unattend auto-install, please use file UOS/Server/20/1050e/ks.cfg.
-16. For Fedora 36 or later unattend auto-install, please use file Fedora/36/ks.cfg.
+16. For Fedora 36 or later unattend auto-install, please use file Fedora/36/Server/ks.cfg.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -14,6 +14,7 @@
 13. For Debian 10.1x or 11.x unattend auto-install, please use file Debian/10/preseed.cfg.
 14. For UnionTech OS Server 20 1050a unattend auto-install, please use file UOS/Server/20/1050a/ks.cfg.
 15. For UnionTech OS Server 20 1050e unattend auto-install, please use file UOS/Server/20/1050e/ks.cfg.
+16. For Fedora 36 or later unattend auto-install, please use file Fedora/36/ks.cfg.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -14,7 +14,7 @@
 13. For Debian 10.1x or 11.x unattend auto-install, please use file Debian/10/preseed.cfg.
 14. For UnionTech OS Server 20 1050a unattend auto-install, please use file UOS/Server/20/1050a/ks.cfg.
 15. For UnionTech OS Server 20 1050e unattend auto-install, please use file UOS/Server/20/1050e/ks.cfg.
-16. For Fedora 36 or later unattend auto-install, please use file Fedora/36/Server/ks.cfg.
+16. For Fedora Server 36 or later unattend auto-install, please use file Fedora/36/Server/ks.cfg.
 
 # Notes
 ## For Windows

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -22,16 +22,17 @@
         - include_tasks: ../../common/esxi_get_version_build.yml
           when: esxi_version is undefined or esxi_update_version is undefined
 
-        - name: Get OS fullname in guest OS
+        - name: "Get OS fullname in guest OS"
           ansible.builtin.debug:
             msg: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
 
-        - name: "Initalize guest_fullnane to 'guest fullname not defined in test case'"
+        - name: "Initalize facts for checking guest full name"
           ansible.builtin.set_fact:
             guest_fullname: "guest fullname not defined in test case"
+            guest_is_otherlinux: false
 
         # Map Ubuntu
-        - name: Set guest_fullname variable for Ubuntu
+        - name: "Set guest_fullname variable for Ubuntu"
           ansible.builtin.set_fact:
             guest_fullname: "Ubuntu Linux ({{ guest_os_bit }})"
           when: guest_os_ansible_distribution == "Ubuntu"
@@ -52,16 +53,25 @@
           when: guest_os_ansible_distribution in ["Amazon", "CentOS", "OracleLinux", "AlmaLinux", "Rocky", "Debian"]
 
         # Map FreeBSD guest full name
-        - name: Set guest_fullname variable for FreeBSD
+        - name: "Set guest_fullname variable for FreeBSD"
           ansible.builtin.set_fact:
             guest_fullname: "FreeBSD {{ guest_os_ansible_distribution_major_ver }} ({{ guest_os_bit }})"
           when: guest_os_ansible_distribution == "FreeBSD"
 
+        # Map Fedora
+        - name: "Set guest_fullname variable for Fedora"
+          ansible.builtin.set_fact:
+            guest_fullname: "Red Hat Fedora ({{ guest_os_bit }})"
+          when: guest_os_ansible_distribution == "Fedora"
+
         # Map Other Linux
+        - name: "Set fact of the guest is other linux"
+          ansible.builtin.set_fact:
+            guest_is_otherlinux: true
+          when: guest_fullname == "guest fullname not defined in test case"
+
         - include_tasks: otherlinux_fullname_map.yml
-          when:
-            - guest_os_ansible_distribution not in ["RedHat", "CentOS", "OracleLinux", "AlmaLinux", "Rocky", "Amazon"]
-            - guest_os_ansible_distribution not in ["SLES", "SLED", "Ubuntu", "Debian", "VMware Photon OS", "FreeBSD"]
+          when: guest_is_otherlinux
 
         # Validate guest OS fullname in guestinfo
         - include_tasks: validate_os_fullname.yml

--- a/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -17,6 +17,14 @@
   tasks:
     - name: "Test case block"
       block:
+        - include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported by {{ guest_id }}"
+            skip_reason: "Not Supported"
+          when:
+            - vm_guest_id is defined
+            - vm_guest_id is match('fedora.*')
+
         - name: Set fact of the initial VM vCPU number
           ansible.builtin.set_fact:
             initial_cpu_num: 2

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -140,7 +140,9 @@
           - ENTER
       when:
         - unattend_install_conf is defined
-        - ('RHEL' in unattend_install_conf) or ('CentOS' in unattend_install_conf)
+        - (('RHEL' in unattend_install_conf) or
+           ('CentOS' in unattend_install_conf) or
+           ('Fedora' in unattend_install_conf))
 
     # Wait autoinstall complete message appear in serial port output file
     - include_tasks: ../../common/vm_wait_log_msg.yml

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -42,7 +42,7 @@
 
     - name: "Set default guest OS list not support GOSC"
       ansible.builtin.set_fact:
-        gos_not_support_gosc: ["FreeBSD", "SLED", "Astra Linux (Orel)"]
+        gos_not_support_gosc: ["FreeBSD", "SLED", "Astra Linux (Orel)", "Fedora"]
 
     - name: "Set fact of GOSC support status to False for {{ guest_os_ansible_distribution }}"
       ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -47,6 +47,7 @@
         - "'Flatcar' not in guest_os_ansible_distribution"
         - not (guest_os_ansible_distribution == "Ubuntu" and
                guest_os_ansible_distribution_major_ver == "22")
+        - guest_os_ansible_distribution != "Fedora"
 
     - name: "Rescan scsi devices in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
       block:
@@ -82,7 +83,8 @@
       when: >
         ('Flatcar' in guest_os_ansible_distribution or
          (guest_os_ansible_distribution == "Ubuntu" and
-          guest_os_ansible_distribution_major_ver == "22"))
+          guest_os_ansible_distribution_major_ver == "22") or
+         guest_os_ansible_distribution == "Fedora")
   when: new_disk_ctrl_type == 'lsilogic'
 
 - name: "Handle NVMe disk"


### PR DESCRIPTION
Added kickstart file for Fedora autoinstall, and fixed test case failures.
Tested with Fedora Server 36 and passed:
```
VM information:
+-----------------------------------------------------------------------+
| Name                      | test_fedora_36_server                     |
+-----------------------------------------------------------------------+
| Guest OS Distribution     | Fedora 36 x86_64                          |
+-----------------------------------------------------------------------+
| Hardware Version          | vmx-20                                    |
+-----------------------------------------------------------------------+
| VMTools Version           | 12.1.0 (build-20219665)                   |
+-----------------------------------------------------------------------+
| CloudInit Version         |                                           |
+-----------------------------------------------------------------------+
| GUI Installed             | False                                     |
+-----------------------------------------------------------------------+
| Config Guest Id           | fedora64Guest                             |
+-----------------------------------------------------------------------+
| GuestInfo Guest Id        | fedora64Guest                             |
+-----------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Fedora (64-bit)                   |
+-----------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                |
+-----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                        |
|                           | bitness='64'                              |
|                           | distroName='Fedora Linux'                 |
|                           | distroVersion='36'                        |
|                           | familyName='Linux'                        |
|                           | kernelVersion='5.17.5-300.fc36.x86_64'    |
|                           | prettyName='Fedora Linux 36 (Thirty Six)' |
+-----------------------------------------------------------------------+


Test Results (Total: 29, Passed: 24, Skipped: 5, Elapsed Time: 01:34:26)
+--------------------------------------------------------------------+
| Name                                 |   Status        | Exec Time |
+--------------------------------------------------------------------+
| deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:09:28  |
| check_inbox_driver                   |   Passed        | 00:01:23  |
| ovt_verify_install                   |   Passed        | 00:09:48  |
| ovt_verify_status                    |   Passed        | 00:01:14  |
| vgauth_check_service                 |   Passed        | 00:01:08  |
| check_ip_address                     |   Passed        | 00:00:37  |
| check_os_fullname                    |   Passed        | 00:00:39  |
| stat_balloon                         |   Passed        | 00:00:37  |
| stat_hosttime                        |   Passed        | 00:01:38  |
| device_list                          |   Passed        | 00:03:20  |
| check_quiesce_snapshot_custom_script |   Passed        | 00:00:58  |
| memory_hot_add_basic                 |   Passed        | 00:05:26  |
| cpu_hot_add_basic                    | * Not Supported | 00:00:00  |
| cpu_multicores_per_socket            |   Passed        | 00:07:55  |
| check_efi_firmware                   |   Passed        | 00:01:12  |
| secureboot_enable_disable            |   Passed        | 00:05:15  |
| e1000e_network_device_ops            |   Passed        | 00:05:10  |
| vmxnet3_network_device_ops           |   Passed        | 00:03:50  |
| gosc_perl_dhcp                       | * Not Supported | 00:02:30  |
| gosc_perl_staticip                   | * Not Supported | 00:01:47  |
| gosc_cloudinit_dhcp                  | * Not Supported | 00:02:03  |
| gosc_cloudinit_staticip              | * Not Supported | 00:01:29  |
| paravirtual_vhba_device_ops          |   Passed        | 00:02:52  |
| lsilogic_vhba_device_ops             |   Passed        | 00:03:46  |
| lsilogicsas_vhba_device_ops          |   Passed        | 00:03:45  |
| sata_vhba_device_ops                 |   Passed        | 00:03:55  |
| nvme_vhba_device_ops                 |   Passed        | 00:02:40  |
| nvdimm_cold_add_remove               |   Passed        | 00:06:37  |
| ovt_verify_uninstall                 |   Passed        | 00:02:16  |
+--------------------------------------------------------------------+
```