### PR TITLE
[Windows] Update URL for downloading ConfigureRemotingForAnsible.ps1

### DIFF
--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -4,7 +4,7 @@
 # This task is used for generating ISO file containing OS unattend auto install
 # configure file, and/or VMware PVSCSI driver from the downloaded VMware tools
 # installation package, and script for configuring Windows for Ansible from this path:
-# https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
+# https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
 #
 - name: Set fact of the timestamp suffix of ISO file name
   ansible.builtin.set_fact:

--- a/windows/deploy_vm/get_ansible_remote_config.yml
+++ b/windows/deploy_vm/get_ansible_remote_config.yml
@@ -6,7 +6,7 @@
 #
 - name: Set fact of the ConfigureRemotingForAnsible.ps1 script URL
   ansible.builtin.set_fact:
-    config_remote_windows: "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"
+    config_remote_windows: "https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"
 - name: Set fact of the local path for downloaded script
   ansible.builtin.set_fact:
     config_remote_windows_local: "{{ local_cache }}/{{ config_remote_windows.split('/')[-1] }}"


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/81011 removed examples folder from `ansible:devel` branch and moved to `ansible-documentation:devel` branch. So this fix updated the URL to get this PS1 script.