### PR TITLE
[Windows]Enable Credential Guard for Windows Server

### DIFF
--- a/windows/utils/win_enable_vbs_guest.yml
+++ b/windows/utils/win_enable_vbs_guest.yml
@@ -35,7 +35,10 @@
       reg add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v "LsaCfgFlags" /t REG_DWORD /d 1 /f
   when: >
     (guest_os_build_num | int < 22621) or
-    (guest_os_product_type | lower == 'client' and guest_os_build_num | int >= 22621 and guest_os_edition | lower not in ['enterprise', 'education'])
+    (guest_os_product_type | lower == 'client' and 
+    guest_os_build_num | int >= 22621 and 
+    guest_os_edition | lower not in ['enterprise', 'education']) or
+    (guest_os_product_type | lower == 'server')
 
 # Try to enable 'HVCIMATRequired' feature from registry while it does not take effect.
 # Refer to 3rd party issue: https://partner.microsoft.com/en-us/dashboard/collaborate/engagements/1759/feedback/wits/Bugs/786316


### PR DESCRIPTION
Enable Windows Defender Credential Guard:

    Go to HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa.
    Add a new DWORD value named LsaCfgFlags. Set the value of this registry setting to 1 to enable Windows Defender Credential Guard with UEFI lock, set it to 2 to enable Windows Defender Credential Guard without lock, and set it to 0 to disable it.

