### PR TITLE
Add Fedora server to Compatible Guest Operating Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guest OS Validation on vSphere using Ansible
+# Guest Operating System Validation on vSphere using Ansible
 
 ## Getting Started
 
@@ -15,16 +15,16 @@ $ ansible-galaxy install -r requirements.yml
 4. Log in to local control machine as root or a user in sudoers
 
 ### Steps to Launch Testing
-1. Git clone project from github to your workspace on control machine,
-2. Set the parameters required for testing in this file: vars/test.yml,
-3. Modify the test cases in test case list file in below default path,
-   * For Linux testing: linux/gosv_testcase_list.yml
-   * For Windows testing: windows/gosv_testcase_list.yml
-4. Launch testing using below commands from the same path of "main.yml",
+1. Git clone project from github to your workspace on control machine.
+2. Set the parameters required for testing in this file: `vars/test.yml`.
+3. Modify the test cases in test case list file in below default path.
+   * For Linux testing: `linux/gosv_testcase_list.yml`
+   * For Windows testing: `windows/gosv_testcase_list.yml`
+4. Launch testing using below commands from the same path of `main.yml`.
 ```
   # For Linux testing:
   # you can use below command to use the default variables file "vars/test.yml",
-  # default test case list file "linux/gosv_testcase_list.yml"
+  # and default test case list file "linux/gosv_testcase_list.yml"
   $ ansible-playbook main.yml
 
   # For Linux or Windows testing:
@@ -32,37 +32,39 @@ $ ansible-galaxy install -r requirements.yml
   # test case list file
   $ ansible-playbook main.yml -e "testing_vars_file=/path_to/test.yml testing_testcase_file=/path_to/gosv_testcase_list.yml"
 ```
-5. New folder for log files and files collected in test cases are created for current test run,
-e.g., "logs/test-vm/2021-07-06-09-27-51/",
-find test case results in "results.log", failed tasks in "failed_tasks.log", testing debug log in "full_debug.log". 
+5. A new log folder will be created for current test run, which will include log files and files collected in test cases, e.g., `logs/test-vm/2021-07-06-09-27-51/`. You can find log files:
+  * `results.log` which has testbed information, VM information and test case results
+  * `full_debug.log` which has testing debug logs
+  * `failed_tasks.log` which has failed tasks logs
+  * `known_issues.log` which lists known issues meet in current test run
 
 ### Catalog
-* main.yml: Main playbook for Guest OS validation test
+* main.yml: Main playbook for guest operating system validation test
 * ansible.cfg: User customized Ansible configuration file
-* autoinstall: Folder for guest OS unattend install configuration files
+* autoinstall: Folder for guest operating system unattend install configuration files
 * common: Folder for common tasks called in test cases
 * docs: Folder for guide file and known issues
 * env_setup: Folder for playbooks or tasks which to prepare or cleanup testing environment
-* linux: Folder for playbooks to test Linux guest OS
-* windows: Folder for playbooks to test Windows guest OS
+* linux: Folder for playbooks to test Linux guest operating system
+* windows: Folder for playbooks to test Windows guest operating system
 * plugin: Folder for plugin scripts
 * tools: Folder for 3rd-party tools used in test cases
 * vars: Folder for variable files used in testing
 * changelogs: Folder for changelog of each release 
 
 ### Supported Testing Scenarios
-This project supports below scenarios for end-to-end guest OS validation testing 
-* Deploy VM and install guest OS from ISO image
+This project supports below scenarios for end-to-end guest operating system validation testing 
+* Deploy VM and install guest operating system from ISO image
 * Deploy VM from an OVA template
-* Existing VM with installed guest OS, which should satisfy below requirments.
-  * SSH and Python are installed and enabled
-  * The vm_python variable in vars/test.yml must be set with correct python path. Or user can set PATH in /etc/environment in guest OS to include the binary directory path to python.
-  * The root user should be enabled and permitted to log in through SSH in Linux guest OS
-  * Execute [ConfigureRemotingForAnsible.ps1](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1) script in Windows guest OS in advance
+* Existing VM with installed guest operating system, which should satisfy below requirments.
+  * SSH and Python are installed and enabled.
+  * The vm_python variable in vars/test.yml must be set with correct python path. Or user can set PATH in /etc/environment in guest operating system to include the binary directory path to python.
+  * The root user should be enabled and permitted to log in through SSH in Linux guest operating system.
+  * Execute [ConfigureRemotingForAnsible.ps1](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1) script in Windows guest operating system in advance.
 
-### Supported Guest OS
+### Compatible Guest Operating Systems
 
-| Guest OS types/versions                         | Automatic install from ISO image | Deploy from ova template | Existing VM and installed guest OS |
+| Guest Operating System Types/Versions                         | Automatic Install from ISO Image | Deploy from OVA Template | Existing VM And Installed Guest Operating System |
 | :---------------------------------------------- | :------------------------------: | :----------------------: | :--------------------------------: |
 | Red Hat Enterprise Linux 7.x, 8.x, 9.x          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
@@ -82,8 +84,9 @@ This project supports below scenarios for end-to-end guest OS validation testing
 | Windows 10, 11                                  | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Windows Server 2019, 2022                       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | UnionTech OS Server 20 1050a                    | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Fedora Server 36 and later                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 
-Note: This supported guest OS list is used for this project only. For guest OS support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).
+Note: This compatible guest operating systems list is used for this project only. For guest operating system support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).
 
 ### Docker images
 * Latest (Release v2.1):

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ $ ansible-galaxy install -r requirements.yml
   $ ansible-playbook main.yml -e "testing_vars_file=/path_to/test.yml testing_testcase_file=/path_to/gosv_testcase_list.yml"
 ```
 5. A new log folder will be created for current test run, which will include log files and files collected in test cases, e.g., `logs/test-vm/2021-07-06-09-27-51/`. You can find log files:
-  * `results.log` which has testbed information, VM information and test case results
-  * `full_debug.log` which has testing debug logs
-  * `failed_tasks.log` which has failed tasks logs
+  * `results.log` which contains testbed information, VM information and test case results
+  * `full_debug.log` which contains testing debug logs
+  * `failed_tasks.log` which contains failed tasks logs
   * `known_issues.log` which lists known issues meet in current test run
 
 ### Catalog
@@ -64,7 +64,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 
 ### Compatible Guest Operating Systems
 
-| Guest Operating System Types/Versions                         | Automatic Install from ISO Image | Deploy from OVA Template | Existing VM And Installed Guest Operating System |
+| Guest Operating Systems                         | Automatic Install from ISO Image | Deploy from OVA Template | Existing VM with Guest Operating System Installed |
 | :---------------------------------------------- | :------------------------------: | :----------------------: | :--------------------------------: |
 | Red Hat Enterprise Linux 7.x, 8.x, 9.x          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |


### PR DESCRIPTION
1. Changed header  `Supported Guest OS` to `Compatible Guest Operating Systems`.
2. Added `Fedora Server 36 and later` to `Compatible Guest Operating Systems`.
3. Replaced `OS` with `operating system`.