### PR TITLE
Change the boot disk to be first in boot order for ubuntu 23.04 desktop after deploy_vm

### DIFF
--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -290,6 +290,15 @@
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
 
+    - name: "The disk is changed to not be first in boot order for ubuntu 23.04 desktop"
+      include_tasks: ../../common/vm_set_boot_options.yml
+      vars:
+        boot_order_list:
+          - disk
+      when:
+        - unattend_install_conf is match('Ubuntu/Desktop/Subiquity')
+        - firmware is defined and firmware|lower == "efi"
+   
     - include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -290,7 +290,7 @@
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
 
-    - name: "The disk is changed to not be first in boot order for ubuntu 23.04 desktop"
+    - name: "Change the boot disk to be first in boot order for ubuntu 23.04 desktop"
       include_tasks: ../../common/vm_set_boot_options.yml
       vars:
         boot_order_list:

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -257,15 +257,22 @@
 
     # Remove serial port
     - include_tasks: ../utils/shutdown.yml
+    
+    - name: "Change CD/DVD to client device and set disk as first boot device for Ubuntu"
+      block:
+        - name: "Change VM's CD/DVD Drive 1 to client device"
+          include_tasks: ../../common/vm_configure_cdrom.yml
+          vars:
+            cdrom_state: present
+            cdrom_type: client
+            cdrom_controller_num: "{{ vm_cdroms[0].controller_number | int }}"
+            cdrom_unit_num: "{{ vm_cdroms[0].unit_number | int }}"
 
-    # Disconnect OS image from Ubuntu Linux VM and change to client device
-    - name: "Change VM's CD/DVD Drive 1 to client device"
-      include_tasks: ../../common/vm_configure_cdrom.yml
-      vars:
-        cdrom_state: present
-        cdrom_type: client
-        cdrom_controller_num: "{{ vm_cdroms[0].controller_number | int }}"
-        cdrom_unit_num: "{{ vm_cdroms[0].unit_number | int }}"
+        - name: "Change the boot disk to be first in boot order"
+          include_tasks: ../../common/vm_set_boot_options.yml
+          vars:
+            boot_order_list:
+              - disk
       when: guest_os_ansible_distribution == "Ubuntu"
     
     - name: "Download serial output file before removing serial port"
@@ -290,15 +297,6 @@
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
 
-    - name: "Change the boot disk to be first in boot order for ubuntu 23.04 desktop"
-      include_tasks: ../../common/vm_set_boot_options.yml
-      vars:
-        boot_order_list:
-          - disk
-      when:
-        - unattend_install_conf is match('Ubuntu/Desktop/Subiquity')
-        - firmware is defined and firmware|lower == "efi"
-   
     - include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'


### PR DESCRIPTION
**Issue:**
The cdrom is the first boot disk in boot order when create VM with firmware efi and install guestOS with ubuntu 23.04 desktop iso.

So it will hit the following issue if we mount iso and then reboot VM:

2023-04-22 03:48:04,022 | TASK [3_vmlibrary_main][Check VMware Tools is running and collects guest IPv4 address successfully] 
task path: /home/worker/workspace/Create_New_VMLibrary_Template/ansible-vsphere-gos-validation/common/vm_wait_guest_ip.yml:49
fatal: [localhost]: FAILED! => {
    "assertion": "vm_guestinfo.instance.guest.toolsRunningStatus == \"guestToolsRunning\"",
    "changed": false,
    "evaluated_to": false,
    "msg": [
        "It's timed out for VMware Tools collecting guest IPv4 address in 300 seconds.",
        "VMware Tools running status is 'guestToolsNotRunning'.",
        "VM's IP address in guest info is ''.",
        "VM's all IP addresses in guest info are '[]'."
    ]
}
error message:
It's timed out for VMware Tools collecting guest IPv4 address in 300 seconds.
VMware Tools running status is 'guestToolsNotRunning'.
VM's IP address in guest info is ''.
VM's all IP addresses in guest info are '[]'.


**Resolution:**
Change the boot disk to be first in boot order for ubuntu 23.04 desktop

**Test result:**
passed to reboot VM after mount ISO to CD/DVD.  it won't hit the upper issue 


