### PR TITLE
[Linux] Fix test issue for Ububuntu 23.04

### DIFF
--- a/linux/guest_customization/linux_gosc_start.yml
+++ b/linux/guest_customization/linux_gosc_start.yml
@@ -48,7 +48,7 @@
 - name: "Wait for GOSC state is completed"
   include_tasks: ../../common/vm_wait_gosc_completed.yml
   vars:
-    get_guest_reset_time_retries: 10
+    get_guest_reset_time_retries: 20
     check_gosc_state_keyword: false
 
 # Traditional GOSC will reboot guest OS (except for Photon) after all customization done

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -46,7 +46,7 @@
       when:
         - "'Flatcar' not in guest_os_ansible_distribution"
         - not (guest_os_ansible_distribution == "Ubuntu" and
-               guest_os_ansible_distribution_major_ver == "22")
+               guest_os_ansible_distribution_major_ver >= "22")
         - guest_os_ansible_distribution != "Fedora"
 
     - name: "Rescan scsi devices in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
@@ -83,7 +83,7 @@
       when: >
         ('Flatcar' in guest_os_ansible_distribution or
          (guest_os_ansible_distribution == "Ubuntu" and
-          guest_os_ansible_distribution_major_ver == "22") or
+          guest_os_ansible_distribution_major_ver >= "22") or
          guest_os_ansible_distribution == "Fedora")
   when: new_disk_ctrl_type == 'lsilogic'
 


### PR DESCRIPTION
1. From Ubuntu 22.04, using `/usr/bin/rescan-scsi-bus.sh` to rescan scsi devices would lead to system crash. The issue is still not resolved by Ubuntu, so here uses workaround for Ubuntu >= 22.04.
2. Ubuntu 23.04 cloud-init GOSC took more than 5 minutes, so this fix increased the GOSC timeout to 10min.

```
Test Results (Total: 4, Passed: 4, Elapsed Time: 00:47:36)
+-------------------------------------------------------------+
| ID | Name                              | Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:19:13  |
|  2 | gosc_cloudinit_dhcp               | Passed | 00:11:40  |
|  3 | gosc_cloudinit_staticip           | Passed | 00:11:39  |
|  4 | lsilogic_vhba_device_ops          | Passed | 00:04:01  |
+-------------------------------------------------------------+
```
