### PR TITLE
Fix empty CloudInit Version and GUI Installed in results.log

### DIFF
--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -778,8 +778,9 @@ class CallbackModule(CallbackBase):
                        self.vm_info.GuestInfo_Detailed_Data = set_fact_result.get("guestinfo_detailed_data", '')
                        self.vm_info.VMTools_Version = set_fact_result.get("guestinfo_vmtools_info", '')
                 if "check_guest_os_gui.yml" == task_file:
-                   if self.vm_info:
-                       self.vm_info.GUI_Installed = str(set_fact_result.get("guest_os_with_gui", ''))
+                   guest_os_with_gui = str(set_fact_result.get("guest_os_with_gui", ''))
+                   if self.vm_info and guest_os_with_gui != '':
+                       self.vm_info.GUI_Installed = guest_os_with_gui
 
         elif str(task.action) == "ansible.builtin.debug":
             if "skip_test_case.yml" == task_file and "Skip testcase:" in task.name:
@@ -837,7 +838,7 @@ class CallbackModule(CallbackBase):
                         self.vcenter_info['version'] = debug_var_value
                     if not self.vcenter_info['build'] and debug_var_name == "vcenter_build":
                         self.vcenter_info['build'] = debug_var_value
-                if "cloudinit_pkg_check.yml" == task_file and debug_var_name == "cloudinit_version":
+                if "get_cloudinit_version.yml" == task_file and debug_var_name == "cloudinit_version":
                     if self.vm_info and not self.vm_info.CloudInit_Version:
                         self.vm_info.CloudInit_Version = debug_var_value
                     if not self.os_cloudinit_version:


### PR DESCRIPTION
Tested with Windows:
```
VM information:
+----------------------------------------------------------------------+
| Name                      | wsl_win_server_25276                     |
+----------------------------------------------------------------------+
| IP                        | x.x.x.x                           |
+----------------------------------------------------------------------+
| Guest OS Distribution     | Microsoft Windows Server 2022 Datacenter |
|                           | 10.0.25276.0 64-bit                      |
+----------------------------------------------------------------------+
| Hardware Version          | vmx-20                                   |
+----------------------------------------------------------------------+
| VMTools Version           |                                          |
+----------------------------------------------------------------------+
| Config Guest Id           | windows2019srvNext_64Guest               |
+----------------------------------------------------------------------+
| GuestInfo Guest Id        |                                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Full Name |                                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Family    |                                          |
+----------------------------------------------------------------------+
| GuestInfo Detailed Data   |                                          |
+----------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:02:10)
+-----------------------------------------+
| Name               | Status | Exec Time |
+-----------------------------------------+
| check_efi_firmware | Passed | 00:01:41  |
+-----------------------------------------+
```

Tested with Linux:
```

VM information:
+------------------------------------------------------------------------------+
| Name                      | rhel9_ansible_test                               |
+------------------------------------------------------------------------------+
| IP                        | x.x.x.x                                  |
+------------------------------------------------------------------------------+
| Guest OS Distribution     | RedHat 9.1 x86_64                                |
+------------------------------------------------------------------------------+
| Hardware Version          | vmx-19                                           |
+------------------------------------------------------------------------------+
| VMTools Version           | 12.0.5 (build-19716617)                          |
+------------------------------------------------------------------------------+
| CloudInit Version         | 22.1                                             |
+------------------------------------------------------------------------------+
| GUI Installed             | True                                             |
+------------------------------------------------------------------------------+
| Config Guest Id           | rhel8_64Guest                                    |
+------------------------------------------------------------------------------+
| GuestInfo Guest Id        | rhel9_64Guest                                    |
+------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Enterprise Linux 9 (64-bit)              |
+------------------------------------------------------------------------------+
| GuestInfo Guest Family    | otherGuestFamily                                 |
+------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                               |
|                           | bitness='64'                                     |
|                           | distroName='Red Hat Enterprise Linux'            |
|                           | distroVersion='9.1'                              |
|                           | familyName='Linux'                               |
|                           | kernelVersion='5.14.0-162.6.1.el9_1.x86_64'      |
|                           | prettyName='Red Hat Enterprise Linux 9.1 (Plow)' |
+------------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:02:51)
+-----------------------------------------+
| Name               | Status | Exec Time |
+-----------------------------------------+
| check_inbox_driver | Passed | 00:02:20  |
+-----------------------------------------+
```