### PR TITLE
Enable Debian online repo for installing open-vm-tools dependencies

### DIFF
--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -7,7 +7,7 @@
 
 - name: "Add online package repositories for {{ guest_os_ansible_distribution }}"
   include_tasks: ../utils/add_official_online_repo.yml
-  when: guest_os_ansible_distribution in ['CentOS', 'VMware Photon OS']
+  when: guest_os_ansible_distribution in ['CentOS', 'VMware Photon OS', 'Debian']
 
 - name: "Add package repositories for {{ guest_os_ansible_distribution }}"
   block:
@@ -17,7 +17,7 @@
 
     - name: "Add online package repositories for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_official_online_repo.yml
-      when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu', 'Debian']
+      when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu']
   when: linux_ovt_repo_url is undefined or not linux_ovt_repo_url
 
 - name: "Add an extra open-vm-tools repository from URL"


### PR DESCRIPTION
By default Debian's online repo is not enabled, which could lead to installing open-vm-tools dependencies failure.
This change is to enable it so that it won't block open-vm-tools installation due to missing of dependencies.