### PR TITLE
[Linux] Correct ovt_packages for Linux guest OS with desktop

### DIFF
--- a/linux/utils/check_guest_os_gui.yml
+++ b/linux/utils/check_guest_os_gui.yml
@@ -47,10 +47,18 @@
         - display_manager_status.rc == 0
         - display_manager_status.stdout_lines is defined
         - display_manager_status.stdout_lines | length > 0
+
+    # If systemctl status display-manager.service error code is 4, it means
+    # the service doesn't exist, so guest OS doesn't have desktop
+    - name: "Set fact of guest OS having no desktop environment"
+      ansible.builtin.set_fact:
+        guest_os_with_gui: false
+      when: >
+        (display_manager_status.rc is undefined or
+        display_manager_status.rc == 4)
   when:
     - guest_os_with_gui | bool
     - guest_os_ansible_distribution != 'Astra Linux (Orel)'
-
 
 - name: "Set fact of guest OS display manager for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:

--- a/linux/utils/set_ovt_facts.yml
+++ b/linux/utils/set_ovt_facts.yml
@@ -25,13 +25,16 @@
     ovt_packages: "{{ ovt_packages | union(['libvmtools0']) }}"
   when: guest_os_family == "Suse"
 
-- name: "Update the fact of open-vm-tools packages for {{ guest_os_family }}"
-  ansible.builtin.set_fact:
-    ovt_packages: "{{ ovt_packages | union(['open-vm-tools-desktop']) }}"
-  when: guest_os_family != "FreeBSD"
+- name: "Update facts of open-vm-tools packages and processes"
+  when:
+    - guest_os_with_gui is defined
+    - guest_os_with_gui
+  block:
+    - name: "Update the fact of open-vm-tools packages for {{ guest_os_family }}"
+      ansible.builtin.set_fact:
+        ovt_packages: "{{ ovt_packages | union(['open-vm-tools-desktop']) }}"
+      when: guest_os_family != "FreeBSD"
 
-- name: "Update the fact of open-vm-tools processes with desktop"
-  ansible.builtin.set_fact:
-    ovt_processes: "{{ ovt_processes | union([{'uid':'vmware', 'cmd':'vmtoolsd -n vmusr'}]) }}"
-  when: guest_os_with_gui is defined and guest_os_with_gui
-
+    - name: "Update the fact of open-vm-tools processes for guest OS with desktop"
+      ansible.builtin.set_fact:
+        ovt_processes: "{{ ovt_processes | union([{'uid':'vmware', 'cmd':'vmtoolsd -n vmusr'}]) }}"

--- a/linux/utils/set_ovt_facts.yml
+++ b/linux/utils/set_ovt_facts.yml
@@ -3,38 +3,35 @@
 ---
 # Set the fact of open-vm-tools packages, processes and services
 #
-- name: "Initialize the fact of open-vm-tools packages, processe and service"
+- name: "Set fact of open-vm-tools service for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
-    ovt_packages: ["open-vm-tools"]
-    ovt_processes: [{"uid": "root", "cmd":"vmtoolsd"}]
     ovt_service: |-
       {%- if guest_os_family == 'FreeBSD' -%}vmware-guestd
       {%- elif guest_os_family in ['Debian', 'Astra Linux (Orel)'] -%}open-vm-tools
       {%- else  -%}vmtoolsd
       {%- endif -%}
 
-- name: "Update the fact of ovt_packages for FreeBSD without GUI"
+- name: "Set facts of open-vm-tools packages and processes for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
-    ovt_packages: ["open-vm-tools-nox11"]
-  when:
-    - guest_os_ansible_distribution == "FreeBSD"
-    - guest_os_with_gui is undefined or not guest_os_with_gui
+    ovt_packages: |-
+      {%- if guest_os_family == 'FreeBSD' -%}["open-vm-tools-nox11"]
+      {%- elif guest_os_family == "Suse" -%}["open-vm-tools", "libvmtools0"]
+      {%- else -%}["open-vm-tools"]
+      {%- endif -%}
+    ovt_processes:
+      - {"uid": "root", "cmd":"vmtoolsd"}
+  when: guest_os_with_gui is undefined or not guest_os_with_gui
 
-- name: "Add extra package libvmtools0 for {{ guest_os_ansible_distribution }}"
+- name: "Set facts of open-vm-tools packages and processes for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
-    ovt_packages: "{{ ovt_packages | union(['libvmtools0']) }}"
-  when: guest_os_family == "Suse"
-
-- name: "Update facts of open-vm-tools packages and processes"
+    ovt_packages: |-
+      {%- if guest_os_family == 'FreeBSD' -%}["open-vm-tools"]
+      {%- elif guest_os_family == "Suse" -%}["open-vm-tools", "open-vm-tools-desktop", "libvmtools0"]
+      {%- else -%}["open-vm-tools", "open-vm-tools-desktop"]
+      {%- endif -%}
+    ovt_processes:
+      - {"uid": "root", "cmd":"vmtoolsd"}
+      - {'uid':'vmware', 'cmd':'vmtoolsd -n vmusr'}
   when:
     - guest_os_with_gui is defined
     - guest_os_with_gui
-  block:
-    - name: "Update the fact of open-vm-tools packages for {{ guest_os_family }}"
-      ansible.builtin.set_fact:
-        ovt_packages: "{{ ovt_packages | union(['open-vm-tools-desktop']) }}"
-      when: guest_os_family != "FreeBSD"
-
-    - name: "Update the fact of open-vm-tools processes for guest OS with desktop"
-      ansible.builtin.set_fact:
-        ovt_processes: "{{ ovt_processes | union([{'uid':'vmware', 'cmd':'vmtoolsd -n vmusr'}]) }}"


### PR DESCRIPTION
```
  - 'Guest os distribution: Ubuntu 20.04 Server x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''20.04.6
    LTS (Focal Fossa)'' distroName=''Ubuntu'' distroVersion=''20.04'' familyName=''Linux''
    kernelVersion=''5.4.0-144-generic'' prettyName=''Ubuntu 20.04.6 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 3.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''3.0''
    distroName=''VMware Photon OS'' distroVersion=''3.0'' familyName=''Linux'' kernelVersion=''4.19.245-2.ph3-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 10 i386'
  - 'Config guest id: debian10Guest'
  - 'Guestinfo guest id: debian10Guest'
  - 'Guestinfo guest full name: Debian GNU/Linux 10 (32-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''32'' distroAddlVersion=''10
    (buster)'' distroName=''Debian GNU/Linux'' distroVersion=''10'' familyName=''Linux''
    kernelVersion=''4.19.0-21-686-pae'' prettyName=''Debian GNU/Linux 10 (buster)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_bios_paravirtual_vmxnet3..............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 23.04 Server x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''23.04
    (Lunar Lobster)'' distroName=''Ubuntu'' distroVersion=''23.04'' familyName=''Linux''
    kernelVersion=''6.2.0-26-generic'' prettyName=''Ubuntu 23.04'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Rocky 9.2 x86_64'
  - 'Config guest id: rockylinux_64Guest'
  - 'Guestinfo guest id: rockylinux_64Guest'
  - 'Guestinfo guest full name: Rocky Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:rocky:rocky:9::baseos''
    distroAddlVersion=''9.2 (Blue Onyx)'' distroName=''Rocky Linux'' distroVersion=''9.2''
    familyName=''Linux'' kernelVersion=''5.14.0-284.11.1.el9_2.x86_64'' prettyName=''Rocky
    Linux 9.2 (Blue Onyx)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 22.04 Server x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''22.04.2
    LTS (Jammy Jellyfish)'' distroName=''Ubuntu'' distroVersion=''22.04'' familyName=''Linux''
    kernelVersion=''5.15.0-78-generic'' prettyName=''Ubuntu 22.04.2 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 11 i386'
  - 'Config guest id: debian11Guest'
  - 'Guestinfo guest id: debian11Guest'
  - 'Guestinfo guest full name: Debian GNU/Linux 11 (32-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''32'' distroAddlVersion=''11
    (bullseye)'' distroName=''Debian GNU/Linux'' distroVersion=''11'' familyName=''Linux''
    kernelVersion=''5.10.0-22-686-pae'' prettyName=''Debian GNU/Linux 11 (bullseye)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_bios_paravirtual_vmxnet3..............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 4.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''4.0''
    distroName=''VMware Photon OS'' distroVersion=''4.0'' familyName=''Linux'' kernelVersion=''5.10.83-7.ph4-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 20.04 Desktop x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''20.04.6
    LTS (Focal Fossa)'' distroName=''Ubuntu'' distroVersion=''20.04'' familyName=''Linux''
    kernelVersion=''5.15.0-78-generic'' prettyName=''Ubuntu 20.04.6 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 10 x86_64'
  - 'Config guest id: debian10_64Guest'
  - 'Guestinfo guest id: debian10_64Guest'
  - 'Guestinfo guest full name: Debian GNU/Linux 10 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''10
    (buster)'' distroName=''Debian GNU/Linux'' distroVersion=''10'' familyName=''Linux''
    kernelVersion=''4.19.0-21-amd64'' prettyName=''Debian GNU/Linux 10 (buster)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: RedHat 9.2 x86_64'
  - 'Config guest id: rhel9_64Guest'
  - 'Guestinfo guest id: rhel9_64Guest'
  - 'Guestinfo guest full name: Red Hat Enterprise Linux 9 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:redhat:enterprise_linux:9::baseos''
    distroAddlVersion=''9.2 (Plow)'' distroName=''Red Hat Enterprise Linux'' distroVersion=''9.2''
    familyName=''Linux'' kernelVersion=''5.14.0-284.11.1.el9_2.x86_64'' prettyName=''Red
    Hat Enterprise Linux 9.2 (Plow)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 22.04 Desktop x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''22.04.2
    LTS (Jammy Jellyfish)'' distroName=''Ubuntu'' distroVersion=''22.04'' familyName=''Linux''
    kernelVersion=''6.2.0-26-generic'' prettyName=''Ubuntu 22.04.2 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 5.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''5.0''
    distroName=''VMware Photon OS'' distroVersion=''5.0'' familyName=''Linux'' kernelVersion=''6.1.10-10.ph5-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: AlmaLinux 9.2 x86_64'
  - 'Config guest id: almalinux_64Guest'
  - 'Guestinfo guest id: almalinux_64Guest'
  - 'Guestinfo guest full name: AlmaLinux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:almalinux:almalinux:9::baseos''
    distroAddlVersion=''9.2 (Turquoise Kodkod)'' distroName=''AlmaLinux'' distroVersion=''9.2''
    familyName=''Linux'' kernelVersion=''5.14.0-284.11.1.el9_2.x86_64'' prettyName=''AlmaLinux
    9.2 (Turquoise Kodkod)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 12.1 i386'
  - 'Config guest id: debian12Guest'
  - 'Guestinfo guest id: debian12Guest'
  - 'Guestinfo guest full name: Debian GNU/Linux 12 (32-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''32'' distroAddlVersion=''12
    (bookworm)'' distroName=''Debian GNU/Linux'' distroVersion=''12'' familyName=''Linux''
    kernelVersion=''6.1.0-10-686-pae'' prettyName=''Debian GNU/Linux 12 (bookworm)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_bios_paravirtual_vmxnet3..............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: OracleLinux 8.8 x86_64'
  - 'Config guest id: oracleLinux8_64Guest'
  - 'Guestinfo guest id: oracleLinux8_64Guest'
  - 'Guestinfo guest full name: Oracle Linux 8 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:oracle:linux:8:8:server''
    distroAddlVersion=''8.8'' distroName=''Oracle Linux Server'' distroVersion=''8.8''
    familyName=''Linux'' kernelVersion=''5.15.0-101.103.2.1.el8uek.x86_64'' prettyName=''Oracle
    Linux Server 8.8'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: ProLinux 8.5 x86_64'
  - 'Config guest id: other4xLinux64Guest'
  - 'Guestinfo guest id: other4xLinux64Guest'
  - 'Guestinfo guest full name: Other 4.x Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:prolinux:prolinux:8.5''
    distroAddlVersion=''8.5'' distroName=''ProLinux'' distroVersion=''8.5'' familyName=''Linux''
    kernelVersion=''4.18.0-348.el8.x86_64'' prettyName=''ProLinux 8.5'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Rocky 8.8 x86_64'
  - 'Config guest id: rockylinux_64Guest'
  - 'Guestinfo guest id: rockylinux_64Guest'
  - 'Guestinfo guest full name: Rocky Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:rocky:rocky:8:GA''
    distroAddlVersion=''8.8 (Green Obsidian)'' distroName=''Rocky Linux'' distroVersion=''8.8''
    familyName=''Linux'' kernelVersion=''4.18.0-477.10.1.el8_8.x86_64'' prettyName=''Rocky
    Linux 8.8 (Green Obsidian)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: ProLinux 7.9 x86_64'
  - 'Config guest id: other3xLinux64Guest'
  - 'Guestinfo guest id: other3xLinux64Guest'
  - 'Guestinfo guest full name: Other 3.x Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:prolinux:prolinux:7:9:server''
    distroAddlVersion=''7.9'' distroName=''ProLinux Server'' distroVersion=''7.9''
    familyName=''Linux'' kernelVersion=''3.10.0-1160.el7.x86_64'' prettyName=''ProLinux
    7.9'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 23.04 Desktop x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''23.04
    (Lunar Lobster)'' distroName=''Ubuntu'' distroVersion=''23.04'' familyName=''Linux''
    kernelVersion=''6.2.0-26-generic'' prettyName=''Ubuntu 23.04'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: CentOS 8.5 x86_64'
  - 'Config guest id: centos8_64Guest'
  - 'Guestinfo guest id: centos8_64Guest'
  - 'Guestinfo guest full name: CentOS 8 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:centos:centos:8''
    distroAddlVersion=''8'' distroName=''CentOS Linux'' distroVersion=''8'' familyName=''Linux''
    kernelVersion=''4.18.0-348.el8.x86_64'' prettyName=''CentOS Linux 8'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 11 x86_64'
  - 'Config guest id: debian11_64Guest'
  - 'Guestinfo guest id: debian11_64Guest'
  - 'Guestinfo guest full name: Debian GNU/Linux 11 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''11
    (bullseye)'' distroName=''Debian GNU/Linux'' distroVersion=''11'' familyName=''Linux''
    kernelVersion=''5.10.0-22-amd64'' prettyName=''Debian GNU/Linux 11 (bullseye)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: AlmaLinux 8.8 x86_64'
  - 'Config guest id: almalinux_64Guest'
  - 'Guestinfo guest id: almalinux_64Guest'
  - 'Guestinfo guest full name: AlmaLinux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:almalinux:almalinux:8::baseos''
    distroAddlVersion=''8.8 (Sapphire Caracal)'' distroName=''AlmaLinux'' distroVersion=''8.8''
    familyName=''Linux'' kernelVersion=''4.18.0-477.10.1.el8_8.x86_64'' prettyName=''AlmaLinux
    8.8 (Sapphire Caracal)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: SLES 15.5 x86_64'
  - 'Config guest id: sles15_64Guest'
  - 'Guestinfo guest id: sles15_64Guest'
  - 'Guestinfo guest full name: SUSE Linux Enterprise 15 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:suse:sles:15:sp5''
    distroAddlVersion=''15-SP5'' distroName=''SLES'' distroVersion=''15.5'' familyName=''Linux''
    kernelVersion=''5.14.21-150500.53-default'' prettyName=''SUSE Linux Enterprise
    Server 15 SP5'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: SLED 15.5 x86_64'
  - 'Config guest id: sles15_64Guest'
  - 'Guestinfo guest id: sles15_64Guest'
  - 'Guestinfo guest full name: SUSE Linux Enterprise 15 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:suse:sled:15:sp5''
    distroAddlVersion=''15-SP5'' distroName=''SLED'' distroVersion=''15.5'' familyName=''Linux''
    kernelVersion=''5.14.21-150500.53-default'' prettyName=''SUSE Linux Enterprise
    Desktop 15 SP5'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: RedHat 8.8 x86_64'
  - 'Config guest id: rhel8_64Guest'
  - 'Guestinfo guest id: rhel8_64Guest'
  - 'Guestinfo guest full name: Red Hat Enterprise Linux 8 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:redhat:enterprise_linux:8::baseos''
    distroAddlVersion=''8.8 (Ootpa)'' distroName=''Red Hat Enterprise Linux'' distroVersion=''8.8''
    familyName=''Linux'' kernelVersion=''4.18.0-477.10.1.el8_8.x86_64'' prettyName=''Red
    Hat Enterprise Linux 8.8 (Ootpa)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: RedHat 7.9 x86_64'
  - 'Config guest id: rhel7_64Guest'
  - 'Guestinfo guest id: rhel7_64Guest'
  - 'Guestinfo guest full name: Red Hat Enterprise Linux 7 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:redhat:enterprise_linux:7.9:GA:server''
    distroAddlVersion=''7.9 (Maipo)'' distroName=''Red Hat Enterprise Linux Server''
    distroVersion=''7.9'' familyName=''Linux'' kernelVersion=''3.10.0-1160.el7.x86_64''
    prettyName=''Red Hat Enterprise Linux Server 7.9 (Maipo)'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: OracleLinux 9.2 x86_64'
  - 'Config guest id: oracleLinux9_64Guest'
  - 'Guestinfo guest id: oracleLinux9_64Guest'
  - 'Guestinfo guest full name: Oracle Linux 9 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:/o:oracle:linux:9:2:server''
    distroAddlVersion=''9.2'' distroName=''Oracle Linux Server'' distroVersion=''9.2''
    familyName=''Linux'' kernelVersion=''5.15.0-101.103.2.1.el9uek.x86_64'' prettyName=''Oracle
    Linux Server 9.2'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 22.04 CloudImage x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''22.04
    (Jammy Jellyfish)'' distroName=''Ubuntu'' distroVersion=''22.04'' familyName=''Linux''
    kernelVersion=''5.15.0-25-generic'' prettyName=''Ubuntu 22.04 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 20.04 CloudImage x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''20.04.6
    LTS (Focal Fossa)'' distroName=''Ubuntu'' distroVersion=''20.04'' familyName=''Linux''
    kernelVersion=''5.4.0-152-generic'' prettyName=''Ubuntu 20.04.6 LTS'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Amazon 2 x86_64'
  - 'Config guest id: other3xLinux64Guest'
  - 'Guestinfo guest id: amazonlinux2_64Guest'
  - 'Guestinfo guest full name: Amazon Linux 2 (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' cpeString=''cpe:2.3:o:amazon:amazon_linux:2''
    distroAddlVersion=''2'' distroName=''Amazon Linux'' distroVersion=''2'' familyName=''Linux''
    kernelVersion=''4.14.301-224.520.amzn2.x86_64'' prettyName=''Amazon Linux 2'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Flatcar 3510.2.5 x86_64'
  - 'Config guest id: other3xLinux64Guest'
  - 'Guestinfo guest id: other5xLinux64Guest'
  - 'Guestinfo guest full name: Other 5.x Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' buildNumber=''2023-07-14-1822''
    distroName=''Flatcar Container Linux by Kinvolk'' distroVersion=''3510.2.5'' familyName=''Linux''
    kernelVersion=''5.15.119-flatcar'' prettyName=''Flatcar Container Linux by Kinvolk
    3510.2.5 (Oklo)'''
  - 'Results: Total (3), Passed (2), Skipped (1)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install.......................................Not Supported'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 4.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''4.0''
    distroName=''VMware Photon OS'' distroVersion=''4.0'' familyName=''Linux'' kernelVersion=''5.10.83-6.ph4-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 5.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''5.0''
    distroName=''VMware Photon OS'' distroVersion=''5.0'' familyName=''Linux'' kernelVersion=''6.1.10-10.ph5-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 23.04 CloudImage x86_64'
  - 'Config guest id: ubuntu64Guest'
  - 'Guestinfo guest id: ubuntu64Guest'
  - 'Guestinfo guest full name: Ubuntu Linux (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''23.04
    (Lunar Lobster)'' distroName=''Ubuntu'' distroVersion=''23.04'' familyName=''Linux''
    kernelVersion=''6.2.0-24-generic'' prettyName=''Ubuntu 23.04'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: VMware Photon OS 3.0 x86_64'
  - 'Config guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest id: vmwarePhoton64Guest'
  - 'Guestinfo guest full name: VMware Photon OS (64-bit)'
  - 'Guestinfo guest family: linuxGuest'
  - 'Guestinfo detailed data: architecture=''X86'' bitness=''64'' distroAddlVersion=''3.0''
    distroName=''VMware Photon OS'' distroVersion=''3.0'' familyName=''Linux'' kernelVersion=''4.19.245-1.ph3-esx''
    prettyName=''VMware Photon OS/Linux'''
  - 'Results: Total (3), Passed (3)'
  - ' * deploy_vm_ova...................................................Passed'
  - ' * ovt_verify_install..............................................Passed'
  - ' * ovt_verify_status...............................................Passed'
```