### PR TITLE
[ansible-vsphere-gos-validation] Remove cdrom ISO before running cloud-init GOSC test cases for Ubuntu OVA

### DIFF
--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -133,7 +133,23 @@
         cdrom_controller_num: "{{ vm_cdrom_controller_num }}"
         cdrom_unit_num: "{{ vm_cdrom_unit_num }}"
         cdrom_state: absent
-      when: cdrom_device_list | length > vm_existing_cdrom_list | length
+      when:
+        - ova_guest_os_type != 'ubuntu'
+        - cdrom_device_list | length > vm_existing_cdrom_list | length
+    
+    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+    - name: "Remove all CDROM"
+      include_tasks: ../../common/vm_configure_cdrom.yml
+      vars:
+        cdrom_type: client
+        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+        cdrom_state: absent
+      with_items: "{{ cdrom_device_list }}"
+      loop_control:
+        loop_var: vm_cdrom
+      when: ova_guest_os_type == 'ubuntu'
   when:
     - cdrom_device_list is defined
     - cdrom_device_list | length > 0
@@ -153,25 +169,6 @@
         remove_serial_port is undefined or
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
-
-    - name: "Get all CDROM devices on VM after poweroff"
-      include_tasks: ../../common/vm_get_cdrom_devices.yml
-
-    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
-    - name: "Remove all CDROM"
-      include_tasks: ../../common/vm_configure_cdrom.yml
-      vars:
-        cdrom_type: client
-        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
-        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
-        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
-        cdrom_state: absent
-      with_items: "{{ cdrom_device_list }}"
-      loop_control:
-        loop_var: vm_cdrom
-      when:
-        - cdrom_device_list is defined
-        - cdrom_device_list | length > 0
 
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -133,23 +133,7 @@
         cdrom_controller_num: "{{ vm_cdrom_controller_num }}"
         cdrom_unit_num: "{{ vm_cdrom_unit_num }}"
         cdrom_state: absent
-      when:
-        - ova_guest_os_type != 'ubuntu'
-        - cdrom_device_list | length > vm_existing_cdrom_list | length
-    
-    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
-    - name: "Remove all CDROM"
-      include_tasks: ../../common/vm_configure_cdrom.yml
-      vars:
-        cdrom_type: client
-        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
-        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
-        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
-        cdrom_state: absent
-      with_items: "{{ cdrom_device_list }}"
-      loop_control:
-        loop_var: vm_cdrom
-      when: ova_guest_os_type == 'ubuntu'
+      when: cdrom_device_list | length > vm_existing_cdrom_list | length
   when:
     - cdrom_device_list is defined
     - cdrom_device_list | length > 0
@@ -169,6 +153,20 @@
         remove_serial_port is undefined or
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
+
+    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+    - name: "Remove all CDROM"
+      include_tasks: ../../common/vm_configure_cdrom.yml
+      vars:
+        cdrom_type: client
+        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+        cdrom_state: absent
+      with_items: "{{ vm_existing_cdrom_list }}"
+      loop_control:
+        loop_var: vm_cdrom
+      when: vm_existing_cdrom_list | length > 0
 
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -154,6 +154,25 @@
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
 
+    - name: "Get all CDROM devices on VM after poweroff"
+      include_tasks: ../../common/vm_get_cdrom_devices.yml
+
+    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+    - name: "Remove all CDROM"
+      include_tasks: ../../common/vm_configure_cdrom.yml
+      vars:
+        cdrom_type: client
+        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+        cdrom_state: absent
+      with_items: "{{ cdrom_device_list }}"
+      loop_control:
+        loop_var: vm_cdrom
+      when:
+        - cdrom_device_list is defined
+        - cdrom_device_list | length > 0
+
     - name: "Power on VM"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:


### PR DESCRIPTION
remove cdrom ISO before running "gosc_cloudinit_dhcp" & gosc_cloudinit_staticip in Ubuntu OVA package

**Test result:**
1) for ubuntu 23.04 OVA
<img width="578" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/4179a4ed-0278-47c5-b69d-7bc27c256c9e">

2) for ubuntu 22.04 OVA
<img width="570" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/7c92cf92-0ed3-450a-b460-26631b55ed71">

3) After running full testing for ubuntu 22.04 and 23.04 OVA, removing  cdrom ISO won't produce new issue.

Best regards
Yuhua Zou
