### PR TITLE
Skip secureboot and nvdimm testing for guest OS not supporting them

### DIFF
--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -17,11 +17,13 @@
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "{{ guest_os_ansible_distribution }} doesn't support NVDIMM"
+            skip_msg: "{{ vm_guest_os_distribution }} doesn't support NVDIMM"
             skip_reason: "Not Supported"
           when: >
             ('Flatcar' in guest_os_ansible_distribution or
-             guest_os_ansible_distribution == 'UnionTech')
+             guest_os_ansible_distribution in ['UnionTech', 'Uos', 'Amazon'] or
+             (guest_os_ansible_distribution == 'Ubuntu' and
+              guest_os_edition == 'CloudImage'))
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:

--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -21,7 +21,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because {{ vm_guest_os_distribution }}
+              Skip test case {{ ansible_play_name }} because {{ vm_guest_os_distribution }}
               doesn't support NVDIMM.
             skip_reason: "Not Supported"
           when: >
@@ -34,7 +34,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because NVDIMM is not supported
+              Skip test case {{ ansible_play_name }} because NVDIMM is not supported
               for 32-bit guest OS {{ vm_guest_os_distribution }}.
             skip_reason: "Not Supported"
           when: guest_os_bit == "32-bit"
@@ -43,9 +43,9 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because
+              Skip test case {{ ansible_play_name }} because
               NVDIMM support starts from ESXi 6.7 and VM hardware version 14.
-              VM hardware version is '{{ vm_hardware_version_num }}', which is not >= 14.
+              VM hardware version is {{ vm_hardware_version_num }}, which is not >= 14.
             skip_reason: "Not Supported"
           when: vm_hardware_version_num | int < 14
 
@@ -55,14 +55,14 @@
             guest_id: "{{ vm_guest_id }}"
             esxi_hardware_version: "{{ vm_hardware_version_num }}"
 
-        - name: "Skip test case for not supported guest id"
+        - name: "Skip test case for not supported guest ID"
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because
-              the VM's guest ID '{{ vm_guest_id }}' with hardware version '{{ vm_hardware_version_num }}'
-              does not support persistent memory, support_persistent_memory config option value
-              is '{{ guest_config_options.support_persistent_memory | default('') }}'.
+              Skip test case {{ ansible_play_name }} because the VM's guest ID {{ vm_guest_id }}
+              with hardware version {{ vm_hardware_version_num }} does not support persistent memory,
+              support_persistent_memory config option value
+              is '{{ guest_config_options.support_persistent_memory | default("") }}'.
             skip_reason: "Not Supported"
           when: >
             (guest_config_options.support_persistent_memory is undefined) or
@@ -81,7 +81,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Test case '{{ ansible_play_name }}' is blocked because guest OS doesn't have libnvdimm module.
+              Test case {{ ansible_play_name }} is blocked because guest OS doesn't have libnvdimm module.
             skip_reason: "Blocked"
           when: >
             (guest_libnvdimm_module_info.filename is undefined) or
@@ -95,9 +95,9 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Test case '{{ ansible_play_name }}' is blocked because ESXi PMem is less than 16MB.
-              ESXi total persistent memory size is '{{ esxi_pmem_total_mb }} MB',
-              ESXi available persistent memory size is '{{ esxi_pmem_available_mb }} MB'.
+              Test case {{ ansible_play_name }} is blocked because ESXi PMem is less than 16MB.
+              ESXi total persistent memory size is {{ esxi_pmem_total_mb }} MB,
+              ESXi available persistent memory size is {{ esxi_pmem_available_mb }} MB.
             skip_reason: "Blocked"
           when: >
             (esxi_pmem_total_mb | int == 0) or

--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -10,14 +10,19 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
           vars:
             skip_test_no_vmtools: false
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for not supported guest OS"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "{{ vm_guest_os_distribution }} doesn't support NVDIMM"
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because {{ vm_guest_os_distribution }}
+              doesn't support NVDIMM.
             skip_reason: "Not Supported"
           when: >
             ('Flatcar' in guest_os_ansible_distribution or
@@ -25,15 +30,20 @@
              (guest_os_ansible_distribution == 'Ubuntu' and
               guest_os_edition == 'CloudImage'))
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for 32-bit guest OS"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "NVDIMM is not supported on {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} {{ guest_os_bit }}"
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because NVDIMM is not supported
+              for 32-bit guest OS {{ vm_guest_os_distribution }}.
             skip_reason: "Not Supported"
           when: guest_os_bit == "32-bit"
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for hardware version lower than 14"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because
               NVDIMM support starts from ESXi 6.7 and VM hardware version 14.
               VM hardware version is '{{ vm_hardware_version_num }}', which is not >= 14.
             skip_reason: "Not Supported"
@@ -44,10 +54,13 @@
           vars:
             guest_id: "{{ vm_guest_id }}"
             esxi_hardware_version: "{{ vm_hardware_version_num }}"
-        - include_tasks: ../../common/skip_test_case.yml
+
+        - name: "Skip test case for not supported guest id"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              This guest ID '{{ vm_guest_id }}' with hardware version '{{ vm_hardware_version_num }}'
+              Skip test case '{{ ansible_play_name }}' because
+              the VM's guest ID '{{ vm_guest_id }}' with hardware version '{{ vm_hardware_version_num }}'
               does not support persistent memory, support_persistent_memory config option value
               is '{{ guest_config_options.support_persistent_memory | default('') }}'.
             skip_reason: "Not Supported"
@@ -77,12 +90,14 @@
 
         - name: "Get ESXi host persistent memory info"
           include_tasks: ../../common/esxi_get_pmem_info.yml
-        - include_tasks: ../../common/skip_test_case.yml
+
+        - name: "Block test case because of ESXi PMem doesn't meet test requirements"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
               Test case '{{ ansible_play_name }}' is blocked because ESXi PMem is less than 16MB.
-              ESXi total persistent memory size is '{{ esxi_pmem_total_mb }} MB'
-              ESXi available persistent memory size is '{{ esxi_pmem_available_mb }} MB'
+              ESXi total persistent memory size is '{{ esxi_pmem_total_mb }} MB',
+              ESXi available persistent memory size is '{{ esxi_pmem_available_mb }} MB'.
             skip_reason: "Blocked"
           when: >
             (esxi_pmem_total_mb | int == 0) or
@@ -94,4 +109,5 @@
         - name: "Test VM NVDIMM cold-remove"
           include_tasks: cold_remove_nvdimm_test.yml
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -19,7 +19,8 @@
   when: >
     (guest_os_ansible_distribution == "Rocky" and
       guest_os_ansible_distribution_ver is version('8.4', '<=')) or
-    (guest_os_ansible_distribution == "Astra Linux (Orel)")
+    guest_os_ansible_distribution is match('Pardus.*') or
+    (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos"])
 
 - name: "Skip secureboot testing for OS version which has vulnerable bootloaders"
   block:

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -8,7 +8,7 @@
   include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: >-
-      Skip test case '{{ ansible_play_name }}' because secure boot is not supported
+      Skip test case {{ ansible_play_name }} because secure boot is not supported
       on VM with hardware version {{ vm_hardware_version_num }}.
     skip_reason: "Not Supported"
   when: vm_hardware_version_num | int < 13
@@ -17,7 +17,7 @@
   include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: >-
-      Skip test case '{{ ansible_play_name }}' because secure boot is not supported
+      Skip test case {{ ansible_play_name }} because secure boot is not supported
       by {{ vm_guest_os_distribution }}.
     skip_reason: "Not Supported"
   when: >
@@ -31,8 +31,8 @@
     - include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: >-
-          Skip test case '{{ ansible_play_name }}' because {{ vm_guest_os_distribution }} image has vulnerable
-          bootloader, which is denied for secure boot from ESXi 8.0 release.
+          Skip test case {{ ansible_play_name }} because {{ vm_guest_os_distribution }} image has
+          vulnerable bootloader, which is denied for secure boot from ESXi 8.0 release.
           Please refer to https://kb.vmware.com/s/article/88737.
         skip_reason: "Not Supported"
       when: >

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -4,17 +4,21 @@
 # Description:
 #   Check whether the guest OS version supports secureboot testing
 #
-- include_tasks: ../../common/skip_test_case.yml
+- name: "Skip test case for hardware version lower than 13"
+  include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: >-
-      Secure boot is not supported on VM with hardware version {{ vm_hardware_version_num }}.
+      Skip test case '{{ ansible_play_name }}' because secure boot is not supported
+      on VM with hardware version {{ vm_hardware_version_num }}.
     skip_reason: "Not Supported"
   when: vm_hardware_version_num | int < 13
 
-- include_tasks: ../../common/skip_test_case.yml
+- name: "Skip test case for not supported guest OS"
+  include_tasks: ../../common/skip_test_case.yml
   vars:
     skip_msg: >-
-      {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} doesn't support secure boot.
+      Skip test case '{{ ansible_play_name }}' because secure boot is not supported
+      by {{ vm_guest_os_distribution }}.
     skip_reason: "Not Supported"
   when: >
     (guest_os_ansible_distribution == "Rocky" and
@@ -22,12 +26,12 @@
     guest_os_ansible_distribution is match('Pardus.*') or
     (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos"])
 
-- name: "Skip secureboot testing for OS version which has vulnerable bootloaders"
+- name: "Skip test case for OS version which has vulnerable bootloaders"
   block:
     - include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: >-
-          {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} image has vulnerable
+          Skip test case '{{ ansible_play_name }}' because {{ vm_guest_os_distribution }} image has vulnerable
           bootloader, which is denied for secure boot from ESXi 8.0 release.
           Please refer to https://kb.vmware.com/s/article/88737.
         skip_reason: "Not Supported"

--- a/linux/utils/get_installed_packages.yml
+++ b/linux/utils/get_installed_packages.yml
@@ -1,0 +1,30 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Get all installed packages on guest OS
+# Return:
+#   guest_installed_packages: A list of all installed packages
+#
+- name: "Initialize the fact of guest installed pacakges"
+  ansible.builtin.set_fact:
+    guest_installed_packages: []
+
+- name: "Get installed packages on {{ guest_os_ansible_distribution }}"
+  ansible.builtin.package_facts:
+    manager: auto
+  delegate_to: "{{ vm_guest_ip }}"
+  register: guest_package_facts
+
+- name: "Set fact of installed packages on {{ guest_os_ansible_distribution }}"
+  ansible.builtin.set_fact:
+    guest_installed_packages: >-
+      {{
+        guest_package_facts.ansible_facts.packages |
+        dict2items |
+        map(attribute='value') |
+        flatten |
+        map(attribute='name')
+      }}
+  when:
+    - guest_package_facts.ansible_facts.packages is defined
+    - guest_package_facts.ansible_facts.packages | length > 0

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -98,6 +98,9 @@
 - name: "Check whether guest OS has GUI"
   include_tasks: check_guest_os_gui.yml
 
+- name: "Get guest OS edition"
+  include_tasks: get_os_edition.yml
+
 - name: "Print Linux guest OS information"
   ansible.builtin.debug:
     msg:
@@ -110,13 +113,17 @@
       - "Guest OS version: {{ guest_os_ansible_distribution_ver }}"
       - "Guest OS kernel: {{ guest_os_ansible_kernel }}"
       - "Guest OS release: {{ guest_os_ansible_distribution_release }}"
+      - "Guest OS edition: {{ guest_os_edition }}"
       - "Guest OS family: {{ guest_os_family }}"
       - "Guest OS with desktop environment: {{ guest_os_with_gui }}"
       - "Guest OS display manager: {{ guest_os_display_manager }}"
 
 - name: "Set fact of VM guest OS type"
   ansible.builtin.set_fact:
-    vm_guest_os_distribution: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} {{ guest_os_ansible_architecture }}"
+    vm_guest_os_distribution: >-
+      {{ guest_os_ansible_distribution }}
+      {{ (guest_os_ansible_distribution_ver ~ ' ' ~ guest_os_edition).strip() }}
+      {{ guest_os_ansible_architecture }}
 
 - name: "Set fact that ansible system information about guest OS has been retrieved"
   ansible.builtin.set_fact:

--- a/linux/utils/get_os_edition.yml
+++ b/linux/utils/get_os_edition.yml
@@ -1,0 +1,41 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Get guest OS edition
+# For example,
+#   Ubuntu: Desktop, Server, Cloud Image
+#   Pardus: Desktop, Server
+#
+- name: "Initialize the fact of guest OS edition"
+  ansible.builtin.set_fact:
+    guest_os_edition: ""
+
+- name: "Get Ubuntu edition"
+  block:
+    - name: "Get installed packages on {{ guest_os_ansible_distribution }}"
+      include_tasks: get_installed_packages.yml
+
+    - name: "Set fact of Ubuntu edition"
+      ansible.builtin.set_fact:
+        guest_os_edition: |-
+          {%- if 'linux-image-virtual' in guest_installed_packages -%}CloudImage
+          {%- elif 'ubuntu-server' in guest_installed_packages -%}Server
+          {%- elif 'ubuntu-desktop' in guest_installed_packages -%}Desktop
+          {%- else -%}{%- endif -%}
+      when: guest_installed_packages | length > 0
+  when: guest_os_ansible_distribution == "Ubuntu"
+
+- name: "Get Pardus edition"
+  block:
+    - name: "Get display manager on {{ guest_os_ansible_distribution }}"
+      include_tasks: check_guest_os_gui.yml
+      when: guest_os_display_manager is undefined
+
+    - name: "Set fact of Pardus edition"
+      ansible.builtin.set_fact:
+        guest_os_edition: |-
+          {%- if guest_os_display_manager == 'lightdm' -%}XFCE
+          {%- elif guest_os_display_manager == 'gdm' -%}GNOME
+          {%- else -%}Server
+          {%- endif -%}
+  when: guest_os_ansible_distribution is match("Pardus.*")

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -34,21 +34,7 @@
     package_manage_list: []
 
 - name: "Get installed packages on {{ guest_os_ansible_distribution }}"
-  ansible.builtin.package_facts:
-    manager: auto
-  delegate_to: "{{ vm_guest_ip }}"
-  register: guest_package_facts
-
-- name: "Set fact of installed packages on {{ guest_os_ansible_distribution }}"
-  ansible.builtin.set_fact:
-    guest_installed_packages: >-
-      {{
-        guest_package_facts.ansible_facts.packages |
-        dict2items |
-        map(attribute='value') |
-        flatten |
-        map(attribute='name')
-      }}
+  include_tasks: get_installed_packages.yml
 
 - name: "Set fact of packages which needs to be installed"
   ansible.builtin.set_fact:


### PR DESCRIPTION
Skip secureboot_enable_disable for Pardus, UOS, ProLinux.
Skip nvdimm_cold_add_remove for UOS, Amazon Linux and Ubuntu Cloud Image.
