### PR TITLE
[Linux] Replace install_linux_esx with linux_flavor for Photon OS autoinstall

### DIFF
--- a/autoinstall/Photon/ks.cfg
+++ b/autoinstall/Photon/ks.cfg
@@ -8,7 +8,7 @@
     "packagelist_file": "packages_ova.json",
     "arch": "x86_64",
     "additional_packages": ["vim","gawk","sudo","tar", "ndctl", "python3-rpm"],
-    "install_linux_esx": true,
+    "linux_flavor": "linux-esx",
     "eject_cdrom": true,
     "postinstall": [
         "#!/bin/sh",


### PR DESCRIPTION
Latest Photon OS 4.0 daily update couldn't recognize 'install_linux_esx' for ISO auto install. Photon OS team suggests replacing it with `"linux_flavor": "linux-esx"`.

```
  - 'Guest os distribution: VMware Photon OS 4.0 x86_64'
  - 'Hardware version: vmx-21'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroName=''VMware
    Photon OS'' distroVersion=''4.0'' familyName=''Linux'' kernelVersion=''5.10.83-7.ph4-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * check_inbox_driver..............................................Passed'

  - 'Guest os distribution: VMware Photon OS 5.0 x86_64'
  - 'Hardware version: vmx-21'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''5.0''
    distroName=''VMware Photon OS'' distroVersion=''5.0'' familyName=''Linux'' kernelVersion=''6.1.10-10.ph5-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * check_inbox_driver..............................................Passed'

  - 'Guest os distribution: VMware Photon OS 3.0 x86_64'
  - 'Hardware version: vmx-21'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroName=''VMware
    Photon OS'' distroVersion=''3.0'' familyName=''Linux'' kernelVersion=''4.19.245-2.ph3-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * check_inbox_driver..............................................Passed'
 ```