### PR TITLE
Fix GOSV-2466: Update vmtools_url_path for Win

### DIFF
--- a/vars/test.yml
+++ b/vars/test.yml
@@ -299,7 +299,7 @@ windows_has_inbox_driver: true
 # 'vmtools_url_path' takes precedence over 'vmtools_iso_path'.
 #
 vmtools_esxi_bundled: false
-vmtools_url_path: "https://packages.vmware.com/tools/releases/12.1.5/windows/VMware-tools-windows-12.1.5-20735119.iso"
+vmtools_url_path: "https://packages.vmware.com/tools/releases/12.2.0/windows/VMware-tools-windows-12.2.0-21223074.iso"
 # vmtools_iso_path: "[datastore1] VMware/VMTools/12.1.5/windows/VMware-tools-windows-12.1.5-20735119.iso"
 
 # 3. guest_os_inplace_upgrade


### PR DESCRIPTION
Fix GOSV-2466: Update vmtools_url_path with VMTools 12.2.0 ISO URL