### PR TITLE
Add vars and tasks to support VGAuth guest operation testing

### DIFF
--- a/common/add_vsphere_hosts_in_inventory.yml
+++ b/common/add_vsphere_hosts_in_inventory.yml
@@ -1,0 +1,34 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Add vCenter Server and ESXi server into memory inventory
+#
+- name: "Add vCenter Server into memory inventory"
+  include_tasks: add_host_in_memory_inventory.yml
+  vars:
+    add_host_in_memory_inventory_ip: "{{ vcenter_hostname }}"
+    add_host_in_memory_inventory_gp: "vcenter"
+    add_host_in_memory_inventory_user: "{{ vcenter_ssh_username }}"
+    add_host_in_memory_inventory_pwd: "{{ vcenter_ssh_password }}"
+    add_host_in_memory_inventory_python: "/bin/python"
+    add_host_in_memory_inventory_ssh_pipeline: true
+    add_host_in_memory_inventory_shell: "/usr/bin/bash"
+  when:
+    - vcenter_hostname is defined
+    - vcenter_hostname
+    - vcenter_ssh_username is defined
+    - vcenter_ssh_username
+    - vcenter_ssh_password is defined
+    - vcenter_ssh_password
+
+- name: "Add ESXi Server into memory inventory"
+  include_tasks: ../common/add_host_in_memory_inventory.yml
+  vars:
+    add_host_in_memory_inventory_ip: "{{ esxi_hostname }}"
+    add_host_in_memory_inventory_gp: "esxi"
+    add_host_in_memory_inventory_user: "{{ esxi_username }}"
+    add_host_in_memory_inventory_pwd: "{{ esxi_password }}"
+    add_host_in_memory_inventory_python: "/bin/python"
+    add_host_in_memory_inventory_ssh_pipeline: true
+    add_host_in_memory_inventory_remote_tmp: "{{ vm_datastore_path }}"
+    add_host_in_memory_inventory_shell: "{{ esxi_shell }}"

--- a/common/vcenter_get_domain_user_info.yml
+++ b/common/vcenter_get_domain_user_info.yml
@@ -1,0 +1,50 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Gather information about a domain user on vCenter Server
+# Parameters:
+#   vcenter_domain_name: The vCenter Server user domain name. Default is same with vcenter_username domain.
+#   vcenter_domain_user_name: The domain user name.
+#
+- name: "Assert vcenter_domain_user_name is set"
+  ansible.builtin.assert:
+    that:
+      - vcenter_is_defined is defined
+      - vcenter_is_defined
+      - vcenter_domain_user_name is defined
+      - vcenter_domain_user_name
+    fail_msg: >-
+      vCenter Server information must be defined in testing vars file and
+      parameter 'vcenter_domain_user_name' must be set for gathering domain user info.
+      Current vcenter_is_defined is {{ vcenter_is_defined | default('undefined')}},
+      vcenter_domain_user_name is {{ vcenter_domain_user_name | default('undefined') }}.
+
+- name: "Set default user domain of vCenter Server"
+  ansible.builtin.set_fact:
+    vcenter_domain_name: "{{ vcenter_username.split('@')[-1] }}"
+  when: vcenter_domain_name is undefined or not vcenter_domain_name
+
+- name: "Initialize the fact of vCenter Server domain user"
+  ansible.builtin.set_fact:
+    vcenter_domain_user_info: ""
+
+- name: "Get info of domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
+  community.vmware.vcenter_domain_user_group_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: "{{ validate_certs | default(false) }}"
+    domain: "{{ vcenter_domain_name }}"
+    search_string: "{{ vcenter_domain_name }}\\{{ vcenter_domain_user_name }}"
+    exact_match: true
+  register: get_domain_user_result
+
+- name: "Set fact of vCenter domain user existing or not"
+  ansible.builtin.set_fact:
+    vcenter_domain_user_info: "{{ get_domain_user_result.domain_user_groups[0] }}"
+  when:
+    - get_domain_user_result.domain_user_groups is defined
+    - get_domain_user_result.domain_user_groups | length > 0
+
+- name: "Display gathered domain user information"
+  ansible.builtin.debug: var=vcenter_domain_user_info

--- a/common/vcenter_get_domain_user_info.yml
+++ b/common/vcenter_get_domain_user_info.yml
@@ -6,7 +6,7 @@
 #   vcenter_domain_name: The vCenter Server user domain name. Default is same with vcenter_username domain.
 #   vcenter_domain_user_name: The domain user name.
 #
-- name: "Assert vcenter_domain_user_name is set"
+- name: "Check parameter 'vcenter_domain_user_name' is set"
   ansible.builtin.assert:
     that:
       - vcenter_is_defined is defined
@@ -39,7 +39,7 @@
     exact_match: true
   register: get_domain_user_result
 
-- name: "Set fact of vCenter domain user existing or not"
+- name: "Set fact of vCenter Server domain user"
   ansible.builtin.set_fact:
     vcenter_domain_user_info: "{{ get_domain_user_result.domain_user_groups[0] }}"
   when:

--- a/common/vcenter_manage_domain_user.yml
+++ b/common/vcenter_manage_domain_user.yml
@@ -3,14 +3,21 @@
 ---
 # Add or delete a domain user on vCenter Server
 # Parameters:
-#   vcenter_domain_name: The vCenter Server user domain name. Default is vcenter_username domain.
 #   vcenter_domain_user_name: The domain user name.
-#   vcenter_domain_user_first_name: The first name of domain user. Default is same as user name.
-#   vcenter_domain_user_last_name: The last name of domain user. Default is same as domain name.
 #   vcenter_domain_user_password: The domain user password.
-#   vcenter_domain_user_group: The user group which domain user belongs to. Default is empty.
 #   vcenter_domain_user_op: The operation of managing domain user: add or delete.
+#   vcenter_domain_name(optional): The vCenter Server user domain name.
+#     Default is vcenter_username domain.
+#   vcenter_domain_user_first_name(optional): The first name of domain user.
+#     Default is same as user name.
+#   vcenter_domain_user_last_name(optional): The last name of domain user.
+#     Default is same as domain name.
+#   vcenter_domain_user_group(optional): The user group which domain user belongs to.
+#     Default is empty.
 #
+# vcenter_is_defined is defined in common/set_vmware_module_hostname.yml
+# groups['vcenter'] is defined in common/add_vsphere_hosts_in_inventory.yml
+# both of them are set at env_setup
 - name: "Check vCenter Server is defined and added into memory inventory"
   ansible.builtin.assert:
     that:
@@ -24,17 +31,20 @@
       and vCenter Server hostname in memory inventory is
       {{ groups['vcenter'] is defined and vcenter_hostname in groups['vcenter'] }}.
 
-- name: "Check vcenter_domain_user_name and vcenter_domain_user_op is set"
+- name: "Check vcenter_domain_user_name, vcenter_domain_user_password and vcenter_domain_user_op are set"
   ansible.builtin.assert:
     that:
       - vcenter_domain_user_name is defined
       - vcenter_domain_user_name
+      - vcenter_domain_user_password is defined
+      - vcenter_domain_user_password
       - vcenter_domain_user_op is defined
       - vcenter_domain_user_op in ['add', 'delete']
     fail_msg: >-
-      Parameter 'vcenter_domain_user_name' or 'vcenter_domain_user_op' is incorrect
-      for managing domain user.
+      Parameter 'vcenter_domain_user_name','vcenter_domain_user_password' and 'vcenter_domain_user_op'
+      must be set correclty for managing domain user.
       Current vcenter_domain_user_name is {{ vcenter_domain_user_name | default('undefined') }},
+      vcenter_domain_user_password is {{ vcenter_domain_user_password | default('undefined') }},
       and vcenter_domain_user_op is {{ vcenter_domain_user_op | default('undefined') }}.
 
 - name: "Set default user domain of vCenter Server"
@@ -64,7 +74,7 @@
   when: vcenter_domain_user_op == "delete"
 
 - name: "{{ vcenter_domain_user_op | capitalize }} domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
-  ansible.builtin.command: "{{  manage_domain_user_cmd }}"
+  ansible.builtin.command: "{{ manage_domain_user_cmd }}"
   ignore_errors: true
   delegate_to: "{{ vcenter_hostname }}"
   register: manage_domain_user_result

--- a/common/vcenter_manage_domain_user.yml
+++ b/common/vcenter_manage_domain_user.yml
@@ -1,0 +1,121 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Add or delete a domain user on vCenter Server
+# Parameters:
+#   vcenter_domain_name: The vCenter Server user domain name. Default is vcenter_username domain.
+#   vcenter_domain_user_name: The domain user name.
+#   vcenter_domain_user_first_name: The first name of domain user. Default is same as user name.
+#   vcenter_domain_user_last_name: The last name of domain user. Default is same as domain name.
+#   vcenter_domain_user_password: The domain user password.
+#   vcenter_domain_user_group: The user group which domain user belongs to. Default is empty.
+#   vcenter_domain_user_op: The operation of managing domain user: add or delete.
+#
+- name: "Check vCenter Server is defined and added into memory inventory"
+  ansible.builtin.assert:
+    that:
+      - vcenter_is_defined is defined
+      - vcenter_is_defined
+      - groups['vcenter'] is defined
+      - vcenter_hostname in groups['vcenter']
+    fail_msg: >-
+      vCenter Server information and its SSH username and password must be set in testing vars file.
+      Current vcenter_is_defined is {{ vcenter_is_defined | default('undefined') }},
+      and vCenter Server hostname in memory inventory is
+      {{ groups['vcenter'] is defined and vcenter_hostname in groups['vcenter'] }}.
+
+- name: "Check vcenter_domain_user_name and vcenter_domain_user_op is set"
+  ansible.builtin.assert:
+    that:
+      - vcenter_domain_user_name is defined
+      - vcenter_domain_user_name
+      - vcenter_domain_user_op is defined
+      - vcenter_domain_user_op in ['add', 'delete']
+    fail_msg: >-
+      Parameter 'vcenter_domain_user_name' or 'vcenter_domain_user_op' is incorrect
+      for managing domain user.
+      Current vcenter_domain_user_name is {{ vcenter_domain_user_name | default('undefined') }},
+      and vcenter_domain_user_op is {{ vcenter_domain_user_op | default('undefined') }}.
+
+- name: "Set default user domain of vCenter Server"
+  ansible.builtin.set_fact:
+    vcenter_domain_name: "{{ vcenter_username.split('@')[-1] }}"
+  when: vcenter_domain_name is undefined or not vcenter_domain_name
+
+- name: "Set command for adding domain user"
+  ansible.builtin.set_fact:
+    manage_domain_user_cmd: >-
+      /usr/lib/vmware-vmafd/bin/dir-cli user create
+      --account "{{ vcenter_domain_user_name }}"
+      --user-password "{{ vcenter_domain_user_password }}"
+      --first-name "{{ vcenter_domain_user_first_name | default(vcenter_domain_user_name) }}"
+      --last-name "{{ vcenter_domain_user_last_name | default(vcenter_domain_name) }}"
+      --login "{{ vcenter_username }}"
+      --password "{{ vcenter_password }}"
+  when: vcenter_domain_user_op == "add"
+
+- name: "Set command for deleteing domain user"
+  ansible.builtin.set_fact:
+    manage_domain_user_cmd: >-
+      /usr/lib/vmware-vmafd/bin/dir-cli user delete
+      --account "{{ vcenter_domain_user_name }}"
+      --login "{{ vcenter_username }}"
+      --password "{{ vcenter_password }}"
+  when: vcenter_domain_user_op == "delete"
+
+- name: "{{ vcenter_domain_user_op | capitalize }} domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
+  ansible.builtin.command: "{{  manage_domain_user_cmd }}"
+  ignore_errors: true
+  delegate_to: "{{ vcenter_hostname }}"
+  register: manage_domain_user_result
+
+- name: "Display result of managing domain user"
+  ansible.builtin.debug: var=manage_domain_user_result
+  when: enable_debug | bool
+
+- name: "Check the result of managing domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
+  ansible.builtin.assert:
+    that:
+      - manage_domain_user_result.rc is defined
+      - manage_domain_user_result.rc == 0
+    fail_msg: >-
+      Failed to {{ vcenter_domain_user_op }} domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'.
+      Return code is '{{ manage_domain_user_result.rc | default("unknown") }}'.
+      Hit error '{{ manage_domain_user_result.stderr | default("unknown") }}'.
+    success_msg: "{{ manage_domain_user_result.stdout | default(omit) }}"
+
+- name: "Add domain user to user group"
+  block:
+    - name: "Set command for adding domain user to user group"
+      ansible.builtin.set_fact:
+        modify_user_group_cmd: >-
+          /usr/lib/vmware-vmafd/bin/dir-cli group modify
+          --name "{{ vcenter_domain_user_group }}"
+          --add "{{ vcenter_domain_user_name }}"
+          --login "{{ vcenter_username }}"
+          --password "{{ vcenter_password }}"
+
+    - name: "Add domain user to user group '{{ vcenter_domain_user_group }}'"
+      ansible.builtin.command: "{{ modify_user_group_cmd }}"
+      delegate_to: "{{ vcenter_hostname }}"
+      register: modify_user_group_result
+
+    - name: "Display result of adding domain user to user group"
+      ansible.builtin.debug: var=modify_user_group_result
+      when: enable_debug | bool
+
+    - name: "Check the result of adding domain user to user group '{{ vcenter_domain_user_group }}'"
+      ansible.builtin.assert:
+        that:
+          - modify_user_group_result.rc is defined
+          - modify_user_group_result.rc == 0
+        fail_msg: >-
+          Failed to add domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'
+          to user group '{{ vcenter_domain_user_group }}'.
+          Return code is '{{ modify_user_group_result.rc | default("unknown") }}'.
+          Hit error '{{ modify_user_group_result.stderr | default("unknown") }}'
+        success_msg: "{{ modify_user_group_result.stdout | default(omit) }}"
+  when:
+    - vcenter_domain_user_op == "add"
+    - vcenter_domain_user_group is defined
+    - vcenter_domain_user_group

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -97,17 +97,8 @@
     - name: Display the datatore path of VM files
       ansible.builtin.debug: var=vm_datastore_path
 
-    - name: "Add esxi host into memory inventory"
-      include_tasks: ../common/add_host_in_memory_inventory.yml
-      vars:
-        add_host_in_memory_inventory_ip: "{{ esxi_hostname }}"
-        add_host_in_memory_inventory_gp: "esxi"
-        add_host_in_memory_inventory_user: "{{ esxi_username }}"
-        add_host_in_memory_inventory_pwd: "{{ esxi_password }}"
-        add_host_in_memory_inventory_python: "/bin/python"
-        add_host_in_memory_inventory_ssh_pipeline: true
-        add_host_in_memory_inventory_remote_tmp: "{{ vm_datastore_path }}"
-        add_host_in_memory_inventory_shell: "{{ esxi_shell }}"
+    - name: "Add vSphere hosts into memory inventory"
+      include_tasks: ../common/add_vsphere_hosts_in_inventory.yml
 
     - name: "Enable guest IP hack on ESXi host to get VM IP address when there is no VMware tools installed or VMware tools is not up"
       include_tasks: ../common/esxi_enable_guest_ip_hack.yml

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -41,7 +41,7 @@
     - name: "Get vCenter Server version and build"
       include_tasks: ../common/vcenter_get_version_build.yml
       when: vcenter_is_defined is defined and vcenter_is_defined
-    
+
     - name: "Get ESXi version and build"
       include_tasks: ../common/esxi_get_version_build.yml
 
@@ -87,7 +87,7 @@
           include_tasks: check_vm_settings.yml
 
         - name: "Get existing VM info"
-          include_tasks: ../common/vm_get_vm_info.yml        
+          include_tasks: ../common/vm_get_vm_info.yml
       when: vm_exists is defined and vm_exists
 
     - name: Set fact of the VM datastore path

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -49,11 +49,14 @@
             - vmtools_is_installed
             - update_vmtools
 
-        # Set the fact of open-vm-tools packages
-        - include_tasks: ../utils/set_ovt_facts.yml
+        - name: "Set facts of open-vm-tools packages, processes and service"
+          include_tasks: ../utils/set_ovt_facts.yml
 
-        # Uninstall open-vm-tools for reinstallation
-        - include_tasks: uninstall_ovt.yml
+        - name: "Set facts of VGAuthService process and service"
+          include_tasks: ../utils/set_vgauth_facts.yml
+
+        - name: "Uninstall open-vm-tools for reinstall"
+          include_tasks: uninstall_ovt.yml
           when:
             - uninstall_tools is defined
             - uninstall_tools

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -30,7 +30,7 @@
         - block:
             - include_tasks: ../utils/add_user.yml
               vars:
-                os_username: "vmware"
+                guest_user_name: "vmware"
 
             - include_tasks: ../utils/enable_auto_login.yml
               vars:

--- a/linux/open_vm_tools/ovt_verify_uninstall.yml
+++ b/linux/open_vm_tools/ovt_verify_uninstall.yml
@@ -12,30 +12,37 @@
   tasks:
     - name: "Test case block"
       block:
-        - include_tasks: ../setup/test_setup.yml
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
         # Flatcar doesn't support to uninstall open-vm-tools
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for {{ guest_os_ansible_distribution }}"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support uninstalling open-vm-tools"
             skip_reason: "Not Supported"
           when: "'Flatcar' in guest_os_ansible_distribution"
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Block test case when guest OS doesn't install open-vm-tools"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because guest OS doesn't has open-vm-tools"
             skip_reason: "Blocked"
           when: vmtools_is_installed is undefined or not (vmtools_is_installed | bool)
 
-        - block:
-            # Set the fact of open-vm-tools packages
-            - include_tasks: ../utils/set_ovt_facts.yml
+        - name: "Uninstall open-vm-tools"
+          block:
+            - name: "Set facts of open-vm-tools packages, processes and service"
+              include_tasks: ../utils/set_ovt_facts.yml
 
-            # Uninstall open-vm-tools for reinstallation
-            - include_tasks: uninstall_ovt.yml
+            - name: "Set facts of VGAuthService process and service"
+              include_tasks: ../utils/set_vgauth_facts.yml
+
+            - name: "Uninstall open-vm-tools and check result"
+              include_tasks: uninstall_ovt.yml
           when:
-            - "'Flatcar' not in guest_os_ansible_distribution"
             - vmtools_is_installed is defined
             - vmtools_is_installed | bool
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/linux/open_vm_tools/uninstall_ovt.yml
+++ b/linux/open_vm_tools/uninstall_ovt.yml
@@ -61,7 +61,7 @@
     expected_service_state: "absent"
   with_items:
     - "{{ ovt_service }}"
-    - "{{ vgauth_service }}"
+    - "{{ vgauth_service_name }}"
 
 - name: "Set the fact that open-vm-tools is removed"
   ansible.builtin.set_fact:

--- a/linux/utils/add_user.yml
+++ b/linux/utils/add_user.yml
@@ -1,37 +1,38 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Add a new user to guest
+# Add a new user in guest OS
 # Parameter:
-#   os_username: The user name to be added
-#   os_group: (Optional)The group name for the new user name.
+#   guest_user_name: The new user name
+#   guest_user_password: The new user's password
+#   guest_user_group: (Optional)The group name for the new user name.
 
 # If user already exists, return changed with 'false'
-- name: "Get user '{{ os_username }}' info"
+- name: "Get user '{{ guest_user_name }}' info"
   ansible.builtin.getent:
     database: passwd
-    key: "{{ os_username }}"
+    key: "{{ guest_user_name }}"
   failed_when: false
   register: getent_user_result
   delegate_to: "{{ vm_guest_ip }}"
 
-- name: "User '{{ os_username }}' already exists"
+- name: "User '{{ guest_user_name }}' already exists"
   ansible.builtin.debug: var=getent_user_result.ansible_facts.getent_passwd
   when:
     - getent_user_result.ansible_facts is defined
     - getent_user_result.ansible_facts.getent_passwd is defined
-    - getent_user_result.ansible_facts.getent_passwd[os_username] is defined
+    - getent_user_result.ansible_facts.getent_passwd[guest_user_name] is defined
 
 # Create a new user if it doesn't exist
-- name: "Add a new user '{{ os_username }}'"
+- name: "Add a new user '{{ guest_user_name }}'"
   ansible.builtin.user:
-    name: "{{ os_username }}"
-    group: "{{ os_group | default('users') }}"
-    password: "{{ vm_password | password_hash('sha512') }}"
+    name: "{{ guest_user_name }}"
+    group: "{{ guest_user_group | default('users') }}"
+    password: "{{ guest_user_password | default(vm_password) | password_hash('sha512') }}"
     update_password: on_create
     expires: -1
   delegate_to: "{{ vm_guest_ip }}"
   when: >
     getent_user_result.ansible_facts is undefined or
     getent_user_result.ansible_facts.getent_passwd is undefined or
-    getent_user_result.ansible_facts.getent_passwd[os_username] is undefined
+    getent_user_result.ansible_facts.getent_passwd[guest_user_name] is undefined

--- a/linux/utils/collect_cloudinit_logs.yml
+++ b/linux/utils/collect_cloudinit_logs.yml
@@ -23,6 +23,9 @@
         operation: "fetch_file"
         src_path: "{{ cloudinit_logs_src_path }}"
         dest_path: "{{ cloudinit_logs_local_path }}"
+      when:
+        - vm_shell_result.exit_code is defined
+        - vm_shell_result.exit_code == 0
   when:
     - vmtools_is_running is defined
     - vmtools_is_running | bool
@@ -31,12 +34,17 @@
     - name: "Collect cloud-init logs"
       ansible.builtin.shell: "/usr/bin/cloud-init collect-logs -u -t {{ cloudinit_logs_src_path }}"
       delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: True
+      register: collect_cloudinit_logs_result
 
     - name: "Fetch cloud-init logs from guest OS"
       include_tasks: fetch_file.yml
       vars:
         fetch_file_src_path: "{{ cloudinit_logs_src_path }}"
         fetch_file_dst_path: "{{ cloudinit_logs_local_path }}"
+      when:
+        - collect_cloudinit_logs_result.rc is defined
+        - collect_cloudinit_logs_result.rc == 0
   when:
     - vmtools_is_running is undefined or not (vmtools_is_running | bool)
     - vm_guest_ip is defined

--- a/linux/utils/collect_vgauth_logs.yml
+++ b/linux/utils/collect_vgauth_logs.yml
@@ -1,0 +1,42 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Collect VGAuthService logs to local test case log directory
+# Parameter:
+#   vgauth_log_file_src: The VGAuthService log file path
+#
+- name: "Initialize the latest VGAuthService log path in guest OS"
+  ansible.builtin.set_fact:
+    vgauth_log_file_src: "/var/log/vmware-vgauthsvc.log.0"
+  when: vgauth_log_file_src is undefined or not vgauth_log_file_src
+
+- name: "Initialize facts of collected VGAuthService log path at localhost"
+  ansible.builtin.set_fact:
+    vgauth_log_file_dest: ""
+    vgauth_log_is_collected: false
+
+- name: "Get VGAuthService log file info"
+  include_tasks: get_file_stat_info.yml
+  vars:
+    guest_file_path: "{{ vgauth_log_file_src }}"
+
+- name: "Set fact of VGAuthService log exists or not"
+  ansible.builtin.set_fact:
+    vgauth_log_file_exists: "{{ guest_file_exists }}"
+
+- name: "Collect VGAuthService log file"
+  block:
+    - name: "Collect VGAuthServce log to test case log dir"
+      include_tasks: fetch_file.yml
+      vars:
+        fetch_file_src_path: "{{ vgauth_log_file_src }}"
+        fetch_file_dst_path: "{{ current_test_log_folder }}/"
+
+    - name: "Set facts of VGAuthService file collected at localhost"
+      ansible.builtin.set_fact:
+        vgauth_log_file_dest: "{{ fetch_file_local_path }}"
+        vgauth_log_is_collected: True
+      when:
+        - fetch_file_local_path is defined
+        - fetch_file_local_path
+  when: vgauth_log_file_exists | bool

--- a/linux/utils/enable_vgauth_logging.yml
+++ b/linux/utils/enable_vgauth_logging.yml
@@ -1,0 +1,101 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Enable debug logging for VGAuthService within Linux guest OS
+# See https://kb.vmware.com/s/article/1007873 for details.
+#
+- name: "Set facts about VGAuthService"
+  include_tasks: set_vgauth_facts.yml
+
+- name: "Set default VGAuthService debug log directory"
+  ansible.builtin.set_fact:
+    vgauth_log_dir: "/tmp/vmware-vgauthsvc-{{ lookup('pipe', 'date +%s') }}"
+
+- name: "Set facts of VGAuthService log files"
+  ansible.builtin.set_fact:
+    vgauth_log_files: "{{ vgauth_log_dir }}/vmware-vgauthsvc.log"
+    vgauth_latest_log_file: "{{ vgauth_log_dir }}/vmware-vgauthsvc.log.0"
+
+- name: "Set facts of VGAuthService config section and options for enabling debug logging"
+  ansible.builtin.set_fact:
+    vgauth_logging_section: service
+    vgauth_logging_options: |-
+      samlSchemaDir = /etc/vmware-tools/vgauth/schemas
+      loglevel=verbose
+      logfile={{ vgauth_log_files }}
+      enableLogging=true
+      enableCoreDumps=true
+      maxOldLogFiles=10
+      maxLogSize=10
+
+- name: "Prepare log directory {{ vgauth_log_dir }} for new logs"
+  ansible.builtin.shell: |
+    if [ -e {{ vgauth_log_dir }} ] ; then
+        rm -rf {{ vgauth_log_dir }};
+    fi;
+    mkdir -p {{ vgauth_log_dir }};
+  delegate_to: "{{ vm_guest_ip }}"
+
+- name: "Get VGAuthService config file stat info"
+  include_tasks: get_file_stat_info.yml
+  vars:
+    guest_file_path: "{{ vgauth_config_file }}"
+
+- name: "Create VGAuthService config file with logging options"
+  ansible.builtin.copy:
+    dest: "{{ vgauth_config_file }}"
+    content: |
+      [{{ vgauth_logging_section }}]
+      {{ vgauth_logging_options }}
+
+      [localization]
+      msgCatalog = /usr/share/open-vm-tools
+  delegate_to: "{{ vm_guest_ip }}"
+  when: not guest_file_exists
+
+- name: "Update VGAuthService config file with logging options"
+  include_tasks: ../../common/update_ini_style_file.yml
+  vars:
+    file_path: "{{ vgauth_config_file }}"
+    section_name: "{{ vgauth_logging_section }}"
+    option_name: "{{ item.key }}"
+    option_value: "{{ item.value }}"
+    ini_state: present
+  loop: "{{ vgauth_logging_options | replace('=',': ') | from_yaml | dict2items }}"
+  when: guest_file_exists
+
+- name: "Save VGAuthService config file to local log directory"
+  include_tasks: fetch_file.yml
+  vars:
+    fetch_file_src_path: "{{ vgauth_config_file }}"
+    fetch_file_dst_path: "{{ current_test_log_folder }}/"
+    fetch_file_ignore_errors: false
+
+# Debian family OS doesn't have '-s' option in VGAuthService start command,
+# which leads to no VGAuthService log file genereated. This block added '-s'
+# option so that we can collect VGAuthService log from Debian family OS
+- name: "Run VGAuthService in daemon mode on {{ guest_os_ansible_distribution }}"
+  block:
+    - name: "Update VGAuthService to run in daemon mode"
+      include_tasks: ../../common/update_ini_style_file.yml
+      vars:
+        file_path: "{{ vgauth_service_file }}"
+        section_name: "Service"
+        option_name: "ExecStart"
+        option_value: "/usr/bin/VGAuthService -s"
+        ini_state: present
+
+    - name: "Reload {{ vgauth_service_name }} service"
+      ansible.builtin.shell: "systemctl daemon-reload "
+      delegate_to: "{{ vm_guest_ip }}"
+  when:
+    - guest_os_family in ["Debian", "Astra Linux (Orel)"]
+    - vgauth_service_file is defined
+    - vgauth_service_file
+
+- name: "Restart VGAuthService to make config take effect"
+  include_tasks: service_operation.yml
+  vars:
+    service_name: "{{ vgauth_service_name }}"
+    service_enabled: true
+    service_state: "restarted"

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -72,6 +72,13 @@
   ansible.builtin.debug: var=vmtools_config
   when: enable_debug
 
+- name: "Collect VMware Tools config file to local log directory"
+  include_tasks: fetch_file.yml
+  vars:
+    fetch_file_src_path: "{{ vmtools_config_file }}"
+    fetch_file_dst_path: "{{ current_test_log_folder }}/"
+    fetch_file_ignore_errors: false
+
 - name: "Get the service name of VMware Tools"
   include_tasks: set_ovt_facts.yml
 

--- a/linux/utils/set_ovt_facts.yml
+++ b/linux/utils/set_ovt_facts.yml
@@ -2,26 +2,19 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Set the fact of open-vm-tools packages, processes and services
-
+#
 - name: "Initialize the fact of open-vm-tools packages, processe and service"
   ansible.builtin.set_fact:
     ovt_packages: ["open-vm-tools"]
     ovt_processes: [{"uid": "root", "cmd":"vmtoolsd"}]
     ovt_service: "vmtoolsd"
 
-- name: "Initialize the fact of VGAuth processe and service"
-  ansible.builtin.set_fact:
-    vgauth_service: "vgauthd"
-    vgauth_process: {"uid": "root", "cmd": "VGAuthService"}
-  when: "'Flatcar' not in guest_os_ansible_distribution"
-
-- name: "Set the fact of open-vm-tools service name for Ubuntu/Debian"
+- name: "Set the fact of open-vm-tools service name for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
     ovt_service: "open-vm-tools"
-    vgauth_service: "vgauth"
   when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
 
-- name: "Add extra package libvmtools0 for SUSE"
+- name: "Add extra package libvmtools0 for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
     ovt_packages: "{{ ovt_packages | union(['libvmtools0']) }}"
   when: guest_os_family == "Suse"

--- a/linux/utils/set_vgauth_facts.yml
+++ b/linux/utils/set_vgauth_facts.yml
@@ -1,0 +1,22 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Set facts of VGAuthService config file, log file, process, service name and file
+#
+- name: "Initialize facts of VGAuthService process, config file and default latest log file"
+  ansible.builtin.set_fact:
+    vgauth_process: {"uid": "root", "cmd": "VGAuthService"}
+    vgauth_config_file: "/etc/vmware-tools/vgauth.conf"
+    vgauth_latest_log_file: "/var/log/vmware-vgauthsvc.log.0"
+
+- name: "Set the fact of VGAuthService service name and file for {{ guest_os_ansible_distribution }}"
+  ansible.builtin.set_fact:
+    vgauth_service_name: "vgauthd"
+    vgauth_service_file: "/lib/systemd/system/vgauthd.service"
+  when: guest_os_family not in ["Debian", "Astra Linux (Orel)"]
+
+- name: "Set the fact of VGAuthService service name for {{ guest_os_ansible_distribution }}"
+  ansible.builtin.set_fact:
+    vgauth_service_name: "vgauth"
+    vgauth_service_file: "/lib/systemd/system/vgauth.service"
+  when: guest_os_family in ["Debian", "Astra Linux (Orel)"]

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -12,11 +12,13 @@
   tasks:
     - name: "Test case block"
       block:
-        - include_tasks: ../setup/test_setup.yml
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
           vars:
             skip_test_no_vmtools: true
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip this test case for Flatcar"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Flatcar doesn't have VGAuth service"
             skip_reason: "Not Supported"
@@ -24,27 +26,27 @@
              (guest_os_ansible_distribution is defined) and
              ('Flatcar' in guest_os_ansible_distribution)
 
-        - name: "Initialize the variable for VGAuth process and service"
-          ansible.builtin.set_fact:
-            vgauth_process: "VGAuthService"
-            vgauth_service: "vgauthd"
+        - name: "Set facts of VGAuthService process and service"
+          include_tasks: ../utils/set_vgauth_facts.yml
 
-        - name: "Set the vgauth service name for Ubuntu/Debian"
-          ansible.builtin.set_fact:
-            vgauth_service: "vgauth"
-          when: guest_os_family in ["Debian", "Astra Linux (Orel)"]
-
-        # Check VGAuth processe is running
-        - include_tasks: ../utils/check_process_status.yml
+        - name: "Check VGAuthService processe is running"
+          include_tasks: ../utils/check_process_status.yml
           vars:
-            process_name: "{{ vgauth_process }}"
+            process_uid: "{{ vgauth_process.uid }}"
+            process_name: "{{ vgauth_process.cmd }}"
             expected_process_state: "present"
 
-        # Check VGAuth service is active and enabled
-        - include_tasks: ../utils/check_service_status.yml
+        - name: "Check VGAuthService is active and enabled"
+          include_tasks: ../utils/check_service_status.yml
           vars:
-            service_name: "{{ vgauth_service }}"
+            service_name: "{{ vgauth_service_name }}"
             expected_service_state: "running"
             expected_service_status: "enabled"
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml
+      always:
+        - name: "Collect VGAuthServcie logs"
+          include_tasks: ../utils/collect_vgauth_logs.yml
+          vars:
+            vgauth_log_file_src: "{{ vgauth_latest_log_file }}"

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -76,9 +76,13 @@ base_snapshot_name: "BaseSnapshot"
 #####################################
 
 # vCenter Server information
+# Basically, vcenter_ssh_username and vcenter_ssh_password are not requied unless you want to
+# run commands on vCenter Server through SSH, for example, adding or deleting domain user.
 vcenter_hostname: "vc.test.com"
 vcenter_username: "Administrator@vsphere.local"
 vcenter_password: "CHANGEME"
+# vcenter_ssh_username: "root"
+# vcenter_ssh_password: "CHANGEME"
 datacenter: "MyDatacenter"
 
 # ESXi Server information

--- a/windows/utils/win_collect_vgauth_logs.yml
+++ b/windows/utils/win_collect_vgauth_logs.yml
@@ -36,7 +36,7 @@
       include_tasks: win_get_file.yml
       vars:
         win_get_file_src_path: "{{ vgauth_log_file_src }}"
-        win_get_file_dst_path: "{{ current_test_log_folder }}/"
+        win_get_file_dst_path: "{{ current_test_log_folder }}"
 
     - name: "Start VGAuthService after getting its log file"
       include_tasks: win_execute_cmd.yml

--- a/windows/utils/win_collect_vgauth_logs.yml
+++ b/windows/utils/win_collect_vgauth_logs.yml
@@ -1,0 +1,56 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Collect VGAuthService logs to local test case log directory
+#
+- name: "Initialize facts for collecting VGAuthService logs"
+  ansible.builtin.set_fact:
+    vgauth_log_file_src: "C:\\ProgramData\\VMware\\VMware VGAuth\\logfile.txt.0"
+    vgauth_log_file_dest: ""
+    vgauth_log_is_collected: false
+
+- name: "Check VGAuthService log file exists or not"
+  include_tasks: ../utils/win_check_file_exist.yml
+  vars:
+    win_check_file_exist_file: "{{ vgauth_log_file_src }}"
+
+- name: "Collect VGAuthService log file"
+  block:
+    - name: "Get VGAuthService status"
+      include_tasks: win_get_service_status.yml
+      vars:
+        win_service_name: "VGAuthService"
+
+    - name: "Set VGAuthService status"
+      ansible.builtin.set_fact:
+        vgauth_service_status: "{{ service_status }}"
+
+    # Stop VGAuthService in case of log file in use error
+    - name: "Stop VGAuthService before getting its log file"
+      include_tasks: win_execute_cmd.yml
+      vars:
+        win_powershell_cmd: "Stop-Service -Name VGAuthService"
+      when: vgauth_service_status == "Running"
+
+    - name: "Get VGAuthServce log file"
+      include_tasks: win_get_file.yml
+      vars:
+        win_get_file_src_path: "{{ vgauth_log_file_src }}"
+        win_get_file_dst_path: "{{ current_test_log_folder }}/"
+
+    - name: "Start VGAuthService after getting its log file"
+      include_tasks: win_execute_cmd.yml
+      vars:
+        win_powershell_cmd: "Start-Service -Name VGAuthService"
+      when: vgauth_service_status == "Running"
+
+    - name: "Set facts of VGAuthService file collected at localhost"
+      ansible.builtin.set_fact:
+        vgauth_log_file_dest: "{{ fetch_file.dest }}"
+        vgauth_log_is_collected: True
+      when:
+        - fetch_file.failed is defined
+        - not fetch_file.failed
+        - fetch_file.dest is defined
+        - fetch_file.dest
+  when: win_check_file_exist_result

--- a/windows/utils/win_enable_vgauth_log.yml
+++ b/windows/utils/win_enable_vgauth_log.yml
@@ -1,0 +1,52 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Enable debug logging for VGAuthService within Windows guest OS
+# See https://kb.vmware.com/s/article/1007873 for details.
+#
+- name: "Set facts of VGAuthService config file"
+  ansible.builtin.set_fact:
+    vgauth_config_file: "C:\\ProgramData\\VMware\\VMware VGAuth\\vgauth.conf"
+
+- name: "Check VGAuthService config file exists or not"
+  include_tasks: win_check_file_exist.yml
+  vars:
+    win_check_file_exist_file: "{{ vgauth_config_file }}"
+
+- include_tasks: win_write_to_file.yml
+  vars:
+    write_file_path: "{{ vgauth_config_file }}"
+    write_file_content: |
+      [service]
+      samlSchemaDir=C:\\Program Files\\VMware\\VMware Tools\\VMware VGAuth\\schemas
+      logfile=C:\\ProgramData\\VMware\\VMware VGAuth\\logfile.txt
+      aliasStoreDir=C:\\ProgramData\\VMware\\VMware VGAuth\\aliasStore\\
+      loglevel=verbose
+      enableLogging=true
+      enableCoreDumps=true
+      maxOldLogFiles=10
+      maxLogSize=10
+ 
+      [localization]
+      msgCatalog=C:\\ProgramData\\VMware\\VMware VGAuth\\msgCatalogs\\
+  when: not win_check_file_exist_result
+
+- name: "Update VGAuthService config file with logging options"
+  community.windows.win_lineinfile:
+    path: "{{ vgauth_config_file }}"
+    regexp: "^(# *)?loglevel.*"
+    line: "loglevel=verbose"
+    state: present
+  delegate_to: "{{ vm_guest_ip }}"
+  when: win_check_file_exist_result
+
+- name: "Save VGAuthService config file to local log directory"
+  include_tasks: win_get_file.yml
+  vars:
+    win_get_file_src_path: "{{ vgauth_config_file }}"
+    win_get_file_dst_path: "{{ current_test_log_folder }}/"
+
+- name: "Retart guest OS to make config take effect"
+  include_tasks: win_shutdown_restart.yml
+  vars:
+    set_win_power_state: "restart"

--- a/windows/utils/win_enable_vgauth_log.yml
+++ b/windows/utils/win_enable_vgauth_log.yml
@@ -13,7 +13,8 @@
   vars:
     win_check_file_exist_file: "{{ vgauth_config_file }}"
 
-- include_tasks: win_write_to_file.yml
+- name: "Add VGAuthService config file with logging options"
+  include_tasks: win_write_to_file.yml
   vars:
     write_file_path: "{{ vgauth_config_file }}"
     write_file_content: |
@@ -36,7 +37,6 @@
     path: "{{ vgauth_config_file }}"
     regexp: "^(# *)?loglevel.*"
     line: "loglevel=verbose"
-    state: present
   delegate_to: "{{ vm_guest_ip }}"
   when: win_check_file_exist_result
 
@@ -44,7 +44,7 @@
   include_tasks: win_get_file.yml
   vars:
     win_get_file_src_path: "{{ vgauth_config_file }}"
-    win_get_file_dst_path: "{{ current_test_log_folder }}/"
+    win_get_file_dst_path: "{{ current_test_log_folder }}"
 
 - name: "Retart guest OS to make config take effect"
   include_tasks: win_shutdown_restart.yml


### PR DESCRIPTION
This fix includes:
1. added common tasks to gather or manage vCenter Server domain user
2. enabled VGAuthService debug logging on Linux and Windows guest OS
3. collected VGAuthService log file on Linux and Windows guest OS