### PR TITLE
check_inbox_driver test failed in Pardus 21.3 due to slash in distribution name

### DIFF
--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -72,7 +72,7 @@
 
         - name: "Set fact of the output file path"
           ansible.builtin.set_fact:
-            os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace(' ','-') | lower }}.json"
+            os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace('/','-').replace(' ','-') | lower }}.json"
 
         - name: "The inbox drivers versions will be dump to a json file"
           ansible.builtin.debug: var=os_release_info_file_path


### PR DESCRIPTION
Signed-off-by: ZouYuhua <zouy@vmware.com>


**Issue:**
2022-11-15 05:33:47,015 | TASK [check_inbox_driver][Dump inbox drivers versions] *****
task path: /home/worker/workspace/lli_Pardus_21.x_64bit_70U1_PARAVIRTUAL_VMXNET3_EFI/ansible-vsphere-gos-validation/linux/check_inbox_driver/check_inbox_driver.yml:80
fatal: [localhost]: FAILED! => {
"changed": false,
"checksum": "dfc38c87136a254159b6d9485a1320423a254401",
"diff": [],
"invocation": {
"module_args":
{ "_original_basename": "tmpjjsgzar_", "attributes": null, "backup": false, "checksum": "dfc38c87136a254159b6d9485a1320423a254401", "content": null, "dest": "/home/worker/workspace/lli_Pardus_21.x_64bit_70U1_PARAVIRTUAL_VMXNET3_EFI/ansible-vsphere-gos-validation/logs/Pardus-21.3-XFCE/2022-11-15-05-31-51/check_inbox_driver/pardus-gnu/linux-21.3.json", "directory_mode": null, "follow": false, "force": true, "group": null, "local_follow": null, "mode": "0644", "owner": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": "/tmp/ansible-tmp-1668490427.2002091-2605-117663837968089/source", "unsafe_writes": false, "validate": null }

},
"msg": "Destination directory /home/worker/workspace/lli_Pardus_21.x_64bit_70U1_PARAVIRTUAL_VMXNET3_EFI/ansible-vsphere-gos-validation/logs/Pardus-21.3-XFCE/2022-11-15-05-31-51/check_inbox_driver/pardus-gnu does not exist"
}

**test result**
Test Results (Total: 1, Passed: 1, Elapsed Time: 00:04:10)
+-----------------------------------------+
| Name               | Status | Exec Time |
+-----------------------------------------+
| check_inbox_driver | Passed | 00:03:43  |
+-----------------------------------------+