### PR TITLE
Ignore esxi_hostname at VM creation when vcenter_hostname is not defined

### DIFF
--- a/common/vm_create.yml
+++ b/common/vm_create.yml
@@ -34,7 +34,7 @@
     password: "{{ vsphere_host_user_password }}"
     validate_certs: "{{ validate_certs | default(false) }}"
     datacenter: "{{ vsphere_host_datacenter }}"
-    esxi_hostname: "{{ esxi_hostname }}"
+    esxi_hostname: "{{ esxi_hostname if vsphere_host_name != esxi_hostname else omit }}"
     folder: "{{ vm_folder }}"
     name: "{{ vm_name }}"
     guest_id: "{{ guest_id }}"


### PR DESCRIPTION
If there is no vcenter_hostname defined in vars/test.yml, vsphere_host_name will be same with esxi_hostname, and `common/vm_create.yml` will report error like "Unable to find host". It means that esxi_hostname is required when vsphere_host_name = vcenter_hostname for this task. The solution is to ignore esxi_hostname when vsphere_host_name = esxi_hostname. 