### PR TITLE
[Linux] Shutdown guest OS after auto install completes instead of rebooting

### DIFF
--- a/autoinstall/BCLinux-for-Euler/21.10/ks.cfg
+++ b/autoinstall/BCLinux-for-Euler/21.10/ks.cfg
@@ -42,8 +42,8 @@ services --disabled="firewalld"
 # System timezone
 timezone America/New_York --isUtc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %packages
 @^graphical-server-environment

--- a/autoinstall/BCLinux/8/ks.cfg
+++ b/autoinstall/BCLinux/8/ks.cfg
@@ -41,8 +41,8 @@ services --disabled="firewalld"
 # System timezone
 timezone America/New_York --isUtc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %packages
 @^graphical-server-environment

--- a/autoinstall/CentOS/7/ks.cfg
+++ b/autoinstall/CentOS/7/ks.cfg
@@ -46,8 +46,8 @@ clearpart --none --initlabel
 services --disabled=firewalld
 eula --agreed
 
-# Reboot when installation finished
-reboot
+# Shutdown when installation finished
+shutdown
 
 %packages
 @^graphical-server-environment

--- a/autoinstall/CentOS/7/minimal/ks.cfg
+++ b/autoinstall/CentOS/7/minimal/ks.cfg
@@ -43,8 +43,8 @@ clearpart --none --initlabel
 services --disabled=firewalld
 eula --agreed
 
-# Reboot when installation finished
-reboot
+# Shutdown when installation finished
+shutdown
 
 %packages
 @^minimal

--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -195,6 +195,9 @@ d-i grub-installer/bootdev string default
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
 
+# Shutdown after installation completes
+d-i debian-installer/exit/poweroff boolean true
+
 # This will prevent the installer from ejecting the CD during the reboot,
 # which is useful in some situations.
 #d-i cdrom-detect/eject boolean false

--- a/autoinstall/Fedora/36/Server/ks.cfg
+++ b/autoinstall/Fedora/36/Server/ks.cfg
@@ -53,8 +53,8 @@ user --name={{ new_user }} --password={{ vm_password_hash }} --groups=root,wheel
 sshkey --username={{ new_user }} "{{ ssh_public_key }}"
 {% endif %}
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %post --interpreter=/usr/bin/bash --log=/root/ks-post.log
 if [ -f /etc/cloud/cloud.cfg ]; then

--- a/autoinstall/FreeBSD/installerconfig
+++ b/autoinstall/FreeBSD/installerconfig
@@ -142,4 +142,4 @@ echo 'autoboot_delay="3"' >> /boot/loader.conf
 
 echo "End of installerconfig" > /dev/ttyu0
 echo "{{ autoinstall_complete_msg }}" > /dev/ttyu0
-shutdown -r now
+shutdown -h now

--- a/autoinstall/FreeBSD/installerconfig
+++ b/autoinstall/FreeBSD/installerconfig
@@ -142,4 +142,6 @@ echo 'autoboot_delay="3"' >> /boot/loader.conf
 
 echo "End of installerconfig" > /dev/ttyu0
 echo "{{ autoinstall_complete_msg }}" > /dev/ttyu0
-shutdown -h now
+
+# Power off system when autoinstall completes
+poweroff

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -189,6 +189,9 @@ d-i grub-installer/bootdev string default
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
 
+# Shutdown after installation completes
+d-i debian-installer/exit/poweroff boolean true
+
 # This will prevent the installer from ejecting the CD during the reboot,
 # which is useful in some situations.
 #d-i cdrom-detect/eject boolean true

--- a/autoinstall/RHEL/7/server_with_GUI/ks.cfg
+++ b/autoinstall/RHEL/7/server_with_GUI/ks.cfg
@@ -46,8 +46,8 @@ clearpart --none --initlabel
 services --disabled=firewalld
 eula --agreed
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 
 %packages

--- a/autoinstall/RHEL/7/server_without_GUI/ks.cfg
+++ b/autoinstall/RHEL/7/server_without_GUI/ks.cfg
@@ -46,8 +46,8 @@ clearpart --none --initlabel
 services --disabled=firewalld
 eula --agreed
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %packages
 @^infrastructure-server-environment

--- a/autoinstall/RHEL/8/server_with_GUI/ks.cfg
+++ b/autoinstall/RHEL/8/server_with_GUI/ks.cfg
@@ -41,8 +41,8 @@ services --disabled="firewalld"
 # System timezone
 timezone America/New_York --isUtc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %packages
 @^graphical-server-environment

--- a/autoinstall/RHEL/8/server_without_GUI/ks.cfg
+++ b/autoinstall/RHEL/8/server_without_GUI/ks.cfg
@@ -39,8 +39,8 @@ services --enabled="chronyd"
 # System timezone
 timezone America/New_York --isUtc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 %packages
 @^server-product-environment
 kexec-tools

--- a/autoinstall/SLE/15/SP3/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLED/autoinst.xml
@@ -220,6 +220,7 @@
   <general t="map">
     <mode t="map">
       <confirm t="boolean">false</confirm>
+      <final_halt config:type="boolean">true</final_halt>
     </mode>
   </general>
   <groups t="list">

--- a/autoinstall/SLE/15/SP3/SLES/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLES/autoinst.xml
@@ -184,6 +184,7 @@
     <ask-list t="list"/>
     <mode t="map">
       <confirm t="boolean">false</confirm>
+      <final_halt config:type="boolean">true</final_halt>
     </mode>
     <proposals t="list"/>
     <signature-handling t="map"/>

--- a/autoinstall/SLE/15/SP3/SLES_Minimal/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLES_Minimal/autoinst.xml
@@ -48,6 +48,7 @@
     <ask-list t="list"/>
     <mode t="map">
       <confirm t="boolean">false</confirm>
+      <final_halt config:type="boolean">true</final_halt>
     </mode>
     <proposals t="list"/>
     <signature-handling t="map"/>

--- a/autoinstall/SLE/15/SP4/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP4/SLED/autoinst.xml
@@ -215,6 +215,7 @@
   <general t="map">
     <mode t="map">
       <confirm t="boolean">false</confirm>
+      <final_halt config:type="boolean">true</final_halt>
     </mode>
   </general>
   <groups t="list">

--- a/autoinstall/UOS/Server/20/1050a/ks.cfg
+++ b/autoinstall/UOS/Server/20/1050a/ks.cfg
@@ -20,7 +20,7 @@ lang en_US.UTF-8
 eula --agreed
 
 # Network information
-network --bootproto=dhcp --ipv6=auto
+#network --bootproto=dhcp --ipv6=auto
 network --hostname=localhost.localdomain
 # Root password
 rootpw --iscrypted {{ vm_password_hash }}
@@ -43,8 +43,8 @@ services --enabled="chronyd"
 # System timezone
 timezone America/New_York --utc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %packages
 @Server with DDE

--- a/autoinstall/UOS/Server/20/1050a/ks.cfg
+++ b/autoinstall/UOS/Server/20/1050a/ks.cfg
@@ -20,7 +20,7 @@ lang en_US.UTF-8
 eula --agreed
 
 # Network information
-#network --bootproto=dhcp --ipv6=auto
+network --bootproto=dhcp --ipv6=auto
 network --hostname=localhost.localdomain
 # Root password
 rootpw --iscrypted {{ vm_password_hash }}

--- a/autoinstall/UOS/Server/20/1050e/ks.cfg
+++ b/autoinstall/UOS/Server/20/1050e/ks.cfg
@@ -49,8 +49,8 @@ services --enabled="chronyd"
 # System timezone
 timezone America/New_York --isUtc
 
-# Reboot when the install is finished.
-reboot
+# Shutdown when the install is finished.
+shutdown
 
 %anaconda
 pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty

--- a/autoinstall/Ubuntu/Desktop/Subiquity/user-data.j2
+++ b/autoinstall/Ubuntu/Desktop/Subiquity/user-data.j2
@@ -44,4 +44,4 @@ autoinstall:
     - sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /target/etc/ssh/sshd_config
     - sed -i 's/^#PasswordAuthentication .*/PasswordAuthentication yes/' /target/etc/ssh/sshd_config
     - echo "{{ autoinstall_complete_msg }}" >> /dev/ttyS0
-  shutdown: 'reboot'
+  shutdown: 'poweroff'

--- a/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
+++ b/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
@@ -58,9 +58,6 @@ d-i finish-install/keep-consoles boolean true
 # if no other operating system is detected on the machine.
 d-i grub-installer/only_debian boolean true
 
-ubiquity/failure_command \
-    in-target echo "Ubuntu autoinstall failed" >/dev/ttyS0
-
 # Install package
 ubiquity ubiquity/success_command \
     in-target apt-get update -y; \
@@ -78,7 +75,7 @@ ubiquity ubiquity/success_command \
     in-target chmod 0644 /root/.ssh/authorized_keys; \
     in-target sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config; \
     in-target sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config; \
-    in-target echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
+    echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
 
 d-i finish-install/reboot_in_progress note
 d-i cdrom-detect/eject boolean true

--- a/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
+++ b/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
@@ -43,7 +43,7 @@ d-i passwd/root-password-crypted password {{ vm_password_md5 }}
 d-i user-setup/allow-password-weak boolean true
 
 d-i pkgsel/language-packs multiselect en, zh
-d-i pkgsel/update-policy select none 
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select none
 
 # By default, the system's locate database will be updated after the
@@ -57,6 +57,9 @@ d-i finish-install/keep-consoles boolean true
 # This is fairly safe to set, it makes grub install automatically to the MBR
 # if no other operating system is detected on the machine.
 d-i grub-installer/only_debian boolean true
+
+ubiquity/failure_command \
+    in-target echo "Ubuntu autoinstall failed" >/dev/ttyS0
 
 # Install package
 ubiquity ubiquity/success_command \
@@ -75,11 +78,10 @@ ubiquity ubiquity/success_command \
     in-target chmod 0644 /root/.ssh/authorized_keys; \
     in-target sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config; \
     in-target sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config; \
-    echo "{{ autoinstall_complete_msg }}" > /target/dev/ttyS0
+    in-target echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
 
 d-i finish-install/reboot_in_progress note
 d-i cdrom-detect/eject boolean true
 
 ubiquity ubiquity/summary note
-#ubiquity ubiquity/reboot boolean true
 ubiquity ubiquity/poweroff boolean true

--- a/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
+++ b/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
@@ -81,4 +81,5 @@ d-i finish-install/reboot_in_progress note
 d-i cdrom-detect/eject boolean true
 
 ubiquity ubiquity/summary note
-ubiquity ubiquity/reboot boolean true
+#ubiquity ubiquity/reboot boolean true
+ubiquity ubiquity/poweroff boolean true

--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -55,4 +55,5 @@ autoinstall:
     - echo 'Acquire::ForceIPv4 "true";' >>/etc/apt/apt.conf.d/99force-ipv4
     - sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /target/etc/ssh/sshd_config
     - sed -i 's/^#PasswordAuthentication .*/PasswordAuthentication yes/' /target/etc/ssh/sshd_config
+    - echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
   shutdown: 'poweroff'

--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -55,3 +55,4 @@ autoinstall:
     - echo 'Acquire::ForceIPv4 "true";' >>/etc/apt/apt.conf.d/99force-ipv4
     - sed -i 's/^#PermitRootLogin .*/PermitRootLogin yes/' /target/etc/ssh/sshd_config
     - sed -i 's/^#PasswordAuthentication .*/PasswordAuthentication yes/' /target/etc/ssh/sshd_config
+  shutdown: 'poweroff'

--- a/autoinstall/openSUSE/15/autoinst.xml
+++ b/autoinstall/openSUSE/15/autoinst.xml
@@ -212,6 +212,7 @@
     <general t="map">
         <mode t="map">
             <confirm t="boolean">false</confirm>
+            <final_halt config:type="boolean">true</final_halt>
         </mode>
     </general>
     <groups t="list">

--- a/linux/deploy_vm/delete_unattend_install_iso.yml
+++ b/linux/deploy_vm/delete_unattend_install_iso.yml
@@ -1,17 +1,8 @@
-# Copyright 2021-2023 VMware, Inc.
+# Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Eject CDROM of unattend install ISO in guest OS
-#- include_tasks: ../utils/eject_cdrom_in_guest.yml
-#  vars:
-#    guest_cdrom_device_num: "{{ os_install_iso_list_len | int -1 }}"
-#  when: guest_os_family != "FreeBSD"
+# Delete unattend install ISO file
 #
-#- name: "Eject CD for FreeBSD"
-#  ansible.builtin.command: "camcontrol eject /dev/cd0"
-#  delegate_to: "{{ vm_guest_ip }}"
-#  when: guest_os_family == "FreeBSD"
-
 # By default, it's attached to the last CDROM in composed VM CDROMs list
 - name: "Set fact of the controller and unit number of CDROM attaching unattend install ISO"
   ansible.builtin.set_fact:

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -195,6 +195,14 @@
         - unattend_install_conf is defined
         - ('UOS' in unattend_install_conf)
 
+    # When there is "reboot: Power down" in serial port log, it means the auto install is completed
+    - name: "Set autoinstall complete message for Ubuntu Desktop 20.04 ~ 22.10"
+      ansible.builtin.set_fact:
+        autoinstall_complete_msg: "reboot: Power down"
+      when:
+        - unattend_install_conf is defined
+        - unattend_install_conf is match('Ubuntu/Desktop/Ubiquity')
+
     - name: "Wait autoinstall complete message appear in serial port output file"
       include_tasks: ../../common/vm_wait_log_msg.yml
       vars:
@@ -208,7 +216,25 @@
       vars:
         vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
 
-    - name: "Wait for OS shutting down after auto install being completed"
+    # VMware Photon OS kickstart file can't add shutdown action, so here
+    # needs to shutdown it separately
+    - name: "Shutdown VMware Photon OS VM after auto install completes"
+      when:
+        - unattend_install_conf is defined
+        - unattend_install_conf is match('Photon')
+      block:
+        - name: "Wait for guest full name on VMware Photon OS VM"
+          include_tasks: ../../common/vm_wait_guest_fullname.yml
+
+        - name: "Get guest IP address"
+          include_tasks: ../../common/update_inventory.yml
+          vars:
+            update_inventory_timeout: 300
+
+        - name: "Shutdown guest OS to remove serial port"
+          include_tasks: ../utils/shutdown.yml
+
+    - name: "Wait for OS shutting down after auto install completes"
       include_tasks: ../../common/vm_wait_power_state.yml
       vars:
         expected_power_status: 'poweredOff'

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -195,14 +195,6 @@
         - unattend_install_conf is defined
         - ('UOS' in unattend_install_conf)
 
-    # When there is "reboot: Power down" in serial port log, it means the auto install is completed
-    - name: "Set autoinstall complete message for Ubuntu Desktop 20.04 ~ 22.10"
-      ansible.builtin.set_fact:
-        autoinstall_complete_msg: "reboot: Power down"
-      when:
-        - unattend_install_conf is defined
-        - unattend_install_conf is match('Ubuntu/Desktop/Ubiquity')
-
     - name: "Wait autoinstall complete message appear in serial port output file"
       include_tasks: ../../common/vm_wait_log_msg.yml
       vars:
@@ -216,8 +208,8 @@
       vars:
         vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
 
-    # VMware Photon OS kickstart file can't add shutdown action, so here
-    # needs to shutdown it separately
+    # VMware Photon OS kickstart file can't add shutdown action,
+    # so here needs to shutdown it separately
     - name: "Shutdown VMware Photon OS VM after auto install completes"
       when:
         - unattend_install_conf is defined
@@ -234,7 +226,7 @@
         - name: "Shutdown guest OS to remove serial port"
           include_tasks: ../utils/shutdown.yml
 
-    - name: "Wait for OS shutting down after auto install completes"
+    - name: "Wait for VM being powered off"
       include_tasks: ../../common/vm_wait_power_state.yml
       vars:
         expected_power_status: 'poweredOff'
@@ -245,7 +237,7 @@
       when:
         - transferred_unattend_iso is defined
         - transferred_unattend_iso
-    
+
     - name: "Change the boot disk to be first boot device in boot order"
       include_tasks: ../../common/vm_set_boot_options.yml
       vars:
@@ -356,17 +348,17 @@
           block:
             - name: "Reboot Oracle Linux"
               include_tasks: ../utils/reboot.yml
-    
+
             - name: "Update VM guest IPv4 address in in-memory inventory"
               include_tasks: ../../common/update_inventory.yml
-    
+
             - name: "Refresh Linux system info"
               include_tasks: ../utils/get_linux_system_info.yml
-    
+
             - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
               ansible.builtin.set_fact:
                 ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
-    
+
             - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
               ansible.builtin.assert:
                 that:

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -18,6 +18,18 @@
     - cpu_number is undefined or not cpu_number
     - cpu_cores_per_socket is defined and cpu_cores_per_socket
 
+# Installing FreeBSD 32bit on lsilogic/lsilogicsas/nvme disk will
+# fail when memory size >= 4 GB
+- name: "Set the fact of memory size for the new VM"
+  ansible.builtin.set_fact:
+    vm_memory_mb: |-
+      {%- if guest_id is match('freebsd\\d+Guest') and
+       boot_disk_controller in ['lsilogic', 'lsilogicsas', 'nvme'] -%}
+      {{ [3072, memory_mb | default(4096) | int ] | min }}
+      {%- else -%}
+      {{ memory_mb | default(4096) | int  }}
+      {%- endif -%}
+
 - name: "Update test case name for deploying VM from ISO image"
   ansible.builtin.set_fact:
     current_testcase_name: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
@@ -33,9 +45,10 @@
 
     - name: "Prepare for Ubuntu installation"
       include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
-      when: "'ubuntu' in guest_id"
+      when: guest_id is match('ubuntu.*')
 
     - name: "Set default unattend install conf file"
+      when: unattend_install_conf is undefined or not unattend_install_conf
       block:
         - name: "Set default unattend install conf file for VMware Photon OS"
           ansible.builtin.set_fact:
@@ -50,8 +63,7 @@
         - name: "Set default unattend install conf file for FreeBSD"
           ansible.builtin.set_fact:
             unattend_install_conf: "FreeBSD/installerconfig"
-          when: "'freebsd' in guest_id"
-      when: unattend_install_conf is undefined or not unattend_install_conf
+          when: guest_id is match('freebsd.*')
 
     - name: "Display warning message about undefined unattend_install_conf"
       ansible.builtin.debug:
@@ -65,20 +77,6 @@
     - name: "Compose VM CDROMs to mount OS install ISO files"
       include_tasks: ../../common/compose_vm_cdroms.yml
 
-    # Failed to install FreeBSD 32bit with lsilogic/lsilogicsas/nvme when memory >= 4G
-    - name: "Initialize the fact of memory size when create VM"
-      ansible.builtin.set_fact:
-        vm_memory_mb: |-
-          {%- if guest_id is match('freebsd\\d+Guest') and boot_disk_controller in ['lsilogic', 'lsilogicsas', 'nvme'] -%}
-          {{ [3072, memory_mb | default(4096) | int ] | min }}
-          {%- else -%}
-          {{ memory_mb | default(4096) | int  }}
-          {%- endif -%}
-
-    - name: "Display the memory size when create VM"
-      ansible.builtin.debug: var=vm_memory_mb
-      when: enable_debug is defined and enable_debug
-
     - name: "Create a new VM with {{ boot_disk_controller }} disk"
       include_tasks: ../../common/vm_create.yml
       vars:
@@ -87,6 +85,8 @@
 
     - name: "Create a new VM with {{ boot_disk_controller }} disk"
       include_tasks: ../../common/vm_create_with_ide_disk.yml
+      vars:
+        memory_mb: "{{ vm_memory_mb }}"
       when: boot_disk_controller == 'ide'
 
     - name: "Get VM info"
@@ -100,6 +100,7 @@
       include_tasks: ../../common/vm_add_serial_port.yml
 
     - name: "Set video memory size"
+      when: install_guest_with_desktop
       block:
         - name: "Get VM's video card info"
           include_tasks: ../../common/vm_get_video_card.yml
@@ -113,7 +114,6 @@
           vars:
             video_memory_mb: 8
           when: vm_default_video_memory_mb | int < 8
-      when: install_guest_with_desktop
 
     - name: "Enable secure boot on VM"
       include_tasks: ../../common/vm_set_boot_options.yml
@@ -154,7 +154,7 @@
 
     - name: "Install Ubuntu OS"
       include_tasks: ubuntu/ubuntu_install_os.yml
-      when: "'ubuntu' in guest_id"
+      when: guest_id is match('ubuntu.*')
 
     # For SLES, OS installation with BIOS firmware, send key to boot
     # screen to start new installation instead of booting from local
@@ -195,16 +195,6 @@
         - unattend_install_conf is defined
         - ('UOS' in unattend_install_conf)
 
-    # We can get the text "ubuntu login:" from the serial output when the installer begin to run
-    # but get this text again after finish installation and reboot
-    # When we get text "gdm.service", We are so close to the state "system is up" after rebooting.
-    - name: "Set autoinstall complete message for Ubuntu Desktop 20.04 ~ 22.10"
-      ansible.builtin.set_fact:
-        autoinstall_complete_msg: "gdm.service"
-      when:
-        - unattend_install_conf is defined
-        - unattend_install_conf is match('Ubuntu/Desktop/Ubiquity')
-
     - name: "Wait autoinstall complete message appear in serial port output file"
       include_tasks: ../../common/vm_wait_log_msg.yml
       vars:
@@ -213,86 +203,21 @@
         vm_wait_log_delay: 30
         vm_wait_log_retries: 120
 
-    - name: "Wait 60s for OS rebooting"
-      ansible.builtin.pause:
-        seconds: 60
-
-    - name: "Wait for guest full name is collected"
-      include_tasks: ../../common/vm_wait_guest_fullname.yml
-      when:
-        - unattend_install_conf is defined
-        - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler).*')
-
-    - name: "Get VM guest IPv4 address and add to in-memory inventory"
-      include_tasks: ../../common/update_inventory.yml
+    - name: "Wait for OS shutting down after auto install being completed"
+      include_tasks: ../../common/vm_wait_power_state.yml
       vars:
-        update_inventory_timeout: 600
+        expected_power_status: 'poweredOff'
+        wait_power_state_timeout: 300
 
-    - name: "Get Linux system info"
-      include_tasks: ../utils/get_linux_system_info.yml
-
-    - name: "Wait for guest OS service is ready"
-      block:
-        # For SLE, RHEL8/CentOS8/OracleLinux8 with desktop: display-manager
-        # service running at the end of installation to wait user login.
-        # Otherwise, systemd-logind service running at the end of installaiton
-        # to wait user login
-        - name: "Set fact of service name for waiting at first time of OS boot"
-          ansible.builtin.set_fact:
-            wait_service_name: |-
-              {%- if guest_os_with_gui -%}display-manager
-              {%- else -%}systemd-logind
-              {%- endif -%}
-
-        - name: "Wait for service {{ wait_service_name }} is running"
-          include_tasks: ../utils/wait_for_service_status.yml
-          vars:
-            service_name: "{{ wait_service_name }}"
-            wait_service_status: "running"
-      when:
-        - guest_os_with_gui is defined
-        - (guest_os_family in ["RedHat", "Suse"] or
-           guest_os_ansible_distribution in ["Ubuntu", "Debian"])
-
+    # Delete unattend install ISO
     - name: "Eject unattend/seed ISO and delete it from datastore"
       include_tasks: eject_del_unattend_install_iso.yml
       when:
         - transferred_unattend_iso is defined
         - transferred_unattend_iso
-
-    - name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
-      block:
-        - include_tasks: ../../common/vm_take_snapshot.yml
-          vars:
-            snapshot_name: "OL_9.0GA_UEK"
-
-        - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
-          ansible.builtin.set_fact:
-            ol9_uekr7_is_upgraded: false
-            ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
-
-        - include_tasks: ../utils/add_official_online_repo.yml
-        - name: "Update Oracle Linux 9.0 to latest UEK R7"
-          ansible.builtin.shell: "yum update --nogpgcheck -y"
-          register: ol9_uekr7_upgrade_result
-          delegate_to: "{{ vm_guest_ip }}"
-
-        - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
-          ansible.builtin.set_fact:
-            ol9_uekr7_is_upgraded: true
-          when:
-            - ol9_uekr7_upgrade_result is defined
-            - ol9_uekr7_upgrade_result.rc is defined
-            - ol9_uekr7_upgrade_result.rc == 0
-      when:
-        - guest_os_ansible_distribution == "OracleLinux"
-        - guest_os_ansible_distribution_ver == "9.0"
-        - "'uek' in guest_os_ansible_kernel"
-
-    - name: "Shutdown guest OS"
-      include_tasks: ../utils/shutdown.yml
     
     - name: "Change CD/DVD to client device and set disk as first boot device for Ubuntu"
+      when: guest_id is match('ubuntu.*')
       block:
         - name: "Change VM's CD/DVD Drive 1 to client device"
           include_tasks: ../../common/vm_configure_cdrom.yml
@@ -307,7 +232,6 @@
           vars:
             boot_order_list:
               - disk
-      when: guest_os_ansible_distribution == "Ubuntu"
 
     - name: "Download serial output file before removing serial port"
       include_tasks: ../../common/esxi_download_datastore_file.yml
@@ -333,34 +257,105 @@
         remove_serial_port.changed is undefined or
         not remove_serial_port.changed
 
-    - name: "Power on VM"
+    - name: "OS auto install is completed. Power on VM now"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'
 
-    - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
-      block:
-        - name: "Update VM guest IPv4 address in in-memory inventory"
-          include_tasks: ../../common/update_inventory.yml
-
-        - name: "Refresh Linux system info"
-          include_tasks: ../utils/get_linux_system_info.yml
-
-        - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
-          ansible.builtin.set_fact:
-            ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
-
-        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
-          ansible.builtin.assert:
-            that:
-              - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
-            fail_msg: >-
-              Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
-              version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
-              version is '{{ ol9_uekr7_after_upgrade }}'.
+    - name: "Wait for guest full name is collected"
+      include_tasks: ../../common/vm_wait_guest_fullname.yml
+      vars:
+        vm_get_fullname_timeout: 600
       when:
-        - ol9_uekr7_is_upgraded is defined
-        - ol9_uekr7_is_upgraded
+        - unattend_install_conf is defined
+        - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler).*')
+
+    - name: "Get VM guest IPv4 address and add to in-memory inventory"
+      include_tasks: ../../common/update_inventory.yml
+      vars:
+        update_inventory_timeout: 600
+
+    - name: "Get Linux system info"
+      include_tasks: ../utils/get_linux_system_info.yml
+
+    - name: "Wait for guest OS service is ready"
+      when:
+        - guest_os_with_gui is defined
+        - (guest_os_family in ["RedHat", "Suse"] or
+           guest_os_ansible_distribution in ["Ubuntu", "Debian"])
+      block:
+        # For SLE, RHEL8/CentOS8/OracleLinux8 with desktop: display-manager
+        # service running at the end of installation to wait user login.
+        # Otherwise, systemd-logind service running at the end of installaiton
+        # to wait user login
+        - name: "Set fact of service name for waiting at first time of OS boot"
+          ansible.builtin.set_fact:
+            wait_service_name: |-
+              {%- if guest_os_with_gui -%}display-manager
+              {%- else -%}systemd-logind
+              {%- endif -%}
+
+        - name: "Wait for service {{ wait_service_name }} is running"
+          include_tasks: ../utils/wait_for_service_status.yml
+          vars:
+            service_name: "{{ wait_service_name }}"
+            wait_service_status: "running"
+
+    - name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
+      when:
+        - guest_os_ansible_distribution == "OracleLinux"
+        - guest_os_ansible_distribution_ver == "9.0"
+        - "'uek' in guest_os_ansible_kernel"
+      block:
+        - include_tasks: ../../common/vm_take_snapshot.yml
+          vars:
+            snapshot_name: "OL_9.0GA_UEK"
+
+        - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
+          ansible.builtin.set_fact:
+            ol9_uekr7_is_upgraded: false
+            ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
+
+        - name: "Add Oracle Linux online repos for upgrading kernel"
+          include_tasks: ../utils/add_official_online_repo.yml
+
+        - name: "Update Oracle Linux 9.0 to latest UEK R7"
+          ansible.builtin.shell: "yum update --nogpgcheck -y"
+          register: ol9_uekr7_upgrade_result
+          delegate_to: "{{ vm_guest_ip }}"
+
+        - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
+          ansible.builtin.set_fact:
+            ol9_uekr7_is_upgraded: true
+          when:
+            - ol9_uekr7_upgrade_result is defined
+            - ol9_uekr7_upgrade_result.rc is defined
+            - ol9_uekr7_upgrade_result.rc == 0
+
+        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
+          when: ol9_uekr7_is_upgraded
+          block:
+            - name: "Reboot Oracle Linux"
+              include_tasks: ../utils/reboot.yml
+    
+            - name: "Update VM guest IPv4 address in in-memory inventory"
+              include_tasks: ../../common/update_inventory.yml
+    
+            - name: "Refresh Linux system info"
+              include_tasks: ../utils/get_linux_system_info.yml
+    
+            - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
+              ansible.builtin.set_fact:
+                ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
+    
+            - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
+              ansible.builtin.assert:
+                that:
+                  - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
+                fail_msg: >-
+                  Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
+                  version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
+                  version is '{{ ol9_uekr7_after_upgrade }}'.
 
   rescue:
     - name: "Test case failure"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -203,35 +203,28 @@
         vm_wait_log_delay: 30
         vm_wait_log_retries: 120
 
+    - name: "Take a screenshot when autoinstall complete message is received"
+      include_tasks: ../../common/vm_take_screenshot.yml
+      vars:
+        vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
+
     - name: "Wait for OS shutting down after auto install being completed"
       include_tasks: ../../common/vm_wait_power_state.yml
       vars:
         expected_power_status: 'poweredOff'
-        wait_power_state_timeout: 300
+        wait_power_state_timeout: 600
 
-    # Delete unattend install ISO
-    - name: "Eject unattend/seed ISO and delete it from datastore"
-      include_tasks: eject_del_unattend_install_iso.yml
+    - name: "Delete unattend install ISO"
+      include_tasks: delete_unattend_install_iso.yml
       when:
         - transferred_unattend_iso is defined
         - transferred_unattend_iso
     
-    - name: "Change CD/DVD to client device and set disk as first boot device for Ubuntu"
+    - name: "Change the boot disk to be first boot device in boot order"
+      include_tasks: ../../common/vm_set_boot_options.yml
+      vars:
+        boot_order_list: ['disk']
       when: guest_id is match('ubuntu.*')
-      block:
-        - name: "Change VM's CD/DVD Drive 1 to client device"
-          include_tasks: ../../common/vm_configure_cdrom.yml
-          vars:
-            cdrom_state: present
-            cdrom_type: client
-            cdrom_controller_num: "{{ vm_cdroms[0].controller_number | int }}"
-            cdrom_unit_num: "{{ vm_cdroms[0].unit_number | int }}"
-
-        - name: "Change the boot disk to be first in boot order"
-          include_tasks: ../../common/vm_set_boot_options.yml
-          vars:
-            boot_order_list:
-              - disk
 
     - name: "Download serial output file before removing serial port"
       include_tasks: ../../common/esxi_download_datastore_file.yml

--- a/linux/deploy_vm/eject_del_unattend_install_iso.yml
+++ b/linux/deploy_vm/eject_del_unattend_install_iso.yml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Eject CDROM of unattend install ISO in guest OS
-- include_tasks: ../utils/eject_cdrom_in_guest.yml
-  vars:
-    guest_cdrom_device_num: "{{ os_install_iso_list_len | int -1 }}"
-  when: guest_os_family != "FreeBSD"
-
-- name: "Eject CD for FreeBSD"
-  ansible.builtin.command: "camcontrol eject /dev/cd0"
-  delegate_to: "{{ vm_guest_ip }}"
-  when: guest_os_family == "FreeBSD"
+#- include_tasks: ../utils/eject_cdrom_in_guest.yml
+#  vars:
+#    guest_cdrom_device_num: "{{ os_install_iso_list_len | int -1 }}"
+#  when: guest_os_family != "FreeBSD"
+#
+#- name: "Eject CD for FreeBSD"
+#  ansible.builtin.command: "camcontrol eject /dev/cd0"
+#  delegate_to: "{{ vm_guest_ip }}"
+#  when: guest_os_family == "FreeBSD"
 
 # By default, it's attached to the last CDROM in composed VM CDROMs list
 - name: "Set fact of the controller and unit number of CDROM attaching unattend install ISO"

--- a/linux/deploy_vm/rebuild_photon_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_photon_unattend_install_iso.yml
@@ -26,7 +26,7 @@
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/{{ item }}"
     regexp: '(.*)(root=[^ ]+)(.*)'
-    replace: "\\1\\2 ks=cdrom:/isolinux/{{ unattend_install_file_name }} \\3"
+    replace: "\\1\\2 ks=cdrom:/isolinux/{{ unattend_install_file_name }} console=ttyS0,115200n8 \\3"
   with_items:
     - "menu.cfg"
     - "grub.cfg"

--- a/linux/deploy_vm/rebuild_ubuntu_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_ubuntu_unattend_install_iso.yml
@@ -103,7 +103,7 @@
       ansible.builtin.replace:
         path: "{{ unattend_iso_cache }}/grub.cfg"
         regexp: '(.*vmlinuz)(.*)'
-        replace: "\\1 autoinstall \\2"
+        replace: "\\1 autoinstall console=ttyS0,115200n8 \\2"
 
     - name: "Set timeout to 5 seconds at boot menu"
       ansible.builtin.replace:
@@ -144,7 +144,7 @@
           ansible.builtin.replace:
             path: "{{ unattend_iso_cache }}/txt.cfg"
             regexp: '(.*initrd)(.*)'
-            replace: "\\1 autoinstall \\2"
+            replace: "\\1 autoinstall console=ttyS0,115200n8 \\2"
 
         - name: "Update md5sum for BIOS boot config file"
           ansible.builtin.shell: |
@@ -176,4 +176,6 @@
           - src_file: "{{ src_iso_file_dir }}/md5sum.txt"
             dest_file: "md5sum.txt"
       when: not ubuntu_bios_cfg_exist
-  when: unattend_install_conf is match('Ubuntu/Server') or unattend_install_conf is match('Ubuntu/Desktop/Subiquity')
+  when: >-
+    (unattend_install_conf is match('Ubuntu/Server') or
+     unattend_install_conf is match('Ubuntu/Desktop/Subiquity'))

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -1,13 +1,10 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Shutdown VM via executing shutdown command in VM
-- name: "Set command to shutdown guestOS"
-  ansible.builtin.set_fact:
-    guest_shutdown_cmd: "{{ 'poweroff' if guest_os_family == 'FreeBSD' else 'shutdown -h now' }}"
-
-- name: Execute guest OS shutdown
-  ansible.builtin.command: "{{ guest_shutdown_cmd }}"
+# Shutdown VM via executing 'poweroff' command in guest OS
+#
+- name: "Shutdown guest OS"
+  ansible.builtin.command: "poweroff"
   delegate_to: "{{ vm_guest_ip }}"
   become: true
   changed_when: false


### PR DESCRIPTION
Even though guest OS sends autoinstall complete message to serial port, it might still be running some post tasks and it won't be rebooted immediately. Sometimes the post tasks take some time, which led to ansible tasks thought starting to wait for guest full name but it failed due to guest OS hasn't reboot at all. 

It is difficult to find the best timing when to wait for guest full name, so in this change I replaced 'reboot' with 'shutdown' as the following action after autoinstall is compeleted. Therefore, we only needs to wait for VM's power states becoming poweredOff after autoinstall complete message received. Then we can consider the complete autoinstall process is finished, and then power on VM to wait for its guest full name.

In this change, I also added boot options for redirecting console output to serial port, so we can have more information when debugging deploy_vm failures.
