### PR TITLE
fix issue: guest_os_family is undefined

### DIFF
--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -101,6 +101,9 @@
   vars:
     update_inventory_timeout: 300
 
+# Retrieve guest system info
+- include_tasks: ../utils/get_linux_system_info.yml
+
 - name: "Eject CDROM devices from guest OS"
   include_tasks: ../utils/eject_cdrom_in_guest.yml
 

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -101,8 +101,8 @@
   vars:
     update_inventory_timeout: 300
 
-# Retrieve guest system info
-- include_tasks: ../utils/get_linux_system_info.yml
+- name: "Retrieve guest system info"
+  include_tasks: ../utils/get_linux_system_info.yml
 
 - name: "Eject CDROM devices from guest OS"
   include_tasks: ../utils/eject_cdrom_in_guest.yml

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -4,7 +4,7 @@
 # Shutdown VM via executing shutdown command in VM
 - name: "Set command to shutdown guestOS"
   ansible.builtin.set_fact:
-    guest_shutdown_cmd: "{{ 'poweroff' if guest_os_family == 'FreeBSD' else 'shutdown -h now' }}"
+    guest_shutdown_cmd: "{{ 'poweroff' if guest_id is match('freebsd') else 'shutdown -h now' }}"
 
 - name: Execute guest OS shutdown
   ansible.builtin.command: "{{ guest_shutdown_cmd }}"

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -4,7 +4,7 @@
 # Shutdown VM via executing shutdown command in VM
 - name: "Set command to shutdown guestOS"
   ansible.builtin.set_fact:
-    guest_shutdown_cmd: "{{ 'poweroff' if guest_id is match('freebsd') else 'shutdown -h now' }}"
+    guest_shutdown_cmd: "{{ 'poweroff' if guest_os_family == 'FreeBSD' else 'shutdown -h now' }}"
 
 - name: Execute guest OS shutdown
   ansible.builtin.command: "{{ guest_shutdown_cmd }}"


### PR DESCRIPTION
**Problem:**
For Ubuntu 22.10 OVA:
TASK [Set command to shutdown guestOS] *****************************************
task path: /home/worker/workspace/Ansible_Regression_Ubuntu_22.10_OVA/ansible-vsphere-gos-validation/linux/utils/shutdown.yml:5
fatal: [localhost]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'guest_os_family' is undefined. 'guest_os_family' is undefined\n\nThe error appears to be in '/home/worker/workspace/Ansible_Regression_Ubuntu_22.10_OVA/ansible-vsphere-gos-validation/linux/utils/shutdown.yml': line 5, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Shutdown VM via executing shutdown command in VM\n- name: \"Set command to shutdown guestOS\"\n  ^ here\n"
}
Read vars_file '{{ testing_vars_file | default('../../vars/test.yml') }}'


**Test result:**
1) For Ubuntu 22.10 OVA:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/41054978/227928959-2f7e2530-1c6b-41d1-9087-7c74eff5426e.png">

2) For Freebsd:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/41054978/227929228-befc05e2-6bef-47d4-8076-6a1410010b27.png">
