### PR TITLE
Fix the issue that PVRDMA client VM has same IP address with server VM

### DIFF
--- a/common/vm_wait_guest_ip.yml
+++ b/common/vm_wait_guest_ip.yml
@@ -39,6 +39,7 @@
     - vm_guestinfo.instance.guest.net is defined
     - vm_guestinfo.instance.guest.net | map(attribute='ipAddress') | flatten | ansible.utils.ipv4
     - vm_guestinfo.instance.guest.ipAddress is defined
+    - vm_guestinfo.instance.guest.ipAddress
     - vm_guestinfo.instance.guest.ipAddress | ansible.utils.ipv4
     - (vm_guestinfo.instance.guest.ipAddress in
        vm_guestinfo.instance.guest.net | map(attribute='ipAddress') | flatten | ansible.utils.ipv4)
@@ -51,6 +52,7 @@
       - vm_guestinfo.instance.guest.toolsRunningStatus is defined
       - vm_guestinfo.instance.guest.toolsRunningStatus == "guestToolsRunning"
       - vm_guestinfo.instance.guest.ipAddress is defined
+      - vm_guestinfo.instance.guest.ipAddress
       - vm_guestinfo.instance.guest.ipAddress | ansible.utils.ipv4
       - (vm_guestinfo.instance.guest.ipAddress in
          vm_guestinfo.instance.guest.net | map(attribute='ipAddress') | flatten | ansible.utils.ipv4)

--- a/linux/network_device_ops/apply_new_network_config.yml
+++ b/linux/network_device_ops/apply_new_network_config.yml
@@ -7,11 +7,6 @@
 - name: "Get guest network device manager"
   include_tasks: ../utils/get_network_manager.yml
 
-- name: "Initialize facts of network config file tempate and path"
-  ansible.builtin.set_fact:
-    network_conf_template: ""
-    network_conf_path: ""
-
 - name: "Add network connection for {{ guest_os_ansible_distribution }}"
   block:
     - name: "Add network connection with static IP address"
@@ -58,66 +53,73 @@
           - nm_add_connection is defined
           - nm_add_connection.rc is defined
           - nm_add_connection.rc == 0
-        fail_msg: "Failed to add network connection"
-        success_msg: "{{ nm_add_connection.stdout | default('Successfully added network connection') }}"
+        fail_msg: "Failed to add network connection on VM {{ vm_name }}"
+        success_msg: "{{ nm_add_connection.stdout |
+                      default('Successfully added network connection on VM ' ~ vm_name) }}"
   when: guest_os_network_manager == "NetworkManager"
 
-# Set fact of network config file in guest OS except VMware Photon OS
-- block:
-    - name: "Set fact of the network configure file for {{ guest_os_ansible_distribution }}"
+# Set network config file in guest OS except VMware Photon OS
+- name: "Set network config file for {{ guest_os_ansible_distribution }}"
+  block:
+    - name: "Initialize fact of network config tempate"
       ansible.builtin.set_fact:
-        network_conf_template: rhel_network_conf.j2
-        network_conf_path: "/etc/sysconfig/network-scripts/ifcfg-{{ new_network_adapter }}"
+        network_config_template: ""
+
+    - name: "Get network config file for '{{ new_network_adapter }}'"
+      include_tasks: ../utils/get_network_config_file.yml
+      vars:
+        network_adapter_name: "{{ new_network_adapter }}"
+
+    - name: "Set fact of the network config template for {{ guest_os_ansible_distribution }}"
+      ansible.builtin.set_fact:
+        network_config_template: rhel_network_conf.j2
       when: guest_os_family == "RedHat"
 
-    - name: "Set fact of the network configure file for Ubuntu desktop"
+    - name: "Set fact of the network config template for Ubuntu desktop"
       ansible.builtin.set_fact:
-        network_conf_template: debian_network_conf.j2
-        network_conf_path: "/etc/network/interfaces"
+        network_config_template: debian_network_conf.j2
       when: >
         (guest_os_ansible_distribution == "Debian") or
-        (guest_os_ansible_distribution == "Ubuntu" and guest_os_with_gui is defined and guest_os_with_gui)
+        (guest_os_ansible_distribution == "Ubuntu" and
+         guest_os_with_gui is defined and guest_os_with_gui)
 
-    - block:
-        # Get netplan config file in Ubuntu server
-        - include_tasks: ../utils/get_netplan_config_file.yml
-        - name: "Set fact of the network configure file for Ubuntu server"
-          ansible.builtin.set_fact:
-            network_conf_template: ubuntu_netplan_conf.j2
-            network_conf_path: "{{ netplan_config_file }}"
-          when: netplan_config_file is defined
+    - name: "Set fact of the network config template for Ubuntu server"
+      ansible.builtin.set_fact:
+        network_config_template: ubuntu_netplan_conf.j2
       when:
         - guest_os_ansible_distribution == "Ubuntu"
         - guest_os_with_gui is defined and not guest_os_with_gui
 
-    - name: "Set fact of the network configure file for SLE"
+    - name: "Set fact of the network config template for SLE"
       ansible.builtin.set_fact:
-        network_conf_template: sles_network_conf.j2
-        network_conf_path: "/etc/sysconfig/network/ifcfg-{{ new_network_adapter }}"
+        network_config_template: sles_network_conf.j2
       when: guest_os_family == "Suse"
 
-    - name: "Set fact of the network configure file for Flatcar"
+    - name: "Set fact of the network config template for Flatcar"
       ansible.builtin.set_fact:
-        network_conf_template: flatcar_network_conf.j2
-        network_conf_path: "/etc/systemd/network/{{ new_network_adapter }}"
+        network_config_template: flatcar_network_conf.j2
       when: "'Flatcar' in guest_os_ansible_distribution"
 
-    # Create the network config file for new network interface
-    - name: "Create/Update network configure file '{{ network_conf_path }}'"
-      ansible.builtin.template:
-        src: "{{ network_conf_template }}"
-        dest: "{{ network_conf_path }}"
-        mode: "0666"
-      delegate_to: "{{ vm_guest_ip }}"
-
-    - name: "Get content of network configure file '{{ network_conf_path }}'"
-      ansible.builtin.command: "cat {{ network_conf_path }}"
-      register: network_config
-      changed_when: false
-      delegate_to: "{{ vm_guest_ip }}"
-
-    - name: "Print content of network configure file '{{ network_conf_path }}'"
-      ansible.builtin.debug: var=network_config.stdout_lines
+    - name: "Create or update network config file for new network interface"
+      block:
+        - name: "Create or update network config file '{{ network_config_path }}'"
+          ansible.builtin.template:
+            src: "{{ network_config_template }}"
+            dest: "{{ network_config_path }}"
+            mode: "0666"
+          delegate_to: "{{ vm_guest_ip }}"
+    
+        - name: "Get content of network config file '{{ network_config_path }}'"
+          ansible.builtin.command: "cat {{ network_config_path }}"
+          register: network_config
+          changed_when: false
+          delegate_to: "{{ vm_guest_ip }}"
+    
+        - name: "Print content of network config file '{{ network_config_path }}'"
+          ansible.builtin.debug: var=network_config.stdout_lines
+      when:
+        - network_config_template
+        - network_config_path
   when:
     - guest_os_network_manager != "NetworkManager"
     - guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]
@@ -174,7 +176,8 @@
       - link_status.stdout is defined
       - search_ip in link_status.stdout
     fail_msg: >-
-      Network adapter '{{ new_network_adapter }}' failed to obtain IPv4 address after 100 seconds.
+      Network adapter '{{ new_network_adapter }}' on VM {{ vm_name }}
+      failed to obtain IPv4 address after 100 seconds.
       Its current IPv4 address is '{{ link_status.stdout | default("") }}'.
 
 - name: "Print the new networ adapter IP address"

--- a/linux/network_device_ops/check_and_reload_pvrdma.yml
+++ b/linux/network_device_ops/check_and_reload_pvrdma.yml
@@ -24,7 +24,7 @@
         that:
           - rdma_devices_after_hotadd | length > 0
           - rdma_devices_after_hotadd | difference(rdma_devices_before_hotadd) | length == 1
-        fail_msg: "No new RDMA device is detected"
+        fail_msg: "No new RDMA device is detected on VM {{ vm_name }}"
 
     - name: "Set fact of new RDMA device"
       ansible.builtin.set_fact:

--- a/linux/network_device_ops/hot_add_network_adapter.yml
+++ b/linux/network_device_ops/hot_add_network_adapter.yml
@@ -34,7 +34,7 @@
   ansible.builtin.assert:
     that:
       - new_network_adapter_dmesg | length > 0
-    fail_msg: "There is no message about new {{ adapter_type }} network adapter in dmesg"
+    fail_msg: "There is no message about new {{ adapter_type }} network adapter in dmesg on VM {{ vm_name }}"
 
 - name: "Get network adapters status after hot-add"
   include_tasks: ../utils/get_network_adapters_status.yml
@@ -47,7 +47,7 @@
   ansible.builtin.assert:
     that:
       - network_adapters_after_hotadd | difference(network_adapters_before_hotadd) | length > 0
-    fail_msg: "Fail to detect new added {{ adapter_type }} network adapter in guest OS"
+    fail_msg: "Guest OS failed to detect new added {{ adapter_type }} network adapter on VM {{ vm_name }}"
 
 # Get new added network interface
 - name: "Set fact of new added network adapter"

--- a/linux/network_device_ops/hot_remove_network_adapter.yml
+++ b/linux/network_device_ops/hot_remove_network_adapter.yml
@@ -24,5 +24,5 @@
   ansible.builtin.assert:
     that:
       - network_adapters_after_hotremove | difference(network_adapters_before_hotadd) | length == 0
-    fail_msg: "After hot removing the new network adapter, guest OS still can detect it"
-    success_msg: "The new {{ adapter_type }} adapter interface is removed from guest OS"
+    fail_msg: "After hot removing the new network adapter from VM {{ vm_name }}, guest OS still can detect it"
+    success_msg: "The new {{ adapter_type }} adapter interface is removed in guest OS on VM {{ vm_name }}"

--- a/linux/network_device_ops/network_status_validate.yml
+++ b/linux/network_device_ops/network_status_validate.yml
@@ -78,4 +78,4 @@
       - ping_success_after_ifup
       - not ping_success_after_disconnect
       - ping_success_after_reconnect
-    fail_msg: "At least one result of ping VLAN gateway is not correct"
+    fail_msg: "At least one result of ping VLAN gateway is not correct on VM {{ vm_name }}"

--- a/linux/network_device_ops/prepare_network_device_test.yml
+++ b/linux/network_device_ops/prepare_network_device_test.yml
@@ -20,6 +20,19 @@
     - guest_os_ansible_distribution in ["SLES", "SLED"]
     - guest_os_ansible_distribution_major_ver | int == 12
 
+- name: "Get existing network interface before hotadd testing"
+  include_tasks: ../utils/get_network_adapters_status.yml
+
+- name: "Set fact of network adapter info before hotadd"
+  ansible.builtin.set_fact:
+    network_adapters_before_hotadd: "{{ guest_network_adapters }}"
+
+# Get eth0 device name in guest. Sometimes it is not 'eth0',
+# e.g., 'ens192', 'ens33', etc.
+- name: "Set fact of the first network adapter interface name in guest OS"
+  ansible.builtin.set_fact:
+    eth0_name: "{{ network_adapters_before_hotadd[0] }}"
+
 - name: "Install rdma packages for PVRDMA testing"
   block:
     - name: "Install rdma packages in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
@@ -35,17 +48,25 @@
         package_list: ["rdma-core", "librdmacm-utils"]
         package_state: "present"
       when: guest_os_family in ["Suse", "RedHat"]
+
+    - name: "Get network config file for '{{ eth0_name }}'"
+      include_tasks: ../utils/get_network_config_file.yml
+      vars:
+        network_adapter_name: "{{ eth0_name }}"
+
+    - name: "Remove MAC address or UUID from network config file"
+      block:
+        - name: "Get network config file state"
+          include_tasks: ../utils/get_file_stat_info.yml
+          vars:
+            guest_file_path: "{{ network_config_path }}"
+    
+        - name: "Remove MAC address or UUID from network config file for '{{ eth0_name }}'"
+          ansible.builtin.lineinfile:
+            path: "{{ network_config_path }}"
+            regexp: "^uuid|^UUID|^MAC|^mac"
+            state: absent
+          delegate_to: "{{ vm_guest_ip }}"
+          when: guest_file_exists
+      when: network_config_path
   when: adapter_type == "pvrdma"
-
-- name: "Get existing network interface before hotadd testing"
-  include_tasks: ../utils/get_network_adapters_status.yml
-
-- name: "Set fact of network adapter info before hotadd"
-  ansible.builtin.set_fact:
-    network_adapters_before_hotadd: "{{ guest_network_adapters }}"
-
-# Get eth0 device name in guest. Sometimes it is not 'eth0',
-# e.g., 'ens192', 'ens33', etc.
-- name: "Set fact of the first network adapter interface name in guest OS"
-  ansible.builtin.set_fact:
-    eth0_name: "{{ network_adapters_before_hotadd[0] }}"

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -119,6 +119,9 @@
               - "Server VM '{{ pvrdma_server_vm_name }}' guest IP is '{{ pvrdma_server_vm_guest_ip }}'."
               - "Client VM '{{ pvrdma_client_vm_name }}' guest IP is '{{ pvrdma_client_vm_guest_ip }}'."
 
+        - name: "Add client VM's IP address into inventory"
+          include_tasks: ../../common/update_inventory.yml
+
         - name: "Hot add a new {{ adapter_type }} network adapter on client VM and apply network config"
           include_tasks: hot_add_network_adapter.yml
           vars:

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -192,4 +192,11 @@
         - name: "Cleanup network"
           include_tasks: ../../common/vds_network_cleanup.yml
       rescue:
+        - name: "Switch to server VM"
+          ansible.builtin.set_fact:
+            vm_name: "{{ pvrdma_server_vm_name }}"
+          when:
+            - pvrdma_client_vm_name is defined
+            - vm_name == pvrdma_client_vm_name
+
         - include_tasks: ../../common/test_rescue.yml

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -48,14 +48,16 @@
         - name: "Set facts for PVRDMA server VM and client VM"
           ansible.builtin.set_fact:
             pvrdma_server_vm_name: "{{ vm_name }}"
+            pvrdma_server_vm_guest_ip: "{{ vm_guest_ip }}"
             pvrdma_server_vm_ipv4: "{{ vds_vmk_ip_addr | ansible.utils.ipmath(1) }}"
             pvrdma_server_vm_net_prefix: "{{ vds_vmk_net_prefix }}"
             pvrdma_server_vm_gateway: "{{ vds_vmk_ip_addr }}"
-            pvrdma_client_vm_name: "{{ vm_name }}_{{ timestamp }}"
+            pvrdma_client_vm_name: "{{ vm_name }}_client_{{ timestamp }}"
             pvrdma_client_vm_ipv4: "{{ vds_vmk_ip_addr | ansible.utils.ipmath(2) }}"
+            pvrdma_client_vm_guest_ip: ""
 
         # Clone a new VM as client VM from current VM, and current VM as server
-        - name: "Clone a new VM as PVRDMA client VM from current VM"
+        - name: "Clone a new VM as client VM from current VM"
           include_tasks: ../../common/vm_instant_clone.yml
           vars:
             parent_vm_name: "{{ pvrdma_server_vm_name }}"
@@ -86,29 +88,47 @@
           include_tasks: start_pvrdma_server.yml
 
         # Switch to client VM
-        - name: "Reset the client VM '{{ pvrdma_client_vm_name }}' for updating IP address"
+        - name: "Switch to client VM"
+          ansible.builtin.set_fact:
+            vm_name: "{{ pvrdma_client_vm_name }}"
+
+        - name: "Reset client VM '{{ pvrdma_client_vm_name }}' for updating IP address"
           include_tasks: ../../common/vm_set_power_state.yml
           vars:
-            vm_name: "{{ pvrdma_client_vm_name }}"
             vm_power_state_set: 'restarted'
 
-        - name: "Add client VM guest IP to inventory"
-          include_tasks: ../../common/update_inventory.yml
-          vars:
-            vm_name: "{{ pvrdma_client_vm_name }}"
-            update_inventory_timeout: 300
+        - name: "Get client VM's guest IP"
+          block:
+            - name: "Refresh client VM's guest IP till it has different IP with server VM"
+              include_tasks: refresh_pvrdma_client_vm_ip.yml
+              with_list: "{{ range(1, 11) | list }}"
+              loop_control:
+                loop_var: retry_count
+          when: >
+            (not pvrdma_client_vm_guest_ip) or
+            (pvrdma_client_vm_guest_ip == pvrdma_server_vm_guest_ip)
+
+        - name: "Check client VM's guest IP is not same with server VM's guest IP"
+          ansible.builtin.assert:
+            that:
+              - pvrdma_client_vm_guest_ip != pvrdma_server_vm_guest_ip
+            fail_msg: >-
+              Client VM '{{ pvrdma_client_vm_name }}' guest IP is '{{ pvrdma_client_vm_guest_ip }}',
+              which is same with server VM '{{ pvrdma_server_vm_name }}' guest IP after refreshing 10 times.
+            success_msg:
+              - "Server VM '{{ pvrdma_server_vm_name }}' guest IP is '{{ pvrdma_server_vm_guest_ip }}'."
+              - "Client VM '{{ pvrdma_client_vm_name }}' guest IP is '{{ pvrdma_client_vm_guest_ip }}'."
 
         - name: "Hot add a new {{ adapter_type }} network adapter on client VM and apply network config"
           include_tasks: hot_add_network_adapter.yml
           vars:
-            vm_name: "{{ pvrdma_client_vm_name }}"
             new_nic_ipv4: "{{ pvrdma_client_vm_ipv4 }}"
 
         - name: "Check the result of pinging gateway from client VM"
           ansible.builtin.assert:
             that:
               - ping_success_after_hotadd | bool
-            fail_msg: "Failed to ping gateway from client VM PVRDMA device"
+            fail_msg: "Failed to ping gateway from PVRDMA device on client VM {{ vm_name }}"
 
         - name: "Check PVRDMA device status and reload it if necessary on client VM"
           include_tasks: check_and_reload_pvrdma.yml
@@ -120,18 +140,24 @@
           ignore_errors: true
           register: rping_server_result
 
-        - name: "Display RDMA ping result"
+        - name: "Display RDMA ping result from client VM to server VM"
           ansible.builtin.debug: var=rping_server_result
 
-        - name: "Check the result of RDMA pinging server VM from client VM"
+        - name: "Check RDMA ping result from client VM to server VM"
           ansible.builtin.assert:
             that:
               - rping_server_result is defined
               - rping_server_result.rc is defined
               - rping_server_result.rc == 0
             fail_msg: >-
-              RDMA pinging server VM from client VM failed.
+              Failed to run RDMA ping from client VM '{{ pvrdma_client_vm_name }}'
+              to server VM '{{ pvrdma_server_vm_name }}' failed.
               Hit error '{{ rping_server_result.stderr | default() }}'
+
+        # Switch to server VM
+        - name: "Switch to server VM"
+          ansible.builtin.set_fact:
+            vm_name: "{{ pvrdma_server_vm_name }}"
 
         - name: "Power off the client VM"
           include_tasks: ../../common/vm_set_power_state.yml
@@ -144,8 +170,8 @@
           vars:
             vm_name: "{{ pvrdma_client_vm_name }}"
 
-        # Switch to server VM
-        - include_tasks: ../../common/update_inventory.yml
+        - name: "Update server VM's IP address"
+          include_tasks: ../../common/update_inventory.yml
 
         - name: "Stop PVRDMA listening on server VM"
           ansible.builtin.shell: "kill -9 {{ rping_server_process_pid }}"

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -154,7 +154,7 @@
               - rping_server_result.rc == 0
             fail_msg: >-
               Failed to run RDMA ping from client VM '{{ pvrdma_client_vm_name }}'
-              to server VM '{{ pvrdma_server_vm_name }}' failed.
+              to server VM '{{ pvrdma_server_vm_name }}'.
               Hit error '{{ rping_server_result.stderr | default() }}'
 
         # Switch to server VM

--- a/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
+++ b/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
@@ -10,8 +10,10 @@
   ansible.builtin.pause:
     seconds: 10
 
-- name: "Update client VM's guest IP in inventory"
-  include_tasks: ../../common/update_inventory.yml
+- name: "Get client VM's guest IP"
+  include_tasks: ../../common/vm_get_ip.yml
+  vars:
+    vm_get_ip_timeout: "300"
 
 - name: "Update the fact of client VM's guest IP"
   ansible.builtin.set_fact:

--- a/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
+++ b/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
@@ -6,6 +6,9 @@
 #   restart. It needs to take few seconds to refresh its own IP address.
 #   This task file will refresh client VM's IP every 10s.
 #
+- name: "Print retry count for refreshing client VM's guest IP"
+  ansible.builtin.debug: var=retry_count
+
 - name: "Sleep 10s for client VM's guest IP refreshing"
   ansible.builtin.pause:
     seconds: 10

--- a/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
+++ b/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
@@ -1,0 +1,18 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Description:
+#   The PVRDMA client VM may have same IP address with parent VM after
+#   restart. It needs to take few seconds to refresh its own IP address.
+#   This task file will refresh client VM's IP every 10s.
+#
+- name: "Sleep 10s for client VM's guest IP refreshing"
+  ansible.builtin.pause:
+    seconds: 10
+
+- name: "Update client VM's guest IP in inventory"
+  include_tasks: ../../common/update_inventory.yml
+
+- name: "Update the fact of client VM's guest IP"
+  ansible.builtin.set_fact:
+    pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -27,6 +27,8 @@
       ansible.builtin.set_fact:
         network_config_path: "{{ network_conn_result.stdout_lines[0].split(':')[2] }}"
       when:
+        - network_conn_result.rc is defined
+        - network_conn_result.rc == 0
         - network_conn_result.stdout_lines | length == 1
         - network_conn_result.stdout_lines[0].split(':') | length == 3
   when: guest_os_network_manager == "NetworkManager"

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -1,0 +1,74 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Get network network config file for an interface
+# Parameters:
+#   network_adapter_name: The network interface name
+# Return:
+#   network_config_path: The network interface config file path
+#
+- name: "Initialize network config file for {{ network_adapter_name }}"
+  ansible.builtin.set_fact:
+    network_config_path: ""
+
+- name: "Get network device manager in guest OS"
+  include_tasks: get_network_manager.yml
+  when: guest_os_network_manager is undefined or not guest_os_network_manager
+
+- name: "Get network config file from NetworkManager"
+  block:
+    - name: "Get network connections"
+      ansible.builtin.shell: "nmcli -t -f NAME,ACTIVE,FILENAME connection show --active | grep '^{{ network_adapter_name }}:'"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: "network_conn_result"
+      ignore_errors: true
+
+    - name: "Set fact of network config file for '{{ network_adapter_name }}' on {{ guest_os_ansible_distribution }}"
+      ansible.builtin.set_fact:
+        network_config_path: "{{ network_conn_result.stdout_lines[0].split(':')[2] }}"
+      when:
+        - network_conn_result.stdout_lines | length == 1
+        - network_conn_result.stdout_lines[0].split(':') | length == 3
+  when: guest_os_network_manager == "NetworkManager"
+
+# Set fact of network config file in guest OS except VMware Photon OS
+- name: "Set fact of network config file"
+  block:
+    - name: "Set fact of network config file for '{{ network_adapter_name }}' on {{ guest_os_ansible_distribution }}"
+      ansible.builtin.set_fact:
+        network_config_path: "/etc/sysconfig/network-scripts/ifcfg-{{ network_adapter_name }}"
+      when: guest_os_family == "RedHat"
+
+    - name: "Set fact of network config file for '{{ network_adapter_name }}' on Ubuntu desktop"
+      ansible.builtin.set_fact:
+        network_config_path: "/etc/network/interfaces"
+      when: >
+        (guest_os_ansible_distribution == "Debian") or
+        (guest_os_ansible_distribution == "Ubuntu" and
+         guest_os_with_gui is defined and guest_os_with_gui)
+
+    - name: "Set fact of network config file in Ubuntu server"
+      block:
+        - name: "Get netplan config file in Ubuntu server"
+          include_tasks: ../utils/get_netplan_config_file.yml
+
+        - name: "Set fact of network config file for '{{ network_adapter_name }}' on Ubuntu server"
+          ansible.builtin.set_fact:
+            network_config_path: "{{ netplan_config_file }}"
+          when: netplan_config_file is defined
+      when:
+        - guest_os_ansible_distribution == "Ubuntu"
+        - guest_os_with_gui is defined and not guest_os_with_gui
+
+    - name: "Set fact of network config file for '{{ network_adapter_name }}' on SLE"
+      ansible.builtin.set_fact:
+        network_config_path: "/etc/sysconfig/network/ifcfg-{{ network_adapter_name }}"
+      when: guest_os_family == "Suse"
+
+    - name: "Set fact of network config file for '{{ network_adapter_name }}' on Flatcar"
+      ansible.builtin.set_fact:
+        network_config_path: "/etc/systemd/network/{{ network_adapter_name }}"
+      when: "'Flatcar' in guest_os_ansible_distribution"
+  when:
+    - guest_os_network_manager != "NetworkManager"
+    - guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]


### PR DESCRIPTION
After the instant cloned client VM reset, its IP address may be same with server VM because of the MAC address hasn't change. Usually after a few seconds, the MAC address will be changed to same with VM's settings and then its IP address would also be changed. 

This fix will remove MAC or UUID from network adapter 1's network config file before instant clone, and then refresh client VM's IP address till it has different IP with server VM. After that, the testing can go ahead.