### PR TITLE
[Linux] Check vCenter Server is defined before PVRDMA testing

### DIFF
--- a/linux/network_device_ops/check_pvrdma_support_status.yml
+++ b/linux/network_device_ops/check_pvrdma_support_status.yml
@@ -48,3 +48,14 @@
   when: >
     (guest_pvrdma_module_info.filename is undefined) or
     ('vmw_pvrdma' not in guest_pvrdma_module_info.filename)
+
+- name: "Block test case due to no vCenter Server"
+  include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: >-
+      Test case is blocked because test environment doesn't have vCenter Server,
+      which doesn't meet PVRDMA requirements.
+    skip_reason: "Blocked"
+  when: >
+    (vcenter_is_defined is undefined) or
+    (not vcenter_is_defined)


### PR DESCRIPTION
Block PVRDMA testing when there is no vCenter Server defined.

```
2023-02-22 05:09:59,022 | Failed at Play [pvrdma_network_device_ops] *****************

2023-02-22 05:09:59,022 | TASK [pvrdma_network_device_ops][Skip testcase: pvrdma_network_device_ops, reason: Blocked] 
task path: /home/worker/workspace/Ansible_Cycle_CentOS_8.x/ansible-vsphere-gos-validation/common/skip_test_case.yml:21
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Test case is blocked because test environment doesn't have vCenter Server, which doesn't meet PVRDMA requirements"
}
error message:
Test case is blocked because test environment doesn't have vCenter Server, which doesn't meet PVRDMA requirements
```