### PR TITLE
[Linux] Skip GOSC testing on builds earlier than VC 7.0U3f for Rocky, AlmaLinux, OracleLinux 9.x

### DIFF
--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -1,14 +1,17 @@
 # This file listed guest OS customization(GOSC) testing supported OS start versions, vCenter Server versions and builds and depended open-vm-tools versions. OS releases listed in this file are supported by ansible-vsphere-gos-validation for GOSC testing. For all OS releases supported guest OS customization on vSphere, please see https://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf. 
-# See https://kb.vmware.com/s/article/2143838 for build numbers and versions of VMware vCenter Server
+# See https://kb.vmware.com/s/article/2143838 for build numbers and versions of VMware vCenter Server.
+# Note: All build numbers listed below are the build numbers of Client/MOB/vpxd.log. 
 
-# SLES 15.3 and higher version supports GOSC on VC 6.7.0 from build 14368073, or higher VC versions
+# SLES 15.3 and higher version supports GOSC testing on vCenter Server 6.7.0 from build 14368073, or higher vCenter Server versions.
 SLES:
   '15.3':
     vcenter:
       6.7.0: 14368073
 
-# Rocky 8.4 and higher version supports GOSC on VC 6.7.0 from build 18831049, and on VC 7.0.3 from build 18700403, or higher VC versions; not supports GOSC for all of builds on 7.0.0/7.0.1/7.0.2.
-# See https://kb.vmware.com/s/article/86163
+# 1. Rocky 8.4 and higher version supports GOSC testing on vCenter Server 6.7.0 from build 18831049, and on vCenter Server 7.0.3 from build 18700403, or higher vCenter Server versions; not supports GOSC testing for all of builds on 7.0.0/7.0.1/7.0.2.
+# See https://kb.vmware.com/s/article/86163.
+# 2. Rocky 9.x supports GOSC testing on vCenter Server 6.7.0 from build 19832280, and on vCenter Server 7.0.3 from build 20051473, or higher vCenter Server versions; not supports GOSC testing for all of builds on 7.0.0/7.0.1/7.0.2.
+# See https://kb.vmware.com/s/article/86163 and https://kb.vmware.com/s/article/88199.
 Rocky:
   '8.4':
     vcenter:
@@ -17,9 +20,18 @@ Rocky:
       7.0.1: N/A
       7.0.2: N/A
       7.0.3: 18700403
+  '9.0':
+    vcenter:
+      6.7.0: 19832280
+      7.0.0: N/A
+      7.0.1: N/A
+      7.0.2: N/A
+      7.0.3: 20051473
 
-# AlmaLinux 8.4 and higher version supports GOSC on VC 6.7.0 from build 18831049, and on VC 7.0.3 from build 19480866, or higher VC versions; not supports GOSC for all of builds on 7.0.0/7.0.1/7.0.2.
-# See https://kb.vmware.com/s/article/85686
+# 1. AlmaLinux 8.4 and higher version supports GOSC testing on vCenter Server 6.7.0 from build 18831049, and on vCenter Server 7.0.3 from build 19480866, or higher vCenter Server versions; not supports GOSC testing for all of builds on 7.0.0/7.0.1/7.0.2.
+# See https://kb.vmware.com/s/article/85686.
+# 2. AlmaLinux 9.x supports GOSC testing on vCenter Server 6.7.0 from build 19832280, and on vCenter Server 7.0.3 from build 20051473, or higher vCenter Server versions; not supports GOSC testing for all of builds on 7.0.0/7.0.1/7.0.2.
+# See https://kb.vmware.com/s/article/85686 and https://kb.vmware.com/s/article/88199.
 AlmaLinux:
   '8.4':
     vcenter:
@@ -28,20 +40,27 @@ AlmaLinux:
       7.0.1: N/A
       7.0.2: N/A
       7.0.3: 19480866
+  '9.0':
+    vcenter:
+      6.7.0: 19832280
+      7.0.0: N/A
+      7.0.1: N/A
+      7.0.2: N/A
+      7.0.3: 20051473
 
-# Debian 10.10 and higher version doesn't support GOSC on VC 7.0.3 and earlier VC versions
-# See https://kb.vmware.com/s/article/85845
+# Debian 10.10 and higher version doesn't support GOSC on vCenter Server 7.0.3 and earlier vCenter Server versions.
+# See https://kb.vmware.com/s/article/85845.
 Debian:
   '10.10':
     vcenter:
       7.0.3: N/A
 
-# 1. Ubuntu 18.04 supports GOSC on VC 6.7.0 from build 14368073, or higher VC versions,
+# 1. Ubuntu 18.04 supports GOSC testing on vCenter Server 6.7.0 from build 14368073, or higher vCenter Server versions,
 # and requires open-vm-tools 10.3.10 or higher versions. See https://kb.vmware.com/s/article/56409.
-# 2. Ubuntu 20.04 supports GOSC on VC 6.7.0 from build 16046713, or higher VC versions.
-# 3. Ubuntu 20.10 supports GOSC on VC 7.0.0 from build 15952599, or higher VC versions.
+# 2. Ubuntu 20.04 supports GOSC testing on vCenter Server 6.7.0 from build 16046713, or higher vCenter Server versions.
+# 3. Ubuntu 20.10 supports GOSC testing on vCenter Server 7.0.0 from build 15952599, or higher vCenter Server versions.
 # See https://kb.vmware.com/s/article/80934.
-# 4. Ubuntu 21.04 and higher version supports GOSC on VC 7.0.1 from build 16858589, or higher VC versions.
+# 4. Ubuntu 21.04 and higher version supports GOSC testing on vCenter Server 7.0.1 from build 16858589, or higher vCenter Server versions.
 # See https://kb.vmware.com/s/article/59687 and	https://kb.vmware.com/s/article/80934.
 Ubuntu:
   '18.04':
@@ -58,8 +77,20 @@ Ubuntu:
     vcenter:
       7.0.1: 16858589
 
-# RHEL 9.0 supports GOSC on VC 6.7.0 from build 19832280, and on VC 7.0.3 from build 20051473, or higher VC versions.
+# RHEL 9.x supports GOSC testing on vCenter Server 6.7.0 from build 19832280, and on vCenter Server 7.0.3 from build 20051473, or higher vCenter Server versions.
+# See https://kb.vmware.com/s/article/80934.
 RedHat:
+  '9.0':
+    vcenter:
+      6.7.0: 19832280
+      7.0.0: N/A
+      7.0.1: N/A
+      7.0.2: N/A
+      7.0.3: 20051473
+
+# OracleLinux 9.x supports GOSC testing on vCenter Server 6.7.0 from build 19832280, and on vCenter Server 7.0.3 from build 20051473, or higher vCenter Server versions.
+# See https://kb.vmware.com/s/article/80934.
+OracleLinux:
   '9.0':
     vcenter:
       6.7.0: 19832280


### PR DESCRIPTION
Skip GOSC testing on builds earlier than VC 7.0U3f for Rocky, AlmaLinux, OracleLinux 9.x according to https://kb.vmware.com/s/article/88199. 

Signed-off-by: Qi Zhang <qiz@vmware.com>