### PR TITLE
[Ubuntu 20.04 desktop] Failed to deploy ubuntu 20.04.6 desktop VM with bios

### DIFF
--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -50,7 +50,7 @@
         replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
 
     - name: "Print the content of modified file grub.cfg"
-      debug:
+      ansible.builtin.debug:
         msg: "{{ lookup('file', src_iso_file_dir + '/grub.cfg') }}"
 
     - name: "Extract isolinux/isolinux.cfg inside ISO for old releases"
@@ -76,8 +76,20 @@
                 append  file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity initrd=/casper/initrd quiet splash noprompt --- console=ttyS0,115200n8
 
         - name: "Print the content of modified file isolinux.cfg"
-          debug:
+          ansible.builtin.debug:
             msg: "{{ lookup('file', src_iso_file_dir + '/isolinux.cfg') }}"
+
+        - name: "Customize the ISO with isolinux/isolinux.cfg"
+          community.general.iso_customize:
+            src_iso: "{{ src_iso_file_path }}"
+            dest_iso: "{{ rebuilt_unattend_iso_path }}"
+            add_files:
+              - src_file: "{{ src_iso_file_dir }}/grub.cfg"
+                dest_file: "/boot/grub/grub.cfg"
+              - src_file: "{{ new_unattend_install_conf }}"
+                dest_file: "/preseed/ubuntu.seed"
+              - src_file: "{{ src_iso_file_dir }}/isolinux.cfg"
+                dest_file: "/isolinux/isolinux.cfg"
       when: not result_extract_file.failed
 
     - name: "Customize the ISO without isolinux/isolinux.cfg"
@@ -90,19 +102,6 @@
           - src_file: "{{ new_unattend_install_conf }}"
             dest_file: "/preseed/ubuntu.seed"
       when: result_extract_file.failed
-
-    - name: "Customize the ISO with isolinux/isolinux.cfg"
-      community.general.iso_customize:
-        src_iso: "{{ src_iso_file_path }}"
-        dest_iso: "{{ rebuilt_unattend_iso_path }}"
-        add_files:
-          - src_file: "{{ src_iso_file_dir }}/grub.cfg"
-            dest_file: "/boot/grub/grub.cfg"
-          - src_file: "{{ new_unattend_install_conf }}"
-            dest_file: "/preseed/ubuntu.seed"
-          - src_file: "{{ src_iso_file_dir }}/isolinux.cfg"
-            dest_file: "/isolinux/isolinux.cfg"
-      when: not result_extract_file.failed
   when: unattend_install_conf is match('Ubuntu/Desktop')
 
 - name: "Rebuild ISO for Photon"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -30,54 +30,58 @@
 
 - name: "Rebuild ISO for Ubuntu desktop"
   block:
-    - name: Extract specific files inside ISO
+    - name: "Extract specific files inside ISO"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
         files:
           - "boot/grub/grub.cfg"
 
-    - name: Modify boot entry
+    - name: "Modify boot entry"
       ansible.builtin.replace:
         path: "{{ src_iso_file_dir }}/grub.cfg"
         regexp: "set timeout=[1-9][0-9]{0,1}"
         replace: "default=0\nset timeout=2"
 
-    - name: Modify boot options
+    - name: "Modify boot options"
       ansible.builtin.replace:
         path: "{{ src_iso_file_dir }}/grub.cfg"
         regexp: "file=/cdrom/preseed/ubuntu.seed maybe-ubiquity quiet splash ---"
         replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
 
-    - name: "Print the content of modified file"
+    - name: "Print the content of modified file grub.cfg"
       debug:
         msg: "{{ lookup('file', src_iso_file_dir + '/grub.cfg') }}"
 
-    - name: Extract isolinux/txt.cfg inside ISO for old releases
+    - name: "Extract isolinux/txt.cfg inside ISO for old releases"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
         files:
           - "isolinux/txt.cfg"
-        ignore_errors: true
-        register: result_extract_file
+      ignore_errors: true
+      register: result_extract_file
 
     - name: "Different file for some old releases such as Ubuntu 20.04 when the firmware is bios"
       block:
-        - name: Modify default boot mode
+        - name: "Modify default boot mode"
           ansible.builtin.replace:
           path: "{{ src_iso_file_dir }}/txt.cfg"
           regexp: "default live"
           replace: "default live-install"
 
-        - name: Modify boot options
+        - name: "Modify boot options"
           ansible.builtin.replace:
           path: "{{ src_iso_file_dir }}/txt.cfg"
           regexp: "file=/cdrom/preseed/ubuntu.seed only-ubiquity initrd=/casper/initrd quiet splash ---"
           replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
+        
+        - name: "Print the content of modified file txt.cfg"
+          debug:
+            msg: "{{ lookup('file', src_iso_file_dir + '/txt.cfg') }}"
       when: not result_extract_file.failed
 
-    - name: Customize the ISO without isolinux/txt.cfg
+    - name: "Customize the ISO without isolinux/txt.cfg"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -88,7 +92,7 @@
             dest_file: "/preseed/ubuntu.seed"
       when: result_extract_file.failed
 
-    - name: Customize the ISO with isolinux/txt.cfg
+    - name: "Customize the ISO with isolinux/txt.cfg"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -104,7 +108,7 @@
 
 - name: "Rebuild ISO for Photon"
   block:
-    - name: Extract specific files inside ISO
+    - name: "Extract specific files inside ISO"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
@@ -128,7 +132,7 @@
         - "menu.cfg"
         - "grub.cfg"
 
-    - name: Customize the ISO
+    - name: "Customize the ISO"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -145,7 +149,7 @@
 
 - name: "Rebuild ISO for Debian"
   block:
-    - name: Extract specific files inside ISO
+    - name: "Extract specific files inside ISO"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
@@ -216,7 +220,7 @@
     - name: "Print command output for updating initrd"
       ansible.builtin.debug: var=update_initrd_output
 
-    - name: Customize the ISO
+    - name: "Customize the ISO"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -266,7 +270,7 @@
       ansible.builtin.set_fact:
         ubuntu_bios_cfg_exist: false
 
-    - name: Extract isolinux/txt.cfg inside ISO if exists
+    - name: "Extract isolinux/txt.cfg inside ISO if exists"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
@@ -297,7 +301,7 @@
           args:
             chdir: "{{ unattend_iso_cache }}"
 
-        - name: Customize the ISO
+        - name: "Customize the ISO"
           community.general.iso_customize:
             src_iso: "{{ src_iso_file_path }}"
             dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -310,7 +314,7 @@
                 dest_file: "isolinux/txt.cfg"
       when: ubuntu_bios_cfg_exist
 
-    - name: Customize the ISO without txt.cfg
+    - name: "Customize the ISO without txt.cfg"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -53,35 +53,34 @@
       debug:
         msg: "{{ lookup('file', src_iso_file_dir + '/grub.cfg') }}"
 
-    - name: "Extract isolinux/txt.cfg inside ISO for old releases"
+    - name: "Extract isolinux/isolinux.cfg inside ISO for old releases"
       community.general.iso_extract:
         image: "{{ src_iso_file_path }}"
         dest: "{{ src_iso_file_dir }}"
         files:
-          - "isolinux/txt.cfg"
+          - "isolinux/isolinux.cfg"
       ignore_errors: true
       register: result_extract_file
 
     - name: "Different file for some old releases such as Ubuntu 20.04 when the firmware is bios"
       block:
-        - name: "Modify default boot mode"
-          ansible.builtin.replace:
-            path: "{{ src_iso_file_dir }}/txt.cfg"
-            regexp: "default live"
-            replace: "default live-install"
+        - name: "Modify boot option"
+          ansible.builtin.blockinfile:
+            path: "{{ src_iso_file_dir }}/isolinux.cfg"
+            insertafter: "^#.*etc.*"
+            block: |
+              default live-install
+              label live-install
+                menu label ^Install Ubuntu
+                kernel /casper/vmlinuz
+                append  file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity initrd=/casper/initrd quiet splash noprompt --- console=ttyS0,115200n8
 
-        - name: "Modify boot options"
-          ansible.builtin.replace:
-            path: "{{ src_iso_file_dir }}/txt.cfg"
-            regexp: "file=/cdrom/preseed/ubuntu.seed only-ubiquity initrd=/casper/initrd quiet splash ---"
-            replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
-        
-        - name: "Print the content of modified file txt.cfg"
+        - name: "Print the content of modified file isolinux.cfg"
           debug:
-            msg: "{{ lookup('file', src_iso_file_dir + '/txt.cfg') }}"
+            msg: "{{ lookup('file', src_iso_file_dir + '/isolinux.cfg') }}"
       when: not result_extract_file.failed
 
-    - name: "Customize the ISO without isolinux/txt.cfg"
+    - name: "Customize the ISO without isolinux/isolinux.cfg"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -92,7 +91,7 @@
             dest_file: "/preseed/ubuntu.seed"
       when: result_extract_file.failed
 
-    - name: "Customize the ISO with isolinux/txt.cfg"
+    - name: "Customize the ISO with isolinux/isolinux.cfg"
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -101,8 +100,8 @@
             dest_file: "/boot/grub/grub.cfg"
           - src_file: "{{ new_unattend_install_conf }}"
             dest_file: "/preseed/ubuntu.seed"
-          - src_file: "{{ src_iso_file_dir }}/txt.cfg"
-            dest_file: "/isolinux/txt.cfg"
+          - src_file: "{{ src_iso_file_dir }}/isolinux.cfg"
+            dest_file: "/isolinux/isolinux.cfg"
       when: not result_extract_file.failed
   when: unattend_install_conf is match('Ubuntu/Desktop')
 

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -62,7 +62,7 @@
       ignore_errors: true
       register: result_extract_file
 
-    - name: "Different file for some old releases such as Ubuntu 20.04 when the firmware is bios"
+    - name: "Modify isolinux.cfg for some old releases such as Ubuntu 20.04 when the firmware is bios"
       block:
         - name: "Modify boot option"
           ansible.builtin.blockinfile:

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -53,7 +53,31 @@
       debug:
         msg: "{{ lookup('file', src_iso_file_dir + '/grub.cfg') }}"
 
-    - name: Customize the ISO
+    - name: Extract isolinux/txt.cfg inside ISO for old releases
+      community.general.iso_extract:
+        image: "{{ src_iso_file_path }}"
+        dest: "{{ src_iso_file_dir }}"
+        files:
+          - "isolinux/txt.cfg"
+        ignore_errors: true
+        register: result_extract_file
+  
+    - name: "Different file for some old releases such as Ubuntu 20.04 when the firmware is bios"
+      block:
+        - name: Modify default boot mode
+          ansible.builtin.replace:
+          path: "{{ src_iso_file_dir }}/txt.cfg"
+          regexp: "default live"
+          replace: "default live-install"
+        
+        - name: Modify boot options
+          ansible.builtin.replace:
+          path: "{{ src_iso_file_dir }}/txt.cfg"
+          regexp: "file=/cdrom/preseed/ubuntu.seed only-ubiquity initrd=/casper/initrd quiet splash ---"
+          replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
+      when: not result_extract_file.failed
+
+    - name: Customize the ISO without isolinux/txt.cfg
       community.general.iso_customize:
         src_iso: "{{ src_iso_file_path }}"
         dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -62,6 +86,20 @@
             dest_file: "/boot/grub/grub.cfg"
           - src_file: "{{ new_unattend_install_conf }}"
             dest_file: "/preseed/ubuntu.seed"
+      when: result_extract_file.failed
+
+    - name: Customize the ISO with isolinux/txt.cfg
+      community.general.iso_customize:
+        src_iso: "{{ src_iso_file_path }}"
+        dest_iso: "{{ rebuilt_unattend_iso_path }}"
+        add_files:
+          - src_file: "{{ src_iso_file_dir }}/grub.cfg"
+            dest_file: "/boot/grub/grub.cfg"
+          - src_file: "{{ new_unattend_install_conf }}"
+            dest_file: "/preseed/ubuntu.seed"
+          - src_file: "{{ src_iso_file_dir }}/txt.cfg"
+            dest_file: "/isolinux/txt.cfg"
+      when: not result_extract_file.failed
   when: unattend_install_conf is match('Ubuntu/Desktop')
 
 - name: "Rebuild ISO for Photon"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -90,7 +90,10 @@
                 dest_file: "/preseed/ubuntu.seed"
               - src_file: "{{ src_iso_file_dir }}/isolinux.cfg"
                 dest_file: "/isolinux/isolinux.cfg"
-      when: not result_extract_file.failed
+      when: 
+        - result_extract_file is defined
+        - result_extract_file.failed is defined
+        - not result_extract_file.failed
 
     - name: "Customize the ISO without isolinux/isolinux.cfg"
       community.general.iso_customize:
@@ -101,7 +104,10 @@
             dest_file: "/boot/grub/grub.cfg"
           - src_file: "{{ new_unattend_install_conf }}"
             dest_file: "/preseed/ubuntu.seed"
-      when: result_extract_file.failed
+      when: 
+        - result_extract_file is defined
+        - result_extract_file.failed is defined
+        - result_extract_file.failed
   when: unattend_install_conf is match('Ubuntu/Desktop')
 
 - name: "Rebuild ISO for Photon"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -61,7 +61,7 @@
           - "isolinux/txt.cfg"
         ignore_errors: true
         register: result_extract_file
-  
+
     - name: "Different file for some old releases such as Ubuntu 20.04 when the firmware is bios"
       block:
         - name: Modify default boot mode
@@ -69,7 +69,7 @@
           path: "{{ src_iso_file_dir }}/txt.cfg"
           regexp: "default live"
           replace: "default live-install"
-        
+
         - name: Modify boot options
           ansible.builtin.replace:
           path: "{{ src_iso_file_dir }}/txt.cfg"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -66,15 +66,15 @@
       block:
         - name: "Modify default boot mode"
           ansible.builtin.replace:
-          path: "{{ src_iso_file_dir }}/txt.cfg"
-          regexp: "default live"
-          replace: "default live-install"
+            path: "{{ src_iso_file_dir }}/txt.cfg"
+            regexp: "default live"
+            replace: "default live-install"
 
         - name: "Modify boot options"
           ansible.builtin.replace:
-          path: "{{ src_iso_file_dir }}/txt.cfg"
-          regexp: "file=/cdrom/preseed/ubuntu.seed only-ubiquity initrd=/casper/initrd quiet splash ---"
-          replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
+            path: "{{ src_iso_file_dir }}/txt.cfg"
+            regexp: "file=/cdrom/preseed/ubuntu.seed only-ubiquity initrd=/casper/initrd quiet splash ---"
+            replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
         
         - name: "Print the content of modified file txt.cfg"
           debug:


### PR DESCRIPTION
Problem:
2023-03-23 09:29:13,023 | TASK [deploy_vm_bios_lsilogic_vmxnet3][Check VMware Tools is running and collects guest OS fullname successfully] 
task path: /home/worker/workspace/Ansible_Ubuntu_20.04_Desktop_ISO_70U3_LSILOGIC_VMXNET3_BIOS/ansible-vsphere-gos-validation/common/vm_wait_guest_fullname.yml:46
fatal: [localhost]: FAILED! => {
    "assertion": "vm_guestinfo.instance.guest.toolsRunningStatus == \"guestToolsRunning\"",
    "changed": false,
    "evaluated_to": false,
    "msg": "It's timed out for VMware Tools collecting guest OS fullname in 300 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''."
}
error message:
It's timed out for VMware Tools collecting guest OS fullname in 300 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''.


Cause:
The old release 20.04 have different setting for autoinstall comparing to 22.04 and later releases when firmmware is bios.


Test results:
passed

