### PR TITLE
Fix regression issue found in SLES/SLED/Ubuntu

### DIFF
--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -45,10 +45,12 @@ autoinstall:
     geoip: true
   packages:
     - sg3-utils
+{% if ubuntu_version is defined and ubuntu_version is version('22.04', '>=') %}
     - ndctl
     - rdma-core
     - rdmacm-utils
     - ibverbs-utils
+{% endif %}
   late-commands:
     - rm -f /etc/cloud/cloud.cfg.d/*-installer.cfg 2>/dev/null
     - echo 'Acquire::ForceIPv4 "true";' >>/etc/apt/apt.conf.d/99force-ipv4

--- a/common/esxi_get_guest_config_options.yml
+++ b/common/esxi_get_guest_config_options.yml
@@ -145,14 +145,14 @@
         tmp_config_option_file: "{{ tmp_path }}"
 
     - name: "Fetch config option file from ESXi server"
-      fetch:
+      ansible.builtin.fetch:
         src: "{{ vm_config_option_esx_hw }}"
         dest: "{{ tmp_config_option_file }}"
         flat: true
       delegate_to: "{{ esxi_hostname }}"
 
     - name: "Get default config option from guest OS descriptor for guest id {{ guest_id }}"
-      xml:
+      community.general.xml:
         path: "{{ tmp_config_option_file }}"
         xpath: "{{ guest_config_options_xpath }}/{{ item }}"
         content: text
@@ -171,7 +171,7 @@
       with_items: "{{ guest_os_descriptor.results | map(attribute='matches') | select('defined') | flatten | map('dict2items') }}"
 
     - name: "Get default video RAM size in KB for guest id {{ guest_id }}"
-      xml:
+      community.general.xml:
         path: "{{ tmp_config_option_file }}"
         xpath: "{{ guest_config_options_xpath }}/vRAMSizeInKB/defaultValue"
         content: text
@@ -187,7 +187,7 @@
         - guest_vram_size.matches | length > 0
 
     - name: "Get supported disk controllers for guest id {{ guest_id }}"
-      xml:
+      community.general.xml:
         path: "{{ tmp_config_option_file }}"
         xpath: "{{ guest_config_options_xpath }}/supportedDiskControllerList/e"
         content: text
@@ -210,7 +210,7 @@
         - guest_supported_disk_ctrls.matches | length > 0
 
     - name: "Get supported disk controllers for guest id {{ guest_id }}"
-      xml:
+      community.general.xml:
         path: "{{ tmp_config_option_file }}"
         xpath: "{{ guest_config_options_xpath }}/supportedEthernetCard/e"
         content: text
@@ -233,7 +233,7 @@
         - guest_supported_ethernet_card.matches | length > 0
 
     - name: "Get supported USB controllers for guest id {{ guest_id }}"
-      xml:
+      community.general.xml:
         path: "{{ tmp_config_option_file }}"
         xpath: "{{ guest_config_options_xpath }}/supportedUSBControllerList/e"
         content: text

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -126,7 +126,7 @@
       vars:
         repo_name: "{{ dvd_repo_name }}-{{ repodata_path | dirname | basename }}"
         repo_baseurl: "{{ repodata_path | dirname }}"
-        gpg_check: true
+        gpg_check: "{{ guest_os_ansible_distribution == 'RedHat' }}"
       with_items: "{{ find_repodata_result.stdout_lines }}"
       loop_control:
         loop_var: repodata_path


### PR DESCRIPTION
There is no default GPG key for SLES/SLED, so remove GPG check for adding SLES/SLED repos. 
Ubuntu 20.04.5 server failed to ndctl, rdma packages during deploy_vm, so in this changes only Ubuntu Server >= 22.04 will install these packages at deploy_vm. Ubuntu 20.04.5 will install these packages in test cases.