### PR TITLE
add open-vm-tools package for ubuntu 20.04 because it's not installed…

### DIFF
--- a/autoinstall/Ubuntu/Desktop/ubuntu.seed
+++ b/autoinstall/Ubuntu/Desktop/ubuntu.seed
@@ -61,7 +61,7 @@ d-i grub-installer/only_debian boolean true
 # Install package
 ubiquity ubiquity/success_command \
     in-target apt-get update -y; \
-    in-target apt-get install -y --force-yes build-essential vim locales cloud-init openssh-server; \
+    in-target apt-get install -y --force-yes build-essential vim locales cloud-init openssh-server open-vm-tools open-vm-tools-desktop; \
 {% if new_user is defined and new_user != 'root' %}
     in-target su root; \
     in-target echo "{{ vm_password }}"; \


### PR DESCRIPTION
**Problem**
Add open-vm-tools package for ubuntu 20.04 destkop because it's not installed.

Signed-off-by: ZouYuhua <zouy@vmware.com>

**Description**
if the open-vm-tools is not installed for ubuntu 20.04 desktop during the unattended installation, it's failed for testcase deploy_vm.

Error message:

2022-12-01 02:50:43,001 | Failed at Play [deploy_vm_efi_paravirtual_vmxnet3] *********

2022-12-01 02:50:43,001 | TASK [deploy_vm_efi_paravirtual_vmxnet3][Check VMware Tools is running and collects guest OS fullname successfully] 
task path: /home/worker/workspace/Ansible_Cycle_Ubuntu_20.04_Desktop_ISO/ansible-vsphere-gos-validation/common/vm_wait_guest_fullname.yml:46
fatal: [localhost]: FAILED! => {
    "assertion": "vm_guestinfo.instance.guest.toolsRunningStatus == \"guestToolsRunning\"",
    "changed": false,
    "evaluated_to": false,
    "msg": "It's timed out for VMware Tools collecting guest OS fullname in 300 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''."
}
error message:
It's timed out for VMware Tools collecting guest OS fullname in 300 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''.


2022-12-01 02:51:33,001 | TASK [deploy_vm_efi_paravirtual_vmxnet3][Testing exit due to failure] 
task path: /home/worker/workspace/Ansible_Cycle_Ubuntu_20.04_Desktop_ISO/ansible-vsphere-gos-validation/common/test_rescue.yml:59
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Exit testing when 'exit_testing_when_fail' is set to True in test case deploy_vm_efi_paravirtual_vmxnet3"
}
error message:
Exit testing when 'exit_testing_when_fail' is set to True in test case deploy_vm_efi_paravirtual_vmxnet3


**Note**
By default, it has open-vm-tools installed for ubuntu 22.04/22.10 desktop.
This changes will update the default open-vm-tools to latest version if it's not the newest version.
