### PR TITLE
[Linux] Add known issue for PVRDMA hot-remove failure on Oracle Linux 8.8

### DIFF
--- a/common/vm_remove_network_adapter.yml
+++ b/common/vm_remove_network_adapter.yml
@@ -1,6 +1,12 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+# Remove network adapter from VM
+# Parameters:
+#   adapter_label: The network adapter label. For example, Network adapter 1.
+#   netadapter_mac_addr: The network adapter MAC address.
+#   vm_remove_adapter_ignore_errors: Ignore errors at removeing network adapter. Default is False.
+#
 - name: "Remove a network adapter from VM '{{ vm_name }}'"
   community.vmware.vmware_guest_network:
     hostname: "{{ vsphere_host_name }}"
@@ -14,8 +20,9 @@
     label: "{{ adapter_label | default(omit) }}"
     mac_address: "{{ netadapter_mac_addr | default(omit) }}"
     state: absent
-  register: remove_result
+  register: remove_adapter
+  ignore_errors: "{{ vm_remove_adapter_ignore_errors | default(False) }}"
 
-- name: Display the result of removing network adapter
-  ansible.builtin.debug: var=remove_result
+- name: "Display the result of removing network adapter"
+  ansible.builtin.debug: var=remove_adapter
   when: enable_debug is defined and enable_debug

--- a/linux/network_device_ops/hot_remove_network_adapter.yml
+++ b/linux/network_device_ops/hot_remove_network_adapter.yml
@@ -7,6 +7,39 @@
   include_tasks: ../../common/vm_remove_network_adapter.yml
   vars:
     netadapter_mac_addr: "{{ new_network_adapter_mac_addr }}"
+    vm_remove_adapter_ignore_errors: True
+
+- name: "Network adapter hot-remove succeeded"
+  ansible.builtin.debug:
+    msg: "Successfully hot removed new {{ adapter_type }} network adapter {{ new_network_adapter }}"
+  when:
+    - remove_adapter.changed is defined
+    - remove_adapter.changed
+
+- name: "Network adapter hot-remove failed"
+  when: >-
+    (remove_adapter.changed is undefined or
+     not remove_adapter.changed)
+  block:
+    - name: "Known issue - PVRDMA network adapter hot-remove caused kernel crash on Oracle Linux 8.8"
+      ansible.builtin.debug:
+        msg:
+          - "Hot removing PVRDMA network adapter could cause kernel crash on Oracle Linux 8.8."
+          - "Please refer to https://kb.vmware.com/s/article/93131 for details."
+      tags:
+        - known_issue
+      when:
+        - remove_adapter.rc is defined
+        - remove_adapter.rc == 1
+        - adapter_type == "pvrdma"
+        - esxi_version is version('7.0.0', '>=')
+        - esxi_version is version('8.0.0', '<')
+        - guest_os_ansible_distribution == "OracleLinux"
+        - guest_os_ansible_distribution_ver == '8.8'
+
+    - name: "Failed to hot remove new {{ adapter_type }} network adapter {{ new_network_adapter }}"
+      ansible.builtin.fail:
+        msg: "{{ remove_adapter }}"
 
 - name: "Check VM connection is not broken after hot-remove"
   include_tasks: ../../common/vm_wait_connection.yml

--- a/linux/network_device_ops/hot_remove_network_adapter.yml
+++ b/linux/network_device_ops/hot_remove_network_adapter.yml
@@ -29,8 +29,9 @@
       tags:
         - known_issue
       when:
-        - remove_adapter.rc is defined
-        - remove_adapter.rc == 1
+        - remove_adapter.module_stderr is defined
+        - (remove_adapter.module_stderr | 
+           regex_findall("The guest operating system did not respond to a hot-remove request for device '.*' in a timely manner.") | length > 0)
         - adapter_type == "pvrdma"
         - esxi_version is version('7.0.0', '>=')
         - esxi_version is version('8.0.0', '<')

--- a/windows/network_device_ops/network_adapter_deviceops.yml
+++ b/windows/network_device_ops/network_adapter_deviceops.yml
@@ -49,8 +49,8 @@
 - name: Check remove network adapter to VM succeed
   ansible.builtin.assert:
     that:
-      - "{{ 'changed' in remove_result }}"
-      - "{{ remove_result.changed }}"
+      - remove_adapter.changed is defined
+      - remove_adapter.changed
     fail_msg: "Hot remove network adapter task result is not changed."
 - name: Wait 10 seconds after network adapter hot remove
   ansible.builtin.pause:


### PR DESCRIPTION
Oracle Linux 8.8 PVRDMA testing might fail on ESXi 7.0.x because of a known issue described in KB https://kb.vmware.com/s/article/93131. To reduce triage time, I added a known issue for it. As the resolution is to upgrade ESXi version, we can workaround it in our test case. So the test case will still fail but print out a known issue.

Test result:
```
+------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                               |
|                           | bitness='64'                                     |
|                           | distroName='Oracle Linux Server'                 |
|                           | distroVersion='8.8'                              |
|                           | familyName='Linux'                               |
|                           | kernelVersion='5.15.0-101.103.2.1.el8uek.x86_64' |
|                           | prettyName='Oracle Linux Server 8.8'             |
+------------------------------------------------------------------------------+


Test Results (Total: 4, Passed: 3, Failed: 1, Elapsed Time: 00:59:08)
+-------------------------------------------------------------+
| ID | Name                            |   Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_bios_lsilogic_vmxnet3 |   Passed | 00:25:03  |
|  2 | e1000e_network_device_ops       |   Passed | 00:04:01  |
|  3 | vmxnet3_network_device_ops      |   Passed | 00:18:33  |
|  4 | pvrdma_network_device_ops       | * Failed | 00:09:37  |
+-------------------------------------------------------------+
```
known_issues.log:
```

2023-08-15 07:31:47,015 | Known Issue in Play [4_pvrdma_network_device_ops] **********

2023-08-15 07:31:47,015 | TASK [4_pvrdma_network_device_ops][Known issue - PVRDMA network adapter hot-remove caused kernel crash on Oracle Linux 8.8] 
task path: /home/worker/workspace/Ansible_OracleLinux_8.x_70GA_LSILOGIC_VMXNET3_BIOS/ansible-vsphere-gos-validation/linux/network_device_ops/hot_remove_network_adapter.yml:24
ok: [localhost] => {
    "msg": [
        "Hot removing PVRDMA network adapter could cause kernel crash on Oracle Linux 8.8.",
        "Please refer to https://kb.vmware.com/s/article/93131 for details."
    ]
}
```
