### PR TITLE
Update checking guest_os_ansible_distribution is Flatcar

### DIFF
--- a/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
+++ b/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
@@ -50,7 +50,7 @@
             - pre-freeze-script
             - post-thaw-script
           delegate_to: "{{ vm_guest_ip }}"
-          when: "'Flatcar' != guest_os_ansible_distribution"
+          when: "guest_os_ansible_distribution != 'Flatcar'"
 
         # Ensure /vss.log is absent
         - name: "Remove {{ vss_log_path }} if it exists"
@@ -96,7 +96,7 @@
         - name: "{{ ansible_play_name }} failed"
           ansible.builtin.fail:
             msg: "{{ vss_log_path }} has incorrect content"
-          when: ('Flatcar' != guest_os_ansible_distribution) and
+          when: (guest_os_ansible_distribution != 'Flatcar') and
               (( not vss_content ) or
               ( vss_content.stdout_lines is undefined ) or
               ( vss_content.stdout_lines | length != 4 ) or
@@ -109,7 +109,7 @@
         - name: "{{ ansible_play_name }} failed"
           ansible.builtin.fail:
             msg: "{{ vss_log_path }} has incorrect content"
-          when: ('Flatcar' == guest_os_ansible_distribution) and
+          when: (guest_os_ansible_distribution == 'Flatcar') and
              (( not vss_content ) or
              ( vss_content.stdout_lines is undefined ) or
              ( vss_content.stdout_lines | length != 2 ) or

--- a/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
+++ b/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
@@ -50,7 +50,7 @@
             - pre-freeze-script
             - post-thaw-script
           delegate_to: "{{ vm_guest_ip }}"
-          when: "'Flatcar' not in guest_os_ansible_distribution"
+          when: "'Flatcar' != guest_os_ansible_distribution"
 
         # Ensure /vss.log is absent
         - name: "Remove {{ vss_log_path }} if it exists"
@@ -96,7 +96,7 @@
         - name: "{{ ansible_play_name }} failed"
           ansible.builtin.fail:
             msg: "{{ vss_log_path }} has incorrect content"
-          when: ('Flatcar' not in guest_os_ansible_distribution) and
+          when: ('Flatcar' != guest_os_ansible_distribution) and
               (( not vss_content ) or
               ( vss_content.stdout_lines is undefined ) or
               ( vss_content.stdout_lines | length != 4 ) or
@@ -109,7 +109,7 @@
         - name: "{{ ansible_play_name }} failed"
           ansible.builtin.fail:
             msg: "{{ vss_log_path }} has incorrect content"
-          when: ('Flatcar' in guest_os_ansible_distribution) and
+          when: ('Flatcar' == guest_os_ansible_distribution) and
              (( not vss_content ) or
              ( vss_content.stdout_lines is undefined ) or
              ( vss_content.stdout_lines | length != 2 ) or

--- a/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
+++ b/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
@@ -50,7 +50,7 @@
             - pre-freeze-script
             - post-thaw-script
           delegate_to: "{{ vm_guest_ip }}"
-          when: "guest_os_ansible_distribution != 'Flatcar'"
+          when: guest_os_ansible_distribution != 'Flatcar'
 
         # Ensure /vss.log is absent
         - name: "Remove {{ vss_log_path }} if it exists"

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -126,7 +126,7 @@
       when:
         - not enable_cloudinit_gosc | bool
         - guest_os_ansible_distribution not in gos_not_support_gosc
-        - "guest_os_ansible_distribution != 'Flatcar'"
+        - guest_os_ansible_distribution != 'Flatcar'
 
     - name: "Display GOSC support status for {{ vm_guest_os_distribution }}"
       ansible.builtin.debug:

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -51,7 +51,7 @@
         gosc_is_supported: false
       when: >
         (guest_os_ansible_distribution in gos_not_support_gosc) or
-        ('Flatcar' in guest_os_ansible_distribution)
+        ('Flatcar' == guest_os_ansible_distribution)
 
     - name: "Set cloud-init GOSC support status for {{ vm_guest_os_distribution }}"
       block:
@@ -126,7 +126,7 @@
       when:
         - not enable_cloudinit_gosc | bool
         - guest_os_ansible_distribution not in gos_not_support_gosc
-        - "'Flatcar' not in guest_os_ansible_distribution"
+        - "'Flatcar' != guest_os_ansible_distribution"
 
     - name: "Display GOSC support status for {{ vm_guest_os_distribution }}"
       ansible.builtin.debug:

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -51,7 +51,7 @@
         gosc_is_supported: false
       when: >
         (guest_os_ansible_distribution in gos_not_support_gosc) or
-        ('Flatcar' == guest_os_ansible_distribution)
+        (guest_os_ansible_distribution == 'Flatcar')
 
     - name: "Set cloud-init GOSC support status for {{ vm_guest_os_distribution }}"
       block:
@@ -126,7 +126,7 @@
       when:
         - not enable_cloudinit_gosc | bool
         - guest_os_ansible_distribution not in gos_not_support_gosc
-        - "'Flatcar' != guest_os_ansible_distribution"
+        - "guest_os_ansible_distribution != 'Flatcar'"
 
     - name: "Display GOSC support status for {{ vm_guest_os_distribution }}"
       ansible.builtin.debug:

--- a/linux/network_device_ops/apply_new_network_config.yml
+++ b/linux/network_device_ops/apply_new_network_config.yml
@@ -98,7 +98,7 @@
     - name: "Set fact of the network config template for Flatcar"
       ansible.builtin.set_fact:
         network_config_template: flatcar_network_conf.j2
-      when: "'Flatcar' == guest_os_ansible_distribution"
+      when: "guest_os_ansible_distribution == 'Flatcar'"
 
     - name: "Create or update network config file for new network interface"
       block:

--- a/linux/network_device_ops/apply_new_network_config.yml
+++ b/linux/network_device_ops/apply_new_network_config.yml
@@ -98,7 +98,7 @@
     - name: "Set fact of the network config template for Flatcar"
       ansible.builtin.set_fact:
         network_config_template: flatcar_network_conf.j2
-      when: "'Flatcar' in guest_os_ansible_distribution"
+      when: "'Flatcar' == guest_os_ansible_distribution"
 
     - name: "Create or update network config file for new network interface"
       block:

--- a/linux/network_device_ops/apply_new_network_config.yml
+++ b/linux/network_device_ops/apply_new_network_config.yml
@@ -98,7 +98,7 @@
     - name: "Set fact of the network config template for Flatcar"
       ansible.builtin.set_fact:
         network_config_template: flatcar_network_conf.j2
-      when: "guest_os_ansible_distribution == 'Flatcar'"
+      when: guest_os_ansible_distribution == 'Flatcar'
 
     - name: "Create or update network config file for new network interface"
       block:

--- a/linux/network_device_ops/check_pvrdma_support_status.yml
+++ b/linux/network_device_ops/check_pvrdma_support_status.yml
@@ -8,9 +8,7 @@
   vars:
     skip_msg: "{{ guest_os_ansible_distribution }} doesn't support PVRDMA"
     skip_reason: "Not Supported"
-  when: >
-    ('Flatcar' == guest_os_ansible_distribution or
-     guest_os_ansible_distribution in ['Fedora', 'VMware Photon OS'])
+  when: guest_os_ansible_distribution in ['Fedora', 'VMware Photon OS', 'Flatcar'])
 
 - name: "Get guest config options"
   include_tasks: ../../common/esxi_get_guest_config_options.yml

--- a/linux/network_device_ops/check_pvrdma_support_status.yml
+++ b/linux/network_device_ops/check_pvrdma_support_status.yml
@@ -8,7 +8,7 @@
   vars:
     skip_msg: "{{ guest_os_ansible_distribution }} doesn't support PVRDMA"
     skip_reason: "Not Supported"
-  when: guest_os_ansible_distribution in ['Fedora', 'VMware Photon OS', 'Flatcar'])
+  when: guest_os_ansible_distribution in ['Fedora', 'VMware Photon OS', 'Flatcar']
 
 - name: "Get guest config options"
   include_tasks: ../../common/esxi_get_guest_config_options.yml

--- a/linux/network_device_ops/check_pvrdma_support_status.yml
+++ b/linux/network_device_ops/check_pvrdma_support_status.yml
@@ -9,7 +9,7 @@
     skip_msg: "{{ guest_os_ansible_distribution }} doesn't support PVRDMA"
     skip_reason: "Not Supported"
   when: >
-    ('Flatcar' in guest_os_ansible_distribution or
+    ('Flatcar' == guest_os_ansible_distribution or
      guest_os_ansible_distribution in ['Fedora', 'VMware Photon OS'])
 
 - name: "Get guest config options"

--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -25,8 +25,7 @@
               doesn't support NVDIMM.
             skip_reason: "Not Supported"
           when: >
-            (guest_os_ansible_distribution == 'Flatcar' or
-             guest_os_ansible_distribution in ['UnionTech', 'Uos', 'Amazon', 'openSUSE Leap'] or
+             (guest_os_ansible_distribution in ['Flatcar', 'UnionTech', 'Uos', 'Amazon', 'openSUSE Leap'] or
              (guest_os_ansible_distribution == 'Ubuntu' and
               guest_os_edition == 'CloudImage'))
 

--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -25,7 +25,7 @@
               doesn't support NVDIMM.
             skip_reason: "Not Supported"
           when: >
-            ('Flatcar' == guest_os_ansible_distribution or
+            (guest_os_ansible_distribution == 'Flatcar' or
              guest_os_ansible_distribution in ['UnionTech', 'Uos', 'Amazon', 'openSUSE Leap'] or
              (guest_os_ansible_distribution == 'Ubuntu' and
               guest_os_edition == 'CloudImage'))

--- a/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
+++ b/linux/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
@@ -25,7 +25,7 @@
               doesn't support NVDIMM.
             skip_reason: "Not Supported"
           when: >
-            ('Flatcar' in guest_os_ansible_distribution or
+            ('Flatcar' == guest_os_ansible_distribution or
              guest_os_ansible_distribution in ['UnionTech', 'Uos', 'Amazon', 'openSUSE Leap'] or
              (guest_os_ansible_distribution == 'Ubuntu' and
               guest_os_edition == 'CloudImage'))

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -26,7 +26,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support installing open-vm-tools"
             skip_reason: "Not Supported"
-          when: "'Flatcar' == guest_os_ansible_distribution"
+          when: "guest_os_ansible_distribution == 'Flatcar'"
 
         # VM has open-vm-tools installed and update_vmtools is set false
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -26,7 +26,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support installing open-vm-tools"
             skip_reason: "Not Supported"
-          when: "'Flatcar' in guest_os_ansible_distribution"
+          when: "'Flatcar' == guest_os_ansible_distribution"
 
         # VM has open-vm-tools installed and update_vmtools is set false
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/open_vm_tools/ovt_verify_install.yml
+++ b/linux/open_vm_tools/ovt_verify_install.yml
@@ -26,7 +26,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support installing open-vm-tools"
             skip_reason: "Not Supported"
-          when: "guest_os_ansible_distribution == 'Flatcar'"
+          when: guest_os_ansible_distribution == 'Flatcar'
 
         # VM has open-vm-tools installed and update_vmtools is set false
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -47,7 +47,7 @@
           with_items: "{{ ovt_packages }}"
           loop_control:
             loop_var: package_name
-          when: "'Flatcar' not in guest_os_ansible_distribution"
+          when: "'Flatcar' != guest_os_ansible_distribution"
 
         # Check open-vm-tools processes are running
         - include_tasks: ../utils/check_process_status.yml

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -47,7 +47,7 @@
           with_items: "{{ ovt_packages }}"
           loop_control:
             loop_var: package_name
-          when: "'Flatcar' != guest_os_ansible_distribution"
+          when: "guest_os_ansible_distribution != 'Flatcar'"
 
         # Check open-vm-tools processes are running
         - include_tasks: ../utils/check_process_status.yml

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -47,7 +47,7 @@
           with_items: "{{ ovt_packages }}"
           loop_control:
             loop_var: package_name
-          when: "guest_os_ansible_distribution != 'Flatcar'"
+          when: guest_os_ansible_distribution != 'Flatcar'
 
         # Check open-vm-tools processes are running
         - include_tasks: ../utils/check_process_status.yml

--- a/linux/open_vm_tools/ovt_verify_uninstall.yml
+++ b/linux/open_vm_tools/ovt_verify_uninstall.yml
@@ -21,7 +21,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support uninstalling open-vm-tools"
             skip_reason: "Not Supported"
-          when: "'Flatcar' in guest_os_ansible_distribution"
+          when: "'Flatcar' == guest_os_ansible_distribution"
 
         - name: "Block test case when guest OS doesn't install open-vm-tools"
           include_tasks: ../../common/skip_test_case.yml

--- a/linux/open_vm_tools/ovt_verify_uninstall.yml
+++ b/linux/open_vm_tools/ovt_verify_uninstall.yml
@@ -21,7 +21,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support uninstalling open-vm-tools"
             skip_reason: "Not Supported"
-          when: "guest_os_ansible_distribution == 'Flatcar'"
+          when: guest_os_ansible_distribution == 'Flatcar'
 
         - name: "Block test case when guest OS doesn't install open-vm-tools"
           include_tasks: ../../common/skip_test_case.yml

--- a/linux/open_vm_tools/ovt_verify_uninstall.yml
+++ b/linux/open_vm_tools/ovt_verify_uninstall.yml
@@ -21,7 +21,7 @@
           vars:
             skip_msg: "Skip test case because {{ guest_os_ansible_distribution }} doesn't support uninstalling open-vm-tools"
             skip_reason: "Not Supported"
-          when: "'Flatcar' == guest_os_ansible_distribution"
+          when: "guest_os_ansible_distribution == 'Flatcar'"
 
         - name: "Block test case when guest OS doesn't install open-vm-tools"
           include_tasks: ../../common/skip_test_case.yml

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -70,7 +70,7 @@
     - name: "Set fact of network config file for '{{ network_adapter_name }}' on Flatcar"
       ansible.builtin.set_fact:
         network_config_path: "/etc/systemd/network/{{ network_adapter_name }}"
-      when: "'Flatcar' in guest_os_ansible_distribution"
+      when: "'Flatcar' == guest_os_ansible_distribution"
   when:
     - guest_os_network_manager != "NetworkManager"
     - guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -70,7 +70,7 @@
     - name: "Set fact of network config file for '{{ network_adapter_name }}' on Flatcar"
       ansible.builtin.set_fact:
         network_config_path: "/etc/systemd/network/{{ network_adapter_name }}"
-      when: "'Flatcar' == guest_os_ansible_distribution"
+      when: "guest_os_ansible_distribution == 'Flatcar'"
   when:
     - guest_os_network_manager != "NetworkManager"
     - guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -70,7 +70,7 @@
     - name: "Set fact of network config file for '{{ network_adapter_name }}' on Flatcar"
       ansible.builtin.set_fact:
         network_config_path: "/etc/systemd/network/{{ network_adapter_name }}"
-      when: "guest_os_ansible_distribution == 'Flatcar'"
+      when: guest_os_ansible_distribution == 'Flatcar'
   when:
     - guest_os_network_manager != "NetworkManager"
     - guest_os_ansible_distribution not in ["VMware Photon OS", "Astra Linux (Orel)"]

--- a/linux/utils/get_network_manager.yml
+++ b/linux/utils/get_network_manager.yml
@@ -55,7 +55,7 @@
             guest_os_network_manager: "systemd-networkd"
           when: >
             (guest_os_ansible_distribution == "VMware Photon OS") or
-            ("Flatcar" in guest_os_ansible_distribution)
+            ("Flatcar" == guest_os_ansible_distribution)
       when: >
         (not service_info or
         service_info.state is undefined or

--- a/linux/utils/get_network_manager.yml
+++ b/linux/utils/get_network_manager.yml
@@ -55,7 +55,7 @@
             guest_os_network_manager: "systemd-networkd"
           when: >
             (guest_os_ansible_distribution == "VMware Photon OS") or
-            ("Flatcar" == guest_os_ansible_distribution)
+            (guest_os_ansible_distribution == "Flatcar")
       when: >
         (not service_info or
         service_info.state is undefined or

--- a/linux/utils/get_network_manager.yml
+++ b/linux/utils/get_network_manager.yml
@@ -53,9 +53,7 @@
         - name: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} network device manager is systemd-networkd"
           ansible.builtin.set_fact:
             guest_os_network_manager: "systemd-networkd"
-          when: >
-            (guest_os_ansible_distribution == "VMware Photon OS") or
-            (guest_os_ansible_distribution == "Flatcar")
+          when: guest_os_ansible_distribution in ['VMware Photon OS', 'Flatcar'] 
       when: >
         (not service_info or
         service_info.state is undefined or

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -24,7 +24,7 @@
             skip_reason: "Not Supported"
           when: >
              (guest_os_ansible_distribution is defined) and
-             ('Flatcar' == guest_os_ansible_distribution)
+             (guest_os_ansible_distribution == 'Flatcar')
 
         - name: "Set facts of VGAuthService process and service"
           include_tasks: ../utils/set_vgauth_facts.yml

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -24,7 +24,7 @@
             skip_reason: "Not Supported"
           when: >
              (guest_os_ansible_distribution is defined) and
-             ('Flatcar' in guest_os_ansible_distribution)
+             ('Flatcar' == guest_os_ansible_distribution)
 
         - name: "Set facts of VGAuthService process and service"
           include_tasks: ../utils/set_vgauth_facts.yml

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -36,7 +36,7 @@
             package_state: "present"
       when:
         - new_disk_ctrl_type == 'lsilogic'
-        - "'Flatcar' not in guest_os_ansible_distribution"
+        - "'Flatcar' != guest_os_ansible_distribution"
 
     - name: "Get the vHBA type for {{ new_disk_ctrl_type }} controller"
       ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -36,7 +36,7 @@
             package_state: "present"
       when:
         - new_disk_ctrl_type == 'lsilogic'
-        - "'Flatcar' != guest_os_ansible_distribution"
+        - "guest_os_ansible_distribution != 'Flatcar'"
 
     - name: "Get the vHBA type for {{ new_disk_ctrl_type }} controller"
       ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -36,7 +36,7 @@
             package_state: "present"
       when:
         - new_disk_ctrl_type == 'lsilogic'
-        - "guest_os_ansible_distribution != 'Flatcar'"
+        - guest_os_ansible_distribution != 'Flatcar'
 
     - name: "Get the vHBA type for {{ new_disk_ctrl_type }} controller"
       ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -44,7 +44,7 @@
             - rescan_scsi_result is defined
             - rescan_scsi_result.stdout_lines
       when:
-        - "'Flatcar' not in guest_os_ansible_distribution"
+        - "'Flatcar' != guest_os_ansible_distribution"
         - not (guest_os_ansible_distribution == "Ubuntu" and
                guest_os_ansible_distribution_major_ver | int >= 22)
         - not (guest_os_ansible_distribution == "Debian" and
@@ -83,7 +83,7 @@
                 - guest_ansible_device[wait_device_name].size == "0.00 Bytes"
           when: wait_device_state | lower == 'absent'
       when: >
-        ('Flatcar' in guest_os_ansible_distribution or
+        ('Flatcar' == guest_os_ansible_distribution or
          (guest_os_ansible_distribution == "Ubuntu" and
           guest_os_ansible_distribution_major_ver | int >= 22) or
          (guest_os_ansible_distribution == "Debian" and

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -44,7 +44,7 @@
             - rescan_scsi_result is defined
             - rescan_scsi_result.stdout_lines
       when:
-        - "'Flatcar' != guest_os_ansible_distribution"
+        - "guest_os_ansible_distribution != 'Flatcar'"
         - not (guest_os_ansible_distribution == "Ubuntu" and
                guest_os_ansible_distribution_major_ver | int >= 22)
         - not (guest_os_ansible_distribution == "Debian" and
@@ -83,7 +83,7 @@
                 - guest_ansible_device[wait_device_name].size == "0.00 Bytes"
           when: wait_device_state | lower == 'absent'
       when: >
-        ('Flatcar' == guest_os_ansible_distribution or
+        (guest_os_ansible_distribution == 'Flatcar' or
          (guest_os_ansible_distribution == "Ubuntu" and
           guest_os_ansible_distribution_major_ver | int >= 22) or
          (guest_os_ansible_distribution == "Debian" and

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -44,7 +44,7 @@
             - rescan_scsi_result is defined
             - rescan_scsi_result.stdout_lines
       when:
-        - "guest_os_ansible_distribution != 'Flatcar'"
+        - guest_os_ansible_distribution != 'Flatcar'
         - not (guest_os_ansible_distribution == "Ubuntu" and
                guest_os_ansible_distribution_major_ver | int >= 22)
         - not (guest_os_ansible_distribution == "Debian" and


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/77635 flatcar distribution name has been fixed in ansible-core 2.14. Now its guest_os_ansible_distribution is 'Flatcar' not 'Flatcar Container Linux by Kinvolk' any more. 