### PR TITLE
Check VMware Tools version after OVA/OVF deployment without poweron

### DIFF
--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -249,3 +249,13 @@
   ansible.builtin.copy:
     dest: "{{ ovf_vm_hardware_config_path }}/{{ ovf_vm_hardware_config_file }}"
     content: "{{ [ovf_vm_hardware_config] | to_nice_json }}"
+
+- name: "Display ddb.toolsVersion of open-vm-tools in OVA"
+  debug: var=ovf_vm_vmtools_info['Config Tools Version']
+        
+- name: "Check ddb.toolsVersion of open-vm-tools in OVA is expected"
+  ansible.builtin.assert:
+    that:
+      - ovf_vm_vmtools_info['Config Tools Version'] | length > 0 or vm_extra_config['guestinfo.vmtools.versionNumber'] | length > 0
+      - ovf_vm_vmtools_info['Config Tools Version'] == '2147483647' or ovf_vm_vmtools_info['Config Tools Version'] == vm_extra_config['guestinfo.vmtools.versionNumber']
+    fail_msg: "The ddb.toolsVersion in OVA template is {{ ovf_vm_vmtools_info['Config Tools Version'] }}, not as expected '2147483647' or {{ vm_extra_config['guestinfo.vmtools.versionNumber'] }}."

--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -250,12 +250,10 @@
     dest: "{{ ovf_vm_hardware_config_path }}/{{ ovf_vm_hardware_config_file }}"
     content: "{{ [ovf_vm_hardware_config] | to_nice_json }}"
 
-- name: "Display ddb.toolsVersion of open-vm-tools in OVA"
-  debug: var=ovf_vm_vmtools_info['Config Tools Version']
-        
 - name: "Check ddb.toolsVersion of open-vm-tools in OVA is expected"
   ansible.builtin.assert:
     that:
       - ovf_vm_vmtools_info['Config Tools Version'] | string | length > 0 or vm_extra_config['guestinfo.vmtools.versionNumber'] | length > 0
       - ovf_vm_vmtools_info['Config Tools Version'] | string in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
     fail_msg: "The ddb.toolsVersion in OVA template is {{ ovf_vm_vmtools_info['Config Tools Version'] }}, not as expected '2147483647' or {{ vm_extra_config['guestinfo.vmtools.versionNumber'] }}."
+    success_msg: "The ddb.toolsVersion in OVA template is {{ ovf_vm_vmtools_info['Config Tools Version'] }}, which is as expected."

--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -256,6 +256,6 @@
 - name: "Check ddb.toolsVersion of open-vm-tools in OVA is expected"
   ansible.builtin.assert:
     that:
-      - ovf_vm_vmtools_info['Config Tools Version'] | length > 0 or vm_extra_config['guestinfo.vmtools.versionNumber'] | length > 0
+      - ovf_vm_vmtools_info['Config Tools Version'] | string | length > 0 or vm_extra_config['guestinfo.vmtools.versionNumber'] | length > 0
       - ovf_vm_vmtools_info['Config Tools Version'] | string in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
     fail_msg: "The ddb.toolsVersion in OVA template is {{ ovf_vm_vmtools_info['Config Tools Version'] }}, not as expected '2147483647' or {{ vm_extra_config['guestinfo.vmtools.versionNumber'] }}."

--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -22,9 +22,6 @@
     ovf_vm_guest_bitness: ""
     ovf_vm_hardware_config_file: 'ovf_deploy_vm_info.json'
 
-- name: "Get VM info"
-  include_tasks: vm_get_vm_info.yml
-
 - name: "Get all the VM hardwares info"
   include_tasks: vm_get_config.yml
 
@@ -33,7 +30,7 @@
     ovf_vm_hardware_config: >-
       {{
         ovf_vm_hardware_config |
-        combine({'Guest OS ID': vm_guest_id | default(''),
+        combine({'Guest OS ID': vm_config.config.guestId | default(''),
                  'Guest OS Version': vm_config.config.guestFullName | default(''),
                  'Hardware Version': vm_hardware_version | default(''),
                  'CPU Number': vm_config.config.hardware.numCPU | default(''),
@@ -153,11 +150,16 @@
     ovf_vm_vmtools_info: >-
       {{
         ovf_vm_vmtools_info |
-        combine({'Version': vm_config.config.tools.toolsVersion | default(''),
+        combine({'Config Tools Version': vm_config.config.tools.toolsVersion | default(''),
                  'Install Type': vm_config.config.tools.toolsInstallType | default(''),
                  'Upgrade Policy': vm_config.config.tools.toolsUpgradePolicy | default(''),
                  'Sync Time with Host': vm_config.config.tools.syncTimeWithHost | default('')})
       }}
+
+- name: "Power on VM"
+  include_tasks: vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'
 
 - name: "Wait for VMware Tools running"
   include_tasks: vm_wait_vmtools_status.yml
@@ -168,12 +170,12 @@
 - name: "Get VM's guest info"
   include_tasks: vm_get_guest_info.yml
 
-- name: "Update VMware Tools version"
+- name: "Get Guest Tools version"
   ansible.builtin.set_fact:
     ovf_vm_vmtools_info: >-
       {{
         ovf_vm_vmtools_info |
-        combine({'Version': guestinfo_vmtools_info })
+        combine({'Guest Tools Version': guestinfo_vmtools_info })
       }}
   when: guestinfo_vmtools_info
 

--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -257,5 +257,5 @@
   ansible.builtin.assert:
     that:
       - ovf_vm_vmtools_info['Config Tools Version'] | length > 0 or vm_extra_config['guestinfo.vmtools.versionNumber'] | length > 0
-      - ovf_vm_vmtools_info['Config Tools Version'] == '2147483647' or ovf_vm_vmtools_info['Config Tools Version'] == vm_extra_config['guestinfo.vmtools.versionNumber']
+      - ovf_vm_vmtools_info['Config Tools Version'] | string in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
     fail_msg: "The ddb.toolsVersion in OVA template is {{ ovf_vm_vmtools_info['Config Tools Version'] }}, not as expected '2147483647' or {{ vm_extra_config['guestinfo.vmtools.versionNumber'] }}."

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -74,7 +74,7 @@
             that:
               - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
             fail_msg: "toolsVersion of open-vm-tools in OVA is not expected"
-      when: ovf_vm_vmtools_info['Install Type'] == "guestToolsTypeOpenVMTools"
+      when: ovf_vm_vmtools_info['Guest Tools Version'] is match("build-")
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -74,7 +74,7 @@
             that:
               - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
             fail_msg: "toolsVersion of open-vm-tools in OVA is not expected"
-      when: ovf_vm_vmtools_info['Guest Tools Version'] is match("build-")
+      when: ovf_vm_vmtools_info['Guest Tools Version'] is match(".*build-\d+")
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -72,11 +72,9 @@
         - name: "Check toolsVersion of open-vm-tools in OVA is expected"
           ansible.builtin.assert:
             that:
-              - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', ovf_vm_vmtools_info['Guest Tools Version']]
+              - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
             fail_msg: "toolsVersion of open-vm-tools in OVA is not expected"
-      when:
-        - ovf_vm_vmtools_info['Config Tools Version'] is defined
-        - ovf_vm_vmtools_info['Config Tools Version'] != ""
+      when: ovf_vm_vmtools_info['Install Type'] == "guestToolsTypeOpenVMTools"
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -55,6 +55,15 @@
       include_tasks: ../../common/vm_take_snapshot.yml
       vars:
         snapshot_name: "{{ base_snapshot_for_reconfig }}"
+    
+    - name: "Get open-vm-tools info in OVA"
+      include_tasks: ../../common/vm_get_config.yml
+      vars:
+        property_list: ['guest']
+
+    - name: "Display toolsVersion of open-vm-tools in OVA"
+      debug: var=vm_config.guest.toolsVersion
+      when: vm_config.guest is defined and vm_config.guest.toolsVersion is defined
 
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml
@@ -69,21 +78,11 @@
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml
 
-    - name: "Check toolsVersion is set to 2147483647 for open-vm-tools"
-      block:
-        - name: "Get open-vm-tools info in OVA"
-          include_tasks: ../../common/vm_get_config.yml
-          vars:
-            property_list: ['guest']
-    
-        - name: "Display toolsVersion of open-vm-tools in OVA"
-          debug: var=vm_config.guest.toolsVersion
-        
-        - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
-          ansible.builtin.assert:
-            that:
-              - vm_config.guest.toolsVersion == "2147483647"
-            fail_msg: "ddb.toolsVersion of open-vm-tools in OVA is not 2147483647"
+    - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
+      ansible.builtin.assert:
+        that:
+          - vm_config.guest.toolsVersion == "2147483647"
+        fail_msg: "ddb.toolsVersion of open-vm-tools in OVA is not 2147483647"
       when: ovf_vm_vmtools_info['Install Type'] == "guestToolsTypeOpenVMTools"
 
     # Revert to snapshot "FreshDeployedFromOVA" to

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -55,7 +55,15 @@
       include_tasks: ../../common/vm_take_snapshot.yml
       vars:
         snapshot_name: "{{ base_snapshot_for_reconfig }}"
-
+    
+    - name: "Get open-vm-tools info from OVA"
+      include_tasks: ../../common/vm_get_config.yml
+      vars:
+        property_list: ['guest']
+    
+    - name: "Display open-vm-tools info from OVA"
+      debug: var=vm_config.guest
+    
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -64,18 +64,6 @@
     - name: "Get VM info"
       include_tasks: ../../common/vm_get_vm_info.yml
 
-    - name: "Check toolsVersion of open-vm-tools in OVA after deploy VM"
-      block:
-        - name: "Display toolsVersion of open-vm-tools in OVA"
-          debug: var=ovf_vm_vmtools_info['Config Tools Version']
-        
-        - name: "Check toolsVersion of open-vm-tools in OVA is expected"
-          ansible.builtin.assert:
-            that:
-              - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', vm_extra_config['guestinfo.vmtools.versionNumber']]
-            fail_msg: "toolsVersion of open-vm-tools in OVA is not expected"
-      when: ovf_vm_vmtools_info['Guest Tools Version'] is match(".*build-\d+")
-
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml
 

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -60,10 +60,21 @@
       include_tasks: ../../common/vm_get_config.yml
       vars:
         property_list: ['guest']
-
-    - name: "Display toolsVersion of open-vm-tools in OVA"
-      debug: var=vm_config.guest.toolsVersion
-      when: vm_config.guest is defined and vm_config.guest.toolsVersion is defined
+    
+    - name: "Check toolsVersion of open-vm-tools in OVA after deploy VM"
+      block:
+        - name: "Display toolsVersion of open-vm-tools in OVA"
+          debug: var=vm_config.guest.toolsVersion
+        
+        - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
+          ansible.builtin.assert:
+            that:
+              - vm_config.guest.toolsVersion == "2147483647"
+            fail_msg: "toolsVersion of open-vm-tools in OVA is not 2147483647"
+      when:
+        - vm_config.guest is defined 
+        - vm_config.guest.toolsStatus is defined
+        - vm_config.guest.toolsStatus is match("NotRunning")
 
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml
@@ -77,13 +88,6 @@
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml
-
-    - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
-      ansible.builtin.assert:
-        that:
-          - vm_config.guest.toolsVersion == "2147483647"
-        fail_msg: "ddb.toolsVersion of open-vm-tools in OVA is not 2147483647"
-      when: ovf_vm_vmtools_info['Install Type'] == "guestToolsTypeOpenVMTools"
 
     # Revert to snapshot "FreshDeployedFromOVA" to
     # proceed the following tasks so that VM's reconfiguration can be

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -55,15 +55,7 @@
       include_tasks: ../../common/vm_take_snapshot.yml
       vars:
         snapshot_name: "{{ base_snapshot_for_reconfig }}"
-    
-    - name: "Get open-vm-tools info from OVA"
-      include_tasks: ../../common/vm_get_config.yml
-      vars:
-        property_list: ['guest']
-    
-    - name: "Display open-vm-tools info from OVA"
-      debug: var=vm_config.guest
-    
+
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
@@ -76,6 +68,23 @@
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml
+
+    - name: "Check toolsVersion is set to 2147483647 for open-vm-tools"
+      block:
+        - name: "Get open-vm-tools info in OVA"
+          include_tasks: ../../common/vm_get_config.yml
+          vars:
+            property_list: ['guest']
+    
+        - name: "Display toolsVersion of open-vm-tools in OVA"
+          debug: var=vm_config.guest.toolsVersion
+        
+        - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
+          ansible.builtin.assert:
+            that:
+              - vm_config.guest.toolsVersion == "2147483647"
+            fail_msg: "ddb.toolsVersion of open-vm-tools in OVA is not 2147483647"
+      when: ovf_vm_vmtools_info['Install Type'] == "guestToolsTypeOpenVMTools"
 
     # Revert to snapshot "FreshDeployedFromOVA" to
     # proceed the following tasks so that VM's reconfiguration can be

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -55,36 +55,28 @@
       include_tasks: ../../common/vm_take_snapshot.yml
       vars:
         snapshot_name: "{{ base_snapshot_for_reconfig }}"
-    
-    - name: "Get open-vm-tools info in OVA"
-      include_tasks: ../../common/vm_get_config.yml
-      vars:
-        property_list: ['guest']
-    
-    - name: "Check toolsVersion of open-vm-tools in OVA after deploy VM"
-      block:
-        - name: "Display toolsVersion of open-vm-tools in OVA"
-          debug: var=vm_config.guest.toolsVersion
-        
-        - name: "Check toolsVersion of open-vm-tools in OVA is 2147483647"
-          ansible.builtin.assert:
-            that:
-              - vm_config.guest.toolsVersion == "2147483647"
-            fail_msg: "toolsVersion of open-vm-tools in OVA is not 2147483647"
-      when:
-        - vm_config.guest is defined 
-        - vm_config.guest.toolsStatus is defined
-        - vm_config.guest.toolsStatus is match("NotRunning")
-
-    - name: "Power on VM"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'powered-on'
 
     - name: "Collect OVA configs"
       include_tasks: "../../common/collect_ovf_vm_config.yml"
       vars:
         ovf_vm_hardware_config_path: "{{ current_test_log_folder }}"
+    
+    - name: "Get VM info"
+      include_tasks: ../../common/vm_get_vm_info.yml
+
+    - name: "Check toolsVersion of open-vm-tools in OVA after deploy VM"
+      block:
+        - name: "Display toolsVersion of open-vm-tools in OVA"
+          debug: var=ovf_vm_vmtools_info['Config Tools Version']
+        
+        - name: "Check toolsVersion of open-vm-tools in OVA is expected"
+          ansible.builtin.assert:
+            that:
+              - ovf_vm_vmtools_info['Config Tools Version'] in ['2147483647', ovf_vm_vmtools_info['Guest Tools Version']]
+            fail_msg: "toolsVersion of open-vm-tools in OVA is not expected"
+      when:
+        - ovf_vm_vmtools_info['Config Tools Version'] is defined
+        - ovf_vm_vmtools_info['Config Tools Version'] != ""
 
     - name: "Try to get OS type from guest info"
       include_tasks: get_ova_guest_os_type.yml

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -41,15 +41,14 @@
   ansible.builtin.set_fact:
     vm_exists: true
 
-- name: "Get VM info"
-  include_tasks: ../../common/vm_get_vm_info.yml
-
 # Get OVA deployed VM info
 - name: "Collect hardware configs of the VM deployed from OVF"
   include_tasks: ../../common/collect_ovf_vm_config.yml
   vars:
     ovf_vm_hardware_config_path: "{{ current_test_log_folder }}"
 
+- name: "Get VM info"
+  include_tasks: ../../common/vm_get_vm_info.yml
 # - include_tasks: ../../common/vm_get_ip_from_vmtools.yml
 
 # Copy script ConfigureRemotingForAnsible.ps1 to guest OS

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -41,12 +41,6 @@
   ansible.builtin.set_fact:
     vm_exists: true
 
-# Power on VM and wait for guest fullname reported by VMware tools
-- name: "Power on VM"
-  include_tasks: ../../common/vm_set_power_state.yml
-  vars:
-    vm_power_state_set: "powered-on"
-
 - name: "Get VM info"
   include_tasks: ../../common/vm_get_vm_info.yml
 


### PR DESCRIPTION
From John:
Can you please check to see if our testing of OVAs includes verification of vmdk that ddb.toolsVersion is set to 2147483647 if open-vm-tools is included?  If we are not doing this then please add as a candidate new test.  I think the check needs to be done without booting the VM to be valid.

Test result: 
1) test with ubuntu 23.04 OVA:
<img width="482" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/538a90a9-acf9-4e14-9a4f-e410097ad0b2">

2) test with photon 5.0 OVA
<img width="538" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/07b65e03-7517-4e9b-9fc0-8ba4233d75bf">
