### PR TITLE
[Windows] Fix variables undefined error during deploying VM

### DIFF
--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -27,7 +27,10 @@
       include_tasks: ../../common/vcenter_add_key_provider.yml
       vars:
         vc_cert_path: "{{ current_test_log_folder }}"
-      when: virtual_tpm is defined and virtual_tpm | bool
+      when:
+        - virtual_tpm is defined
+        - virtual_tpm | bool
+        - key_provider_type is defined
 
     - name: "Deploy VM"
       block:

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -126,7 +126,6 @@
   block:
     - name: "Get guest OS system info"
       include_tasks: ../utils/get_windows_system_info.yml
-      when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
     - name: "Enable VBS in guest OS"
       include_tasks: ../utils/win_enable_vbs_guest.yml
     - name: "Get VBS status in guest OS"

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -124,6 +124,14 @@
 
 - name: "Enable VBS"
   block:
+    - name: "Get guest OS system info"
+      include_tasks: ../utils/get_windows_system_info.yml
+      when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
+    # Test code, comparing the info got here and in test_setup
+    - name: "Set fact that ansible system information about guest OS has been retrieved"
+      ansible.builtin.set_fact:
+        guest_os_system_info_retrieved: false
+
     - name: "Enable VBS in guest OS"
       include_tasks: ../utils/win_enable_vbs_guest.yml
     - name: "Get VBS status in guest OS"

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -127,11 +127,6 @@
     - name: "Get guest OS system info"
       include_tasks: ../utils/get_windows_system_info.yml
       when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
-    # Test code, comparing the info got here and in test_setup
-    - name: "Set fact that ansible system information about guest OS has been retrieved"
-      ansible.builtin.set_fact:
-        guest_os_system_info_retrieved: false
-
     - name: "Enable VBS in guest OS"
       include_tasks: ../utils/win_enable_vbs_guest.yml
     - name: "Get VBS status in guest OS"


### PR DESCRIPTION
1. Getting the guest OS build number before enabling VBS
2. Do not add key provider when key provider type is not defined. 