### PR TITLE
Add back VMware Photon OS 5.0 online repo photon.repo

### DIFF
--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -188,7 +188,7 @@
 
     - name: "Set the fact of VMware Photon OS {{ guest_os_ansible_distribution_major_ver }} online repositories"
       ansible.builtin.set_fact:
-        photon_online_repos: ["photon-release", "photon-updates"]
+        photon_online_repos: ["photon", "photon-release", "photon-updates"]
       when: guest_os_ansible_distribution_major_ver | int >= 4
 
     - name: "Enable VMware Photon OS online repositories"
@@ -199,15 +199,6 @@
         option_name: "enabled"
         option_value: 1
       with_items: "{{ photon_online_repos }}"
-
-    - name: "Disable VMware Photon OS online repository - photon.repo"
-      include_tasks: ../../common/update_ini_style_file.yml
-      vars:
-        file_path: "/etc/yum.repos.d/photon.repo"
-        section_name: "photon"
-        option_name: "enabled"
-        option_value: 0
-      when: guest_os_ansible_distribution_major_ver | int == 5
 
     - name: "Update baseurl to repositories on https://packages.vmware.com/photon"
       block:


### PR DESCRIPTION
Photon OS 5.0 online repo photon.repo is able to use after GA. I removed it for testing pre releases, now add it back.
photon.repo: Include all of packages versions for the Photon OS release
photon-release.repo: Include packages for the GA release
photon-updates.repo: Include latest packages for the Photon OS release

We usually use photon-release.repo and photon-updates.repo for package installation. In case we might need to install some old package versions, it is better to have photon.repo enabled also. So add it back.

```
Photon_4.0_OVA:
  - 'VMTOOLS: 12.2.0 ob-21223074'
  - 'Guest os distribution: VMware Photon OS 4.0 x86_64'
  - 'Hardware version: vmx-20'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''4.0''
    distroName=''VMware Photon OS'' distroVersion=''4.0'' familyName=''Linux'' kernelVersion=''5.10.83-6.ph4-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'

Photon_4.0_ISO:
  - 'VMTOOLS: 12.2.0 ob-21223074'
  - 'Guest os distribution: VMware Photon OS 4.0 x86_64'
  - 'Hardware version: vmx-20'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''4.0''
    distroName=''VMware Photon OS'' distroVersion=''4.0'' familyName=''Linux'' kernelVersion=''5.10.83-7.ph4-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'

Photon_5.0_OVA:
  - 'VMTOOLS: 12.2.0 ob-21223074'
  - 'Guest os distribution: VMware Photon OS 5.0 x86_64'
  - 'Hardware version: vmx-20'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''5.0''
    distroName=''VMware Photon OS'' distroVersion=''5.0'' familyName=''Linux'' kernelVersion=''6.1.10-10.ph5-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'

Photon_5.0_ISO: 
  - 'VMTOOLS: 12.2.0 ob-21223074'
  - 'Guest os distribution: VMware Photon OS 5.0 x86_64'
  - 'Hardware version: vmx-20'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''5.0''
    distroName=''VMware Photon OS'' distroVersion=''5.0'' familyName=''Linux'' kernelVersion=''6.1.10-10.ph5-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  ```