### PR TITLE
[ubuntu 23.04 live server] fix issue: unknown keyboard variable "us" for layout "us"

### DIFF
--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -7,8 +7,7 @@ autoinstall:
     update: false
   locale: en_US.UTF-8
   keyboard:
-    layout: en
-    variant: us
+    layout: us
   user-data:
     package_update: false
     package_upgrade: false

--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -7,7 +7,7 @@ autoinstall:
     update: false
   locale: en_US.UTF-8
   keyboard:
-    layout: us
+    layout: en
     variant: us
   user-data:
     package_update: false


### PR DESCRIPTION
 fix issue: unknown keyboard variable "us" for layout "us"


test result:
pass for ubuntu 23.04, 22.04 and 20.04 live server