### PR TITLE
Update log plugin to support more than one test case runs

### DIFF
--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -10,7 +10,7 @@
 # if N < 10, test cases will be 1 ~ N
 # if N >= 10, test cases will be 01 ~ N
 # so that test cases log folders are sorted
-- name: "Set current test case index and name"
+- name: "Set current test case index"
   ansible.builtin.set_fact:
     current_testcase_index: "{{ '{:<}'.format(((current_testcase_index | default(0) | int + 1) | string).
                                               rjust(gosv_testcases_count | string | length, '0')) }}"

--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Set current test case index, name and log folder
-# Paramers:
+# Parameters:
 #   create_test_log_folder: True to create log folder for current test case.
 #   test_log_folder_mode: The mode of log folder for current test case. Default is 0755.
 #
@@ -10,32 +10,21 @@
 # if N < 10, test cases will be 1 ~ N
 # if N >= 10, test cases will be 01 ~ N
 # so that test cases log folders are sorted
-- name: "Set current test case index"
+- name: "Set current test case index and name"
   ansible.builtin.set_fact:
     current_testcase_index: "{{ '{:<}'.format(((current_testcase_index | default(0) | int + 1) | string).
                                               rjust(gosv_testcases_count | string | length, '0')) }}"
-
-- name: "Set current test case name"
-  ansible.builtin.set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
-  when: current_testcase_name is undefined or not current_testcase_name
 
 - name: "Set the log folder path for current test case on local machine"
   ansible.builtin.set_fact:
     current_test_log_folder: "{{ testrun_log_path }}/{{ current_testcase_index }}_{{ ansible_play_name }}"
 
 - name: "Create log folder for current test case"
-  block:
-    - name: "Create log folder for current test case with mode {{ test_log_folder_mode | default('0755') }}"
-      ansible.builtin.file:
-        path: "{{ current_test_log_folder }}"
-        state: directory
-        mode: "{{ test_log_folder_mode | default('0755') }}"
-      register: create_log_path
-
-    - name: "Display the result of creating log folder for current test case"
-      ansible.builtin.debug: var=create_log_path
-      when: enable_debug is defined and enable_debug
+  include_tasks: create_directory.yml
+  vars:
+    dir_path: "{{ current_test_log_folder }}"
+    dir_mode: "{{ test_log_folder_mode | default('0755') }}"
   when:
     - create_test_log_folder is defined
     - create_test_log_folder | bool

--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -1,0 +1,32 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Set current test case index, name and log folder
+# Paramers:
+#   create_test_log_folder: True to create log folder for current test case.
+#   test_log_folder_mode: The mode of log folder for current test case. Default is 0755.
+#
+- name: "Set current test case index and name"
+  ansible.builtin.set_fact:
+    current_testcase_index: "{{ current_testcase_index | default(0) | int + 1 }}"
+    current_testcase_name: "{{ ansible_play_name }}"
+
+- name: "Set the log folder path for current test case on local machine"
+  ansible.builtin.set_fact:
+    current_test_log_folder: "{{ testrun_log_path }}/{{ current_testcase_index }}_{{ ansible_play_name }}"
+
+- name: "Create log folder for current test case"
+  block:
+    - name: "Create log folder for current test case with mode {{ test_log_folder_mode | default('0755') }}"
+      ansible.builtin.file:
+        path: "{{ current_test_log_folder }}"
+        state: directory
+        mode: "{{ test_log_folder_mode | default('0755') }}"
+      register: create_log_path
+
+    - name: "Display the result of creating log folder for current test case"
+      ansible.builtin.debug: var=create_log_path
+      when: enable_debug is defined and enable_debug
+  when:
+    - create_test_log_folder is defined
+    - create_test_log_folder | bool

--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -14,7 +14,11 @@
   ansible.builtin.set_fact:
     current_testcase_index: "{{ '{:<}'.format(((current_testcase_index | default(0) | int + 1) | string).
                                               rjust(gosv_testcases_count | string | length, '0')) }}"
+
+- name: "Set current test case name"
+  ansible.builtin.set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
+  when: current_testcase_name is undefined or not current_testcase_name
 
 - name: "Set the log folder path for current test case on local machine"
   ansible.builtin.set_fact:

--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -6,9 +6,14 @@
 #   create_test_log_folder: True to create log folder for current test case.
 #   test_log_folder_mode: The mode of log folder for current test case. Default is 0755.
 #
+# Supposing there are N test cases,
+# if N < 10, test cases will be 1 ~ N
+# if N >= 10, test cases will be 01 ~ N
+# so that test cases log folders are sorted
 - name: "Set current test case index and name"
   ansible.builtin.set_fact:
-    current_testcase_index: "{{ current_testcase_index | default(0) | int + 1 }}"
+    current_testcase_index: "{{ '{:<}'.format(((current_testcase_index | default(0) | int + 1) | string).
+                                              rjust(gosv_testcases_count | string | length, '0')) }}"
     current_testcase_name: "{{ ansible_play_name }}"
 
 - name: "Set the log folder path for current test case on local machine"

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -10,10 +10,6 @@
 - name: "Set timestamp of failure state"
   ansible.builtin.set_fact:
     timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
-- name: "Set test case name"
-  ansible.builtin.set_fact:
-    current_testcase_name: "{{ deploy_casename | default(ansible_play_name) }}"
-  when: ansible_play_name == "deploy_vm"
 
 - name: "Print failed test case"
   ansible.builtin.debug:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -9,23 +9,17 @@
   vars_files:
     - "{{ testing_vars_file | default('../../vars/test.yml') }}"
   tasks:
+    - name: "Set current test case index, name and log folder"
+      include_tasks: ../../common/set_current_testcase_facts.yml
+      vars:
+        create_test_log_folder: "{{ new_vm is defined and new_vm | bool }}"
+
     - name: "Skip test case"
       include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
         skip_reason: "Skipped"
       when: new_vm is undefined or (not new_vm | bool)
-
-    - name: "Set current test case log path on local machine"
-      ansible.builtin.set_fact:
-        current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
-
-    - name: "Create the current test case log folder with mode '0755'"
-      ansible.builtin.file:
-        path: "{{ current_test_log_folder }}"
-        state: directory
-        mode: '0755'
-      register: create_log_path
 
     # Change vm_username to root if it is not. And add a new user after VM deployment
     - name: "Set user account for new VM"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -1,6 +1,8 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+# Deploy a new VM and install guest OS automatically from an ISO image
+#
 # Initialize undefined variables
 - name: "Initialize variables for new VM settings"
   ansible.builtin.set_fact:
@@ -16,9 +18,9 @@
     - cpu_number is undefined or not cpu_number
     - cpu_cores_per_socket is defined and cpu_cores_per_socket
 
-- name: "Set fact of the deploy VM test case name"
+- name: "Update test case name for deploying VM from ISO image"
   ansible.builtin.set_fact:
-    deploy_casename: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
+    current_testcase_name: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
 
 - name: "Initialize the fact whether to install guest OS with desktop"
   ansible.builtin.set_fact:

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -4,7 +4,7 @@
 # Initialize deploy_casename with guest_id
 - name: "Set fact of deploy VM test case name"
   ansible.builtin.set_fact:
-    deploy_casename: "deploy_ova"
+    deploy_casename: "deploy_vm_ova"
 
 - name: "Test case block"
   block:

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -1,10 +1,11 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Initialize deploy_casename with guest_id
-- name: "Set fact of deploy VM test case name"
+# Deploy a new VM from OVA image
+#
+- name: "Update test case name for deploying VM from OVA image"
   ansible.builtin.set_fact:
-    deploy_casename: "deploy_vm_ova"
+    current_testcase_name: "deploy_vm_ova"
 
 - name: "Test case block"
   block:

--- a/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
+++ b/linux/deploy_vm/flatcar/reconfigure_flatcar_vm.yml
@@ -1,11 +1,6 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Reset deploy_casename in case user doesn't provide correct guest_id
-- name: "Set fact of deploy VM test case name"
-  ansible.builtin.set_fact:
-    deploy_casename: "deploy_flatcar_ova"
-
 # Use Ignition to configure ssh authorized key and user password
 - name: "Generate Ignition config file"
   include_tasks: generate_ignition_config.yml

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -1,10 +1,6 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of the deploy VM test case name"
-  ansible.builtin.set_fact:
-    deploy_casename: "deploy_{{ ova_guest_os_type }}_ova"
-
 - name: "Set fact of cloud-init final message"
   ansible.builtin.set_fact:
     cloudinit_final_msg: "The system is finally up, after $UPTIME seconds"

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -5,25 +5,23 @@
 # If base snapshot does not exist, will take a snapshot of VM as the
 # base snapshot, if it exists, then revert to it directly.
 #
-- name: "Set current test case name and log path on local machine"
-  ansible.builtin.set_fact:
-    current_testcase_name: "{{ ansible_play_name }}"
-    current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
+- name: "Set current test case index, name and log folder"
+  include_tasks: ../../common/set_current_testcase_facts.yml
 
-# Check base snapshot existence and/or revert to it
-- include_tasks: base_snapshot_check_revert.yml
+- name: "Check base snapshot existence and/or revert to it"
+  include_tasks: base_snapshot_check_revert.yml
 
-# Get VM guest IP
-- include_tasks: ../../common/update_inventory.yml
+- name: "Get VM guest IP"
+  include_tasks: ../../common/update_inventory.yml
 
 - name: "Print VM guest IP address"
   ansible.builtin.debug: var=vm_guest_ip
 
-# Get VMware tools status if required
-- include_tasks: ../../common/vm_get_vmtools_status.yml
+- name: "Get VMware tools status"
+  include_tasks: ../../common/vm_get_vmtools_status.yml
 
-# Skip test case run when VMware tools is required but not installed or not running
-- include_tasks: ../../common/skip_test_case.yml
+- name: "Block test case because VMware Toos is not installed or not running"
+  include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: "Test case is blocked because VMware tools installed: {{ vmtools_is_installed | default(false) }}, running: {{ vmtools_is_running | default(false) }}"
     skip_reason: "Blocked"
@@ -32,26 +30,26 @@
     - skip_test_no_vmtools
     - not (vmtools_is_running is defined and vmtools_is_running | bool)
 
-# Get guest OS system info
-- include_tasks: ../utils/get_linux_system_info.yml
+- name: "Get guest OS system info"
+  include_tasks: ../utils/get_linux_system_info.yml
   when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
-# Get VMware tools version info
-- include_tasks: ../utils/get_guest_ovt_version_build.yml
+- name: "Get VMware Tools version and build"
+  include_tasks: ../utils/get_guest_ovt_version_build.yml
   when:
     - vmtools_is_installed is defined
     - vmtools_is_installed | bool
     - vmtools_info_from_vmtoolsd is undefined or not vmtools_info_from_vmtoolsd
 
-# Get VM guest info guest id, guest full name and guest detailed data
-- include_tasks: ../../common/vm_get_guest_info.yml
+- name: "Get VM guest info including guest id, full name, family and detailed data"
+  include_tasks: ../../common/vm_get_guest_info.yml
   when:
     - vmtools_is_running is defined
     - vmtools_is_running | bool
     - guestinfo_gathered is undefined or not guestinfo_gathered
 
-# Create a base snapshot if it does not exist
-- include_tasks: create_base_snapshot.yml
+- name: "Take a base snapshot if it does not exist"
+  include_tasks: create_base_snapshot.yml
   when: not (base_snapshot_exists | bool)
 
 # Hit issue in Ubuntu 22.04 casually: Temporary failure in name resolution. Restarting servcie can fix it
@@ -62,7 +60,8 @@
       delegate_to: "{{ vm_guest_ip }}"
       register: dns_servers_output
 
-    - include_tasks: ../utils/service_operation.yml
+    - name: "Restart service 'systemd-resolved'"
+      include_tasks: ../utils/service_operation.yml
       vars:
         service_name: "systemd-resolved"
         service_enabled: true

--- a/main.yml
+++ b/main.yml
@@ -20,6 +20,20 @@
       vars:
         dir_path: "{{ local_cache }}"
         dir_mode: "0777"
+
+    - name: "Get test cases number in total"
+      ansible.builtin.set_fact:
+        gosv_testcases_count: >-
+          {{
+            lookup('file', testing_testcase_file |
+            default('linux/gosv_testcase_list.yml')) |
+            from_yaml | length
+          }}
+
+    - name: "Print test cases number in total"
+      ansible.builtin.debug:
+        msg: "There are {{ gosv_testcases_count }} test cases to run in total."
+
 # Prepare testing environment
 - import_playbook: env_setup/env_setup.yml
 # Execute test case one by one

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -376,12 +376,12 @@ class TestRun(object):
     def start(self):
         self.start_time = time.time()
         self.status = "Running"
-        # print("Test {} is started.".format(self.id))
+        print("Test {} is started.".format(self.id))
 
     def complete(self, status):
         self.duration = int(time.time() - self.start_time)
         self.status = status
-        # print("Test {} is completed, result is {}.".format(self.id, self.status))
+        print("Test {} is completed, result is {}.".format(self.id, self.status))
 
 class CallbackModule(CallbackBase):
     CALLBACK_NAME = 'ansible_vsphere_gosv_log'
@@ -698,6 +698,7 @@ class CallbackModule(CallbackBase):
         |  3 | gosc_cloudinit_dhcp  | * Failed | 00:12:58  |
         +--------------------------------------------------+
         """
+        print(str(self.test_runs.values()))
 
         total_exec_time = ""
         total_count = len(self.test_runs)
@@ -741,6 +742,7 @@ class CallbackModule(CallbackBase):
         test_idx = 0
         for test_id in self.test_runs:
             test_result = self.test_runs[test_id]
+            print("test_id={}, test_result={}".format(test_id, test_result))
             test_idx += 1
             test_exec_time = time.strftime('%H:%M:%S', time.gmtime(test_result.duration))
             if test_result.status == 'Passed':
@@ -1092,7 +1094,7 @@ class CallbackModule(CallbackBase):
             self.testcase_list[0] == self._play_name):
             # Start new test case
             self._last_test_id = "{}_{}".format((test_index+1), self._play_name)
-            # print("New test id is " + self._last_test_id)
+            print("New test id is " + self._last_test_id)
             if self._last_test_id in self.test_runs:
                 self.test_runs[self._last_test_id].start()
 

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -892,9 +892,7 @@ class CallbackModule(CallbackBase):
                            "get_guest_ovt_version_build.yml",
                            "get_windows_system_info.yml",
                            "win_get_vmtools_version_build.yml",
-                           "check_inbox_driver.yml",
-                           "reconfigure_flatcar_vm.yml",
-                           "reconfigure_vm_with_cloudinit.yml"] or
+                           "check_inbox_driver.yml"] or
              "deploy_vm_from" in task_file) and
                 str(task.action) == "ansible.builtin.set_fact"):
             ansible_facts = task_result.get('ansible_facts', None)
@@ -902,9 +900,7 @@ class CallbackModule(CallbackBase):
                 non_empty_facts = dict(filter(lambda item: item[1],
                                               ansible_facts.items()))
                 self._ansible_gosv_facts.update(non_empty_facts)
-                if (("deploy_vm_from" in task_file or
-                     task_file in ["reconfigure_flatcar_vm.yml",
-                                   "reconfigure_vm_with_cloudinit.yml"]) and
+                if ("deploy_vm_from" in task_file and
                     "deploy_casename" in non_empty_facts and
                     self._last_test_id and
                     self._last_test_id in self.test_runs):

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -668,7 +668,7 @@ class CallbackModule(CallbackBase):
             for index, playbook in enumerate(playbooks):
                 test_name = os.path.basename(playbook['import_playbook']).replace('.yml', '')
                 test_id = "{}_{}".format(str(index+1).rjust(len(str(self.testcases_count)), '0'), test_name)
-                print("Get test id: {}".format(test_id))
+                # print("DEBUG: Get test id: {}".format(test_id))
                 self.test_runs[test_id] = TestRun(test_id, test_name)
                 self.not_completed_testcases.append(test_name)
 
@@ -757,7 +757,11 @@ class CallbackModule(CallbackBase):
             test_idx += 1
             test_exec_time = time.strftime('%H:%M:%S', time.gmtime(test_result.duration))
             if test_result.status == 'Passed':
-                msg += row_format.format(str(test_idx).rjust(min([idx_col_width, len(str(total_count))]), '0'),
+                if len(str(total_count)) == 1:
+                    align_char = ' '
+                else:
+                    align_char = '0'
+                msg += row_format.format(str(test_idx).rjust(idx_col_width, align_char),
                                          test_result.name.ljust(name_col_width),
                                          (status_mark + test_result.status).ljust(status_col_width),
                                          test_exec_time)
@@ -910,7 +914,7 @@ class CallbackModule(CallbackBase):
                 str(task.action) == "ansible.builtin.set_fact"):
             ansible_facts = task_result.get('ansible_facts', None)
             if ansible_facts:
-                non_empty_facts = dict(filter(lambda item: item[1],
+                non_empty_facts = dict(filter(lambda item: item[1] != '',
                                               ansible_facts.items()))
                 self._ansible_gosv_facts.update(non_empty_facts)
                 if ("current_testcase_name" in non_empty_facts and
@@ -1168,6 +1172,10 @@ class CallbackModule(CallbackBase):
 
         # Dump guest info into a json file
         self._dump_guest_info()
+
+        # Debug about ansible facts
+        # print("DEBUG: retieved ansible facts\n{}".format(json.dumps(self._ansible_gosv_facts,
+        #                                                            indent=4)))
 
         # Print test summary when there is test run
         if len(self.test_runs) > 0:

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -743,13 +743,13 @@ class CallbackModule(CallbackBase):
             test_idx += 1
             test_exec_time = time.strftime('%H:%M:%S', time.gmtime(test_result.duration))
             if test_result.status == 'Passed':
-                msg += row_format.format(str(test_idx).rjust(idx_col_width),
+                msg += row_format.format(str(test_idx).rjust(idx_col_width, '0'),
                                          test_result.name.ljust(name_col_width),
                                          (status_mark + test_result.status).ljust(status_col_width),
                                          test_exec_time)
                 status_stats[test_result.status] += 1
             else:
-                msg += row_format.format(str(test_idx).rjust(idx_col_width),
+                msg += row_format.format(str(test_idx).rjust(idx_col_width, '0'),
                                          test_result.name.ljust(name_col_width),
                                          ("* " + test_result.status).ljust(status_col_width),
                                          test_exec_time)
@@ -890,7 +890,9 @@ class CallbackModule(CallbackBase):
                            "get_guest_ovt_version_build.yml",
                            "get_windows_system_info.yml",
                            "win_get_vmtools_version_build.yml",
-                           "check_inbox_driver.yml"] or
+                           "check_inbox_driver.yml",
+                           "reconfigure_flatcar_vm.yml",
+                           "reconfigure_vm_with_cloudinit.yml"] or
              "deploy_vm_from" in task_file) and
                 str(task.action) == "ansible.builtin.set_fact"):
             ansible_facts = task_result.get('ansible_facts', None)
@@ -898,7 +900,9 @@ class CallbackModule(CallbackBase):
                 non_empty_facts = dict(filter(lambda item: item[1],
                                               ansible_facts.items()))
                 self._ansible_gosv_facts.update(non_empty_facts)
-                if ("deploy_vm_from" in task_file and
+                if (("deploy_vm_from" in task_file or
+                     task_file in ["reconfigure_flatcar_vm.yml",
+                                   "reconfigure_vm_with_cloudinit.yml"]) and
                     "deploy_casename" in non_empty_facts and
                     self._last_test_id and
                     self._last_test_id in self.test_runs):

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -791,18 +791,13 @@ class CallbackModule(CallbackBase):
         json_file_path = os.path.join(self.log_dir, self.guest_info_json_file)
         new_guest_info = {}
         if guestinfo:
-            if 'guestinfo_vmtools_info' in guestinfo:
-                new_guest_info['VMware Tools'] = guestinfo['guestinfo_vmtools_info']
-            if 'guestinfo_guest_id' in guestinfo:
-                new_guest_info['GuestInfo Guest ID'] = guestinfo['guestinfo_guest_id']
-            if 'guestinfo_guest_full_name' in guestinfo:
-                new_guest_info['GuestInfo Guest Full Name'] = guestinfo['guestinfo_guest_full_name']
-            if 'guestinfo_guest_family' in guestinfo:
-                new_guest_info['GuestInfo Guest Family'] = guestinfo['guestinfo_guest_family']
-            if 'guestinfo_detailed_data' in guestinfo:
-                new_guest_info['GuestInfo_Detailed_Data'] = guestinfo['guestinfo_detailed_data']
+            new_guest_info['VMware Tools'] = guestinfo.get('guestinfo_vmtools_info', None)
+            new_guest_info['GuestInfo Guest ID'] = guestinfo.get('guestinfo_guest_id', '')
+            new_guest_info['GuestInfo Guest Full Name'] = guestinfo.get('guestinfo_guest_full_name','')
+            new_guest_info['GuestInfo Guest Family'] = guestinfo.get('guestinfo_guest_family', '')
+            new_guest_info['GuestInfo_Detailed_Data'] = guestinfo.get('guestinfo_detailed_data', '')
 
-            if len(new_guest_info.keys()) > 0:
+            if new_guest_info['VMware Tools']:
                 orig_guest_info = {}
                 if os.path.exists(json_file_path):
                     with open(json_file_path, 'r') as json_file:
@@ -1016,12 +1011,13 @@ class CallbackModule(CallbackBase):
         self._play_name = play.get_name()
         self._play_path = self._get_play_path(play)
 
+        if self._last_test_id is None:
+            test_index = 0
+        else:
+            test_index = int(self._last_test_id.split('_')[0]) + 1
+
         # Start new test case
         if self._play_name in self.testcase_list:
-            if self._last_test_id is None:
-                test_index = 0
-            else:
-                test_index = int(self._last_test_id.split('_')[0]) + 1
 
             # Start new test case
             self._last_test_id = "{}_{}".format(test_index, self._play_name)

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -898,7 +898,13 @@ class CallbackModule(CallbackBase):
                 non_empty_facts = dict(filter(lambda item: item[1],
                                               ansible_facts.items()))
                 self._ansible_gosv_facts.update(non_empty_facts)
-                if task_file == "vm_get_guest_info.yml":
+                if ("deploy_vm_from" in task_file and
+                    "deploy_casename" in non_empty_facts and
+                    self._last_test_id and
+                    self._last_test_id in self.test_runs):
+                    # Update deploy_vm test case name
+                    self.test_runs[self._last_test_id].name = non_empty_facts['deploy_casename']
+                elif task_file == "vm_get_guest_info.yml":
                     # Save guest info
                     vm_guest_info = VmGuestInfo(self._ansible_gosv_facts)
                     if vm_guest_info.VMTools_Version:

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -1092,12 +1092,13 @@ class CallbackModule(CallbackBase):
             self.not_completed_testcases.pop(0)
 
         # Move to new started playbook
+        self._last_test_id = None
         self._play_name = play.get_name()
         self._play_path = self._get_play_path(play)
         self._load_testing_vars(play)
 
         test_index = len(self.test_runs) - len(self.not_completed_testcases)
-        # print("Current test index is: {}, play name: {}".format(test_index, self._play_name))
+        # print("DEBUG: Current test index is: {}, play name: {}".format(test_index, self._play_name))
         # Start new test case
         if (test_index < len(self.test_runs) and
             self.not_completed_testcases[0] == self._play_name):
@@ -1107,8 +1108,12 @@ class CallbackModule(CallbackBase):
 
             if self._last_test_id in self.test_runs:
                 self.test_runs[self._last_test_id].start()
+            else:
+                self._last_test_id = None
 
-        if self._play_name:
+        if self._last_test_id:
+            msg = self._banner("PLAY [{}]".format(self._last_test_id))
+        elif self._play_name:
             msg = self._banner("PLAY [{}]".format(self._play_name))
         else:
             msg = self._banner("PLAY")

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -394,6 +394,7 @@ class CallbackModule(CallbackBase):
         self.hosts = []
         self.play = None
         self.log_msg = ''
+        self.testcases_count = 0
         self.test_runs = OrderedDict()
         self.not_completed_testcases = []
 
@@ -663,9 +664,10 @@ class CallbackModule(CallbackBase):
 
         with open(testcase_file_path, 'r') as fd:
             playbooks = yaml.load(fd, Loader=yaml.Loader)
+            self.testcases_count = len(playbooks)
             for index, playbook in enumerate(playbooks):
                 test_name = os.path.basename(playbook['import_playbook']).replace('.yml', '')
-                test_id = "{}_{}".format((index+1), test_name)
+                test_id = "{}_{}".format(str(index+1).rjust(len(str(self.testcases_count)), '0'), test_name)
                 print("Get test id: {}".format(test_id))
                 self.test_runs[test_id] = TestRun(test_id, test_name)
                 self.not_completed_testcases.append(test_name)
@@ -1100,7 +1102,9 @@ class CallbackModule(CallbackBase):
         if (test_index < len(self.test_runs) and
             self.not_completed_testcases[0] == self._play_name):
             # Start new test case
-            self._last_test_id = "{}_{}".format((test_index+1), self._play_name)
+            self._last_test_id = "{}_{}".format(str(test_index+1).rjust(len(str(self.testcases_count)), '0'),
+                                                self._play_name)
+
             if self._last_test_id in self.test_runs:
                 self.test_runs[self._last_test_id].start()
 

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -13,31 +13,28 @@
   vars_files:
     - "{{ testing_vars_file | default('../../vars/test.yml') }}"
   tasks:
-    - include_tasks: ../../common/skip_test_case.yml
+    - name: "Set current test case index, name and log folder"
+      include_tasks: ../../common/set_current_testcase_facts.yml
+      vars:
+        create_test_log_folder: "{{ new_vm is defined and new_vm | bool }}"
+
+    - name: "Skip test case"
+      include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case due to new_vm is set to '{{ new_vm | default(false) }}'"
         skip_reason: "Skipped"
       when: new_vm is undefined or not new_vm | bool
 
-    - block:
-        - name: "Set current test case log path on local machine"
-          ansible.builtin.set_fact:
-            current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
-        - name: "Create the current test case log folder with mode '0755'"
-          ansible.builtin.file:
-            path: "{{ current_test_log_folder }}"
-            state: directory
-            mode: '0755'
-          register: create_log_path
-        - ansible.builtin.debug: var=create_log_path
-          when: enable_debug is defined and enable_debug
-
-        - include_tasks: deploy_vm_from_iso.yml
+    - name: "Deploy VM"
+      block:
+        - name: "Deploy VM by creating a new VM and install OS from ISO image on it"
+          include_tasks: deploy_vm_from_iso.yml
           when: >
             (vm_deploy_method is undefined) or
             (vm_deploy_method | lower == 'iso')
 
-        - include_tasks: deploy_vm_from_ova.yml
+        - name: "Deploy VM from an OVF template"
+          include_tasks: deploy_vm_from_ova.yml
           when:
             - vm_deploy_method is defined
             - vm_deploy_method | lower == 'ova'
@@ -46,24 +43,26 @@
           ansible.builtin.debug: var=vm_guest_ip
           when: vm_guest_ip is defined
 
-        # Take screenshot of VM after guest OS install
-        - include_tasks: ../../common/vm_take_screenshot.yml
+        - name: "Take screenshot of VM after guest OS install"
+          include_tasks: ../../common/vm_take_screenshot.yml
           vars:
             vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml
           vars:
             exit_testing_when_fail: true
       always:
-        - block:
-            # Umount NFS share points
-            - include_tasks: ../../common/local_unmount.yml
+        - name: "Remove NFS mount point"
+          block:
+            - name: "Umount NFS share point"
+              include_tasks: ../../common/local_unmount.yml
               vars:
                 mount_path: "{{ nfs_mount_dir }}"
                 local_unmount_ignore_errors: true
               when: nfs_mounted is defined and nfs_mounted | bool
-            # Remove temporary folders
-            - include_tasks: ../../common/delete_local_file.yml
+            - name: "Remove NFS mount folder"
+              include_tasks: ../../common/delete_local_file.yml
               vars:
                 local_path: "{{ nfs_mount_dir }}"
                 del_local_file_ignore_errors: true

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -13,9 +13,9 @@
     firmware: "{{ firmware if (firmware is defined and firmware) else 'efi' }}"
     boot_disk_size_gb: "{{ [64, boot_disk_size_gb | default(64) | int] | max }}"
 
-- name: "Set fact of the deploy VM test case name"
+- name: "Update test case name for deploying VM from ISO image"
   ansible.builtin.set_fact:
-    deploy_casename: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
+    current_testcase_name: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
 
 # Check configured VM CPU number and cores per socket number
 - include_tasks: check_cpu_socket.yml

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -3,9 +3,9 @@
 ---
 # Deploy a new Windows VM through the Windows OVF/OVA template
 #
-- name: "Set fact of the deploy VM test case name"
+- name: "Update test case name for deploying VM from OVF image"
   ansible.builtin.set_fact:
-    deploy_casename: "deploy_vm_ovf"
+    current_testcase_name: "deploy_vm_ovf"
 
 # OVA file on local machine
 - name: "Get OVA path and file name"

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -5,37 +5,38 @@
 # if base snapshot exists, revert to the base snapshot when it exists.
 # If base snapshot does not exist, then take a snapshot of VM as the base snapshot.
 #
-- name: "Set current test case name and log path on local machine"
-  ansible.builtin.set_fact:
-    current_testcase_name: "{{ ansible_play_name }}"
-    current_test_log_folder: "{{ testrun_log_path }}/{{ ansible_play_name }}"
-
-- name: "Create current test case log folder when required"
-  include_tasks: ../../common/create_directory.yml
+- name: "Set current test case index, name and log folder"
+  include_tasks: ../../common/set_current_testcase_facts.yml
   vars:
-    dir_path: "{{ current_test_log_folder }}"
-    dir_mode: "0777"
-  when: create_current_test_folder is defined and create_current_test_folder
+    create_test_log_folder: "{{ create_current_test_folder is defined and create_current_test_folder }}"
+    test_log_folder_mode: "0777"
 
-- include_tasks: base_snapshot_check_revert.yml
+- name: "Check base snapshot existence and/or revert to it"
+  include_tasks: base_snapshot_check_revert.yml
 
-- include_tasks: ../../common/vm_get_ip.yml
+- name: "Get VM guest IP"
+  include_tasks: ../../common/vm_get_ip.yml
   vars:
     vm_get_ip_timeout: 600
-- include_tasks: ../utils/win_check_winrm.yml
-- include_tasks: ../utils/add_windows_host.yml
+
+- name: "Check Windows winrm is connectable"
+  include_tasks: ../utils/win_check_winrm.yml
+
+- name: "Add Windows host to in-memory inventory"
+  include_tasks: ../utils/add_windows_host.yml
+
 - name: "Print VM guest IP address"
   ansible.builtin.debug: var=vm_guest_ip
 
-# Pause Windows Update
-- include_tasks: ../utils/win_pause_windows_update.yml
+- name: "Pause Windows Update"
+  include_tasks: ../utils/win_pause_windows_update.yml
   when: not base_snapshot_exists
 
-# Get VMware tools status
-- include_tasks: ../../common/vm_get_vmtools_status.yml
+- name: "Get VMware Tools status"
+  include_tasks: ../../common/vm_get_vmtools_status.yml
 
-# Skip test case run when VMware tools is required but not installed or not running
-- include_tasks: ../../common/skip_test_case.yml
+- name: "Block test case because VMware Toos is not installed or not running"
+  include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: "Test case '{{ current_testcase_name }}' is blocked because VMware tools installed: {{ vmtools_is_installed | default(false) }}, running: {{ vmtools_is_running | default(false) }}"
     skip_reason: "Blocked"
@@ -44,23 +45,24 @@
     - skip_test_no_vmtools
     - not (vmtools_is_running is defined and vmtools_is_running | bool)
 
-- include_tasks: ../utils/win_get_vmtools_version_build.yml
+- name: "Get VMware Tools version and build"
+  include_tasks: ../utils/win_get_vmtools_version_build.yml
   when:
     - vmtools_is_installed is defined
     - vmtools_is_installed | bool
     - vmtools_info_from_vmtoolsd is undefined or not vmtools_info_from_vmtoolsd
 
-# Get guest OS info if not defined
-- include_tasks: ../utils/get_windows_system_info.yml
+- name: "Get guest OS system info"
+  include_tasks: ../utils/get_windows_system_info.yml
   when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
-# Get VM guest info guest id, guest full name and guest detailed data
-- include_tasks: ../../common/vm_get_guest_info.yml
+- name: "Get VM guest info including guest id, full name, family and detailed data"
+  include_tasks: ../../common/vm_get_guest_info.yml
   when:
     - vmtools_is_running is defined
     - vmtools_is_running | bool
     - guestinfo_gathered is undefined or not guestinfo_gathered
 
-# Take base snapshot if not exist
-- include_tasks: create_base_snapshot.yml
+- name: "Take a base snapshot if it does not exist"
+  include_tasks: create_base_snapshot.yml
   when: not base_snapshot_exists


### PR DESCRIPTION
Changes in this fix will print test cases in order in results.log with a case index in front of them, so that it can distinguish different runs for same test case. And test case log folder will have same case index in front of folder name. 

If there are less than 10 test cases, case index will start from "1".
If there are 10 or more test cases, case index will starts from "01".
```
Testbed information:
+------------------------------------------------------------------------------------------+
| Product | Version | Build    | Hostname or IP | Server Model                             |
+------------------------------------------------------------------------------------------+
| vCenter | 8.0.0   | 20519528 | x.x.x.x  |                                          |
+------------------------------------------------------------------------------------------+
| ESXi    | 8.0.0   | 20513097 | x.x.x.x | VMware, Inc. VMware7,1                   |
|         |         |          |                | Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz |
+------------------------------------------------------------------------------------------+


VM information:
+----------------------------------------------------------------------+
| Name                      | test_ubuntu22.10_ova-3                   |
+----------------------------------------------------------------------+
| Guest OS Distribution     | Ubuntu 22.10 x86_64                      |
+----------------------------------------------------------------------+
| IP                        | 10.186.131.184                           |
+----------------------------------------------------------------------+
| GUI Installed             | False                                    |
+----------------------------------------------------------------------+
| CloudInit Version         |                                          |
+----------------------------------------------------------------------+
| Hardware Version          | vmx-20                                   |
+----------------------------------------------------------------------+
| VMTools Version           | 12.3.0 (build-21507661)                  |
+----------------------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                            |
+----------------------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                            |
+----------------------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)                    |
+----------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                               |
+----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                       |
|                           | bitness='64'                             |
|                           | distroAddlVersion='22.10 (Kinetic Kudu)' |
|                           | distroName='Ubuntu'                      |
|                           | distroVersion='22.10'                    |
|                           | familyName='Linux'                       |
|                           | kernelVersion='5.19.0-21-generic'        |
|                           | prettyName='Ubuntu 22.10'                |
+----------------------------------------------------------------------+


Test Results (Total: 4, Passed: 4, Elapsed Time: 00:30:48)
+----------------------------------------------+
| ID | Name               | Status | Exec Time |
+----------------------------------------------+
|  1 | deploy_vm_ova      | Passed | 00:07:11  |
|  2 | check_os_fullname  | Passed | 00:01:12  |
|  3 | ovt_verify_install | Passed | 00:20:57  |
|  4 | check_os_fullname  | Passed | 00:01:10  |
+----------------------------------------------+


VM information:
+------------------------------------------------------------------------------------------+
| Name                      | test_windows_server_ltsc_vnext                               |
+------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Microsoft Windows Server 2022 Datacenter 10.0.25314.0 64-bit |
+------------------------------------------------------------------------------------------+
| IP                        | x.x.x.x                                      |
+------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                                       |
+------------------------------------------------------------------------------------------+
| VMTools Version           | x.x.x                              |
+------------------------------------------------------------------------------------------+
| Config Guest Id           | windows2019srvNext_64Guest                                   |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | windows2022srvNext_64Guest                                   |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Microsoft Windows Server 2025 (64-bit)                       |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | windowsGuest                                                 |
+------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                           |
|                           | bitness='64'                                                 |
|                           | buildNumber='25314'                                          |
|                           | distroVersion='Windows'                                      |
|                           | distroAddlVersion='10.0'                                     |
|                           | familyName='Windows'                                         |
|                           | kernelVersion='25314.1000'                                   |
|                           | prettyName='Windows Server 2025, 64-bit (Build 25314.1000)'  |
+------------------------------------------------------------------------------------------+


Test Results (Total: 27, Passed: 27, Elapsed Time: 02:23:50)
+------------------------------------------------------------+
| ID | Name                             | Status | Exec Time |
+------------------------------------------------------------+
| 01 | deploy_vm_efi_nvme_e1000e        | Passed | 00:13:52  |
| 02 | check_inbox_driver               | Passed | 00:03:30  |
| 03 | secureboot_enable_disable        | Passed | 00:05:43  |
| 04 | wintools_complete_install_verify | Passed | 00:10:47  |
| 05 | check_efi_firmware               | Passed | 00:00:58  |
| 06 | check_ip_address                 | Passed | 00:01:07  |
| 07 | check_os_fullname                | Passed | 00:00:49  |
| 08 | mouse_driver_vmtools             | Passed | 00:00:40  |
| 09 | vgauth_check_service             | Passed | 00:00:49  |
| 10 | stat_balloon                     | Passed | 00:00:50  |
| 11 | stat_hosttime                    | Passed | 00:00:58  |
| 12 | paravirtual_vhba_device_ops      | Passed | 00:05:25  |
| 13 | lsilogicsas_vhba_device_ops      | Passed | 00:06:00  |
| 14 | sata_vhba_device_ops             | Passed | 00:05:36  |
| 15 | nvme_vhba_device_ops             | Passed | 00:07:18  |
| 16 | nvme_vhba_device_ops_spec13      | Passed | 00:07:35  |
| 17 | nvme_disk_hot_extend_spec13      | Passed | 00:05:19  |
| 18 | nvdimm_cold_add_remove           | Passed | 00:09:42  |
| 19 | e1000e_network_device_ops        | Passed | 00:05:45  |
| 20 | vmxnet3_network_device_ops       | Passed | 00:04:58  |
| 21 | memory_hot_add_basic             | Passed | 00:05:15  |
| 22 | check_quiesce_snapshot           | Passed | 00:02:32  |
| 23 | cpu_multicores_per_socket        | Passed | 00:10:24  |
| 24 | gosc_sanity_staticip             | Passed | 00:06:56  |
| 25 | gosc_sanity_dhcp                 | Passed | 00:09:08  |
| 26 | wintools_uninstall_verify        | Passed | 00:06:25  |
| 27 | cpu_hot_add_basic                | Passed | 00:04:00  |
+------------------------------------------------------------+

```

Test cases log folders will be like
```
01_deploy_vm
02_check_inbox_driver
07_check_os_fullname
11_check_quiesce_snapshot_custom_script
20_gosc_perl_dhcp
21_gosc_perl_staticip
22_gosc_cloudinit_dhcp
23_gosc_cloudinit_staticip
29_nvdimm_cold_add_remove
```

The play name in log files will also has the case index:
```
2023-03-26 15:51:14,026 | Failed at Play [29_nvdimm_cold_add_remove] *****************

2023-03-26 15:51:14,026 | TASK [29_nvdimm_cold_add_remove][Check the new PMem device is recognized by guest OS after cold add] 
task path: /home/worker/workspace/Ansible_Regression_Ubuntu_20.04_Server_OVA/ansible-vsphere-gos-validation/linux/nvdimm_cold_add_remove/cold_add_nvdimm_test.yml:117
fatal: [localhost]: FAILED! => {
    "assertion": "(guest_nvdimm_list_after_add | difference(guest_nvdimm_list_before_add)) | length == 1",
    "changed": false,
    "evaluated_to": false,
    "msg": "Guest PMem device list before cold add is [], after cold add is [], the new added PMem device is not recognized."
}
error message:
Guest PMem device list before cold add is [], after cold add is [], the new added PMem device is not recognized.

```

Deploy_vm failure would block the rest of test cases:
```
Test Results (Total: 4, Failed: 1, Blocked: 3, Elapsed Time: 01:16:00)
+---------------------------------------------------------------+
| ID | Name                             |   Status  | Exec Time |
+---------------------------------------------------------------+
|  1 | deploy_vm_efi_lsilogicsas_e1000e | * Failed  | 01:14:59  |
|  2 | wintools_complete_install_verify | * Blocked | 00:00:00  |
|  3 | guest_os_inplace_upgrade         | * Blocked | 00:00:00  |
|  4 | wintools_complete_install_verify | * Blocked | 00:00:00  |
+---------------------------------------------------------------+
```