### PR TITLE
Fix 370 redirecting types and deprecation warnings

### DIFF
--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -106,7 +106,7 @@
         - name: "Collect VMware Tools logs"
           block:
             - name: "Archive VMware Tools debug logs"
-              ansible.builtin.archive:
+              community.general.archive:
                 path: "{{ vmtools_log_dir }}"
                 dest: "{{ vmtools_log_dir }}.tgz"
                 mode: "0644"

--- a/linux/utils/add_repo_from_baseurl.yml
+++ b/linux/utils/add_repo_from_baseurl.yml
@@ -90,7 +90,7 @@
         - repo_baseurl[0] == '/'
 
     - name: "Add zypper repository {{ repo_name }}"
-      zypper_repository:
+      community.general.zypper_repository:
         name: "{{ repo_name }}"
         repo: "{{ repo_baseurl_prefix }}{{ repo_baseurl }}"
         state: "present"

--- a/windows/deploy_vm/execute_win_gosc.yml
+++ b/windows/deploy_vm/execute_win_gosc.yml
@@ -7,7 +7,7 @@
     ansible_script_runonce_cmd: "powershell.exe -ExecutionPolicy Unrestricted -File C:\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP"
 
 - name: "Customize Windows guest OS"
-  vmware_guest:
+  community.vmware.vmware_guest:
     validate_certs: "{{ validate_certs | default(false) }}"
     hostname: "{{ vcenter_hostname }}"
     esxi_hostname: "{{ esxi_hostname }}"

--- a/windows/deploy_vm/get_pvscsi_driver.yml
+++ b/windows/deploy_vm/get_pvscsi_driver.yml
@@ -64,7 +64,7 @@
     success_msg: "Downloaded VMware tools ISO file exists {{ download_vmtools_iso_path }}"
 
 - name: Extract ISO file to get PVSCSI driver
-  iso_extract:
+  community.general.iso_extract:
     image: "{{ download_vmtools_iso_path }}"
     dest: "{{ local_cache }}/"
     files:

--- a/windows/guest_customization/win_gosc_execution.yml
+++ b/windows/guest_customization/win_gosc_execution.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 - name: "Customize Windows guest OS"
-  vmware_guest:
+  community.vmware.vmware_guest:
     validate_certs: "{{ validate_certs | default(false) }}"
     hostname: "{{ vcenter_hostname }}"
     esxi_hostname: "{{ esxi_hostname }}"

--- a/windows/network_device_ops/network_adapter_deviceops.yml
+++ b/windows/network_device_ops/network_adapter_deviceops.yml
@@ -82,7 +82,7 @@
 - name: Verify network adapter numbers and connect status to VLAN gateway
   ansible.builtin.assert:
     that:
-      - new_nic_mac_address | ansible.netcommon.hwaddr
+      - new_nic_mac_address | ansible.utils.hwaddr
       - "{{ nic_num_before_hotadd | int == nic_num_before_hotadd_guest | int }}"
       - "{{ nic_num_after_hotadd | int == nic_num_after_hotadd_guest | int }}"
       - "{{ nic_num_before_hotadd | int == nic_num_after_hotadd | int - 1 }}"

--- a/windows/utils/win_check_file_exist.yml
+++ b/windows/utils/win_check_file_exist.yml
@@ -12,7 +12,7 @@
     win_check_file_exist_result: false
 
 - name: Check if specified file exists in Windows guest OS
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ win_check_file_exist_file }}"
   delegate_to: "{{ vm_guest_ip }}"
   register: win_check_file_info

--- a/windows/utils/win_copy_file_from_local.yml
+++ b/windows/utils/win_copy_file_from_local.yml
@@ -7,7 +7,7 @@
 #   dest_path_remote: destination file path
 #
 - name: Copy file from local to Windows guest
-  win_copy:
+  ansible.windows.win_copy:
     src: "{{ src_path_local }}"
     dest: "{{ dest_path_remote }}"
   delegate_to: "{{ vm_guest_ip }}"

--- a/windows/utils/win_create_file.yml
+++ b/windows/utils/win_create_file.yml
@@ -6,7 +6,7 @@
 #   new_empty_file_path: file path to be created
 #
 - name: Create an empty file in Windows guest OS
-  win_file:
+  ansible.windows.win_file:
     path: "{{ new_empty_file_path }}"
     state: touch
   delegate_to: "{{ vm_guest_ip }}"

--- a/windows/utils/win_execute_cmd.yml
+++ b/windows/utils/win_execute_cmd.yml
@@ -35,7 +35,7 @@
       ignore_errors: true
     - ansible.builtin.debug: var=ping_vm_result
     - name: "Test connection into guest"
-      setup:
+      ansible.windows.setup:
         filter: "ansible_all_ipv4_addresses"
       register: setup_vm_connection
       delegate_to: "{{ vm_guest_ip }}"

--- a/windows/utils/win_get_physical_cpu_devcon.yml
+++ b/windows/utils/win_get_physical_cpu_devcon.yml
@@ -12,7 +12,7 @@
     processor_number_devcon: 0
 
 - name: Copy devcon.exe to target guest OS
-  win_copy:
+  ansible.windows.win_copy:
     src: ../../tools/devcon64.exe
     dest: C:\devcon.exe
   register: win_copy_output
@@ -20,7 +20,7 @@
   when: target_guest_os_bitness == "64-bit"
 
 - name: Copy devcon.exe to target guest OS
-  win_copy:
+  ansible.windows.win_copy:
     src: ../../tools/devcon32.exe
     dest: C:\devcon.exe
   register: win_copy_output

--- a/windows/utils/win_wait_file_exist.yml
+++ b/windows/utils/win_wait_file_exist.yml
@@ -6,7 +6,7 @@
 #   win_wait_file_exist_file: the file path
 #
 - name: Check specified file status until it exists in Windows guest
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ win_wait_file_exist_file }}"
   delegate_to: "{{ vm_guest_ip }}"
   register: file_info

--- a/windows/utils/win_write_to_file.yml
+++ b/windows/utils/win_write_to_file.yml
@@ -7,7 +7,7 @@
 #   write_file_content: the content will be written to the file
 #
 - name: Write specified content to file in Windows guest OS
-  win_copy:
+  ansible.windows.win_copy:
     dest: "{{ write_file_path }}"
     content: "{{ write_file_content }}"
   delegate_to: "{{ vm_guest_ip }}"


### PR DESCRIPTION

[ansible-vsphere-gos-validation] Fix redirecting types and deprecation warnings

redirecting (type: action) ansible.builtin.win_copy to ansible.windows.win_copy
redirecting (type: modules) ansible.builtin.win_stat to ansible.windows.win_stat
redirecting (type: modules) ansible.builtin.win_file to ansible.windows.win_file
redirecting (type: callback) ansible.builtin.timer to ansible.posix.timer (Cannot find)
redirecting (type: modules) ansible.builtin.setup to ansible.windows.setup 
redirecting (type: filter) ansible.netcommon.hwaddr to ansible.utils.hwaddr
redirecting (type: modules) ansible.builtin.vmware_guest to community.vmware.vmware_guest 

There is one still exists.
redirecting (type: callback) ansible.builtin.timer to ansible.posix.timer
 
Verified with Qi, and make sure it is a callback and isn't a module. It can be ignored.