### PR TITLE
[Linux] Set VM boot order before vHBA testing and test file read/write on new disk

### DIFF
--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -54,19 +54,6 @@
         download_file_fail_ignore: true
       when: vm_dir_name is defined and vm_dir_name
 
-    - name: "Download serial output file"
-      include_tasks: esxi_download_datastore_file.yml
-      vars:
-        src_datastore: "{{ datastore }}"
-        src_file_path: "{{ vm_dir_name }}/{{ vm_serial_port_output_file | basename }}"
-        dest_file_path: "{{ current_test_log_folder }}/{{ vm_serial_port_output_file | basename }}"
-        download_file_fail_ignore: true
-      when: 
-        - vm_dir_name is defined
-        - vm_dir_name
-        - vm_serial_port_output_file is defined
-        - vm_serial_port_output_file
-
     - name: "Take a snapshot at VM current state"
       include_tasks: vm_take_snapshot.yml
       vars:

--- a/linux/nvdimm_cold_add_remove/cold_add_nvdimm_test.yml
+++ b/linux/nvdimm_cold_add_remove/cold_add_nvdimm_test.yml
@@ -164,7 +164,7 @@
 - name: "Test file read/write on new partition {{ new_nvdimm_part_dev_path }}"
   include_tasks: ../vhba_hot_add_remove/test_file_read_write.yml
   vars:
-    test_partition_name: "{{ new_nvdimm_part_name }}"
-    test_partition_uuid: "{{ new_nvdimm_part_uuid }}"
-    test_partition_device_path: "{{ new_nvdimm_part_dev_path }}"
-    test_partition_fstype: "{{ new_nvdimm_part_fstype }}"
+    new_partition_name: "{{ new_nvdimm_part_name }}"
+    new_partition_uuid: "{{ new_nvdimm_part_uuid }}"
+    new_partition_device_path: "{{ new_nvdimm_part_dev_path }}"
+    new_partition_fstype: "{{ new_nvdimm_part_fstype }}"

--- a/linux/utils/freebsd_get_geom_conf_xml.yml
+++ b/linux/utils/freebsd_get_geom_conf_xml.yml
@@ -1,0 +1,41 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Description:
+#   Get GEOM config info in XML on FreeBSD
+#
+- name: "Set fact of local file to save FreeBSD GEOM config info"
+  ansible.builtin.set_fact:
+    freebsd_geom_xml_file: "{{ current_test_log_folder }}/geom_conf_{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}.xml"
+
+- name: "Check exitence of current test case log folder"
+  ansible.builtin.stat:
+    path: "{{ current_test_log_folder }}"
+  register: test_log_folder_stat
+
+- name: "Create log folder for current test case"
+  include_tasks: ../../common/create_directory.yml
+  vars:
+    dir_path: "{{ current_test_log_folder }}"
+    dir_mode: "0777"
+  when: not (test_log_folder_stat.exists | default(False))
+
+- name: "Create local file to save FreeBSD GEOM config info"
+  ansible.builtin.file:
+    path: "{{ freebsd_geom_xml_file }}"
+    state: touch
+    mode: "0666"
+
+- name: "Get FreeBSD GEOM config info"
+  ansible.builtin.shell: "sysctl kern.geom.confxml"
+  delegate_to: "{{ vm_guest_ip }}"
+  register: geom_in_xml_result
+
+- name: "Write FreeBSD GEOM info to XML file"
+  ansible.builtin.copy:
+    content: "{{ geom_in_xml_result.stdout | replace('kern.geom.confxml: ', '') }}"
+    dest: "{{ freebsd_geom_xml_file }}"
+
+- name: "Print the file path of FreeBSD GEOM config info"
+  ansible.builtin.debug: 
+    msg: "FreeBSD GEOM config in XML format are saved into file {{ freebsd_geom_xml_file }}"

--- a/linux/utils/freebsd_get_partition_info.yml
+++ b/linux/utils/freebsd_get_partition_info.yml
@@ -1,0 +1,89 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Description:
+#   Get disk partition info by partition name or UUID on FreeBSD
+# Paramters:
+#   disk_partition_name: The disk partition name on FreeBSD
+#   disk_partition_uuid: The disk partition UUID on FreeBSD
+# Return:
+#   disk_partition_info: The disk partition info on FreeBSD
+#
+- name: "Check paramters to get FreeBSD disk partition info"
+  ansible.builtin.assert:
+    that:
+      - disk_partition_name | default('') or disk_partition_uuid | default('')
+    fail_msg: >-
+      Parameter 'disk_partition_name' or 'disk_partition_uuid' must be set
+      to get disk partition info.
+
+- name: "Initialize facts of FreeBSD disk partition info"
+  ansible.builtin.set_fact:
+    disk_partition_info: {}
+    disk_partition_config_info: {}
+
+- name: "Get FreeBSD GEOM config file in XML"
+  include_tasks: freebsd_get_geom_conf_xml.yml
+
+- name: "Set facts of XPATHs for geting disk partition info"
+  ansible.builtin.set_fact:
+    xpath_of_disk_part: "/mesh/class[name='PART']/geom/provider[name='{{ disk_partition_name }}']/*"
+    xpath_of_disk_part_config: "/mesh/class[name='PART']/geom/provider[name='{{ disk_partition_name }}']/config/*"
+  when:
+    - disk_partition_name is defined
+    - disk_partition_name
+
+- name: "Set facts of XPATHs for geting disk partition info"
+  ansible.builtin.set_fact:
+    xpath_of_disk_part: "/mesh/class[name='PART']/geom/provider/*[../config[rawuuid='{{ disk_partition_uuid }}']]"
+    xpath_of_disk_part_config:  "/mesh/class[name='PART']/geom/provider/config[rawuuid='{{ disk_partition_uuid }}']/*"
+  when:
+    - disk_partition_uuid is defined
+    - disk_partition_uuid
+
+- name: "Get disk partition"
+  community.general.xml:
+    path: "{{ freebsd_geom_xml_file }}"
+    xpath: "{{ xpath_of_disk_part }}"
+    content: text
+  register: geom_part_xml
+
+- name: "Set fact of disk partition info"
+  ansible.builtin.set_fact:
+    disk_partition_info: >-
+      {{ 
+        disk_partition_info | combine({'config': ''}) if geom_item['config'] is defined
+        else disk_partition_info | combine(geom_item)
+      }}
+  with_items: "{{ geom_part_xml.matches }}"
+  loop_control:
+    loop_var: geom_item
+  when:
+    - geom_part_xml.matches is defined
+    - geom_part_xml.matches | length > 0
+
+- debug: var=disk_partition_info
+- name: "Get disk partition config"
+  community.general.xml:
+    path: "{{ freebsd_geom_xml_file }}"
+    xpath: "{{ xpath_of_disk_part_config }}"
+    content: text
+  register: geom_conf_xml
+
+- name: "Set fact of disk partition info"
+  ansible.builtin.set_fact:
+    disk_partition_config_info: "{{ disk_partition_config_info | combine(geom_item) }}"
+  with_items: "{{ geom_conf_xml.matches }}"
+  loop_control:
+    loop_var: geom_item
+  when:
+    - geom_conf_xml.matches is defined
+    - geom_conf_xml.matches | length > 0
+
+- debug: var=disk_partition_config_info
+- name: "Update fact of disk partition with config info"
+  ansible.builtin.set_fact:
+    disk_partition_info: "{{ disk_partition_info | combine({'config': disk_partition_config_info}) }}"
+
+- name: "Print disk partition info on FreeBSD"
+  ansible.builtin.debug: var=disk_partition_info

--- a/linux/vhba_hot_add_remove/freebsd_create_disk_partition.yml
+++ b/linux/vhba_hot_add_remove/freebsd_create_disk_partition.yml
@@ -15,6 +15,7 @@
   ansible.builtin.set_fact:
     partition_name: ""
     partition_device_path: ""
+    partition_uuid: ""
 
 - name: "Set default partition filesystem to ext4"
   ansible.builtin.set_fact:
@@ -61,19 +62,15 @@
   register: partition_result
   when: partition_fstype == "ufs"
 
-- name: "Get the UUID of partition {{ partition_device_path }}"
-  ansible.builtin.shell: "gpart list {{ disk_name }} | grep rawuuid"
-  changed_when: false
-  delegate_to: "{{ vm_guest_ip }}"
-  register: blkid_part_result
+- name: "Get disk partition info"
+  include_tasks: ../utils/freebsd_get_partition_info.yml
+  vars:
+    disk_partition_name: "{{ partition_name }}"
 
 - name: "Set the fact of partition {{ partition_device_path }} UUID"
   ansible.builtin.set_fact:
-    partition_uuid: "{{ blkid_part_result.stdout.split(':')[-1] }}"
-  when:
-    - blkid_part_result is defined
-    - blkid_part_result.stdout is defined
-    - blkid_part_result.stdout
+    partition_uuid: "{{ disk_partition_info.config.rawuuid }}"
+  when: disk_partition_info.config.rawuuid | default('')
 
 - name: "Check the UUID of partition {{ partition_device_path }}"
   ansible.builtin.assert:

--- a/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
+++ b/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
@@ -5,7 +5,21 @@
   ansible.builtin.set_fact:
     new_disk_size_gb: 1
 
-- include_tasks: ../../common/vm_hot_add_ctrl_disk.yml
+# Disk hot-add
+- name: "Get guest disk list before hot-add"
+  include_tasks: ../utils/get_device_list.yml
+  vars:
+    guest_device_type: "disk"
+
+- name: "Set the fact of guest disk list before hot-add"
+  ansible.builtin.set_fact:
+    guest_disk_list_before_hotadd: "{{ guest_device_list }}"
+
+- name: "Print guest disk list before hot-add"
+  ansible.builtin.debug: var=guest_disk_list_before_hotadd
+
+- name: "Hot add a new disk on a new {{ new_disk_ctrl_type }} controller"
+  include_tasks: ../../common/vm_hot_add_ctrl_disk.yml
   vars:
     disk_controller_type: "{{ new_disk_ctrl_type }}"
     disk_size_gb: "{{ new_disk_size_gb }}"
@@ -13,7 +27,8 @@
     unit_number: "{{ new_unit_number }}"
   when: add_new_controller
 
-- include_tasks: ../../common/vm_hot_add_remove_disk.yml
+- name: "Hot add a new disk on an existing {{ new_disk_ctrl_type }} controller"
+  include_tasks: ../../common/vm_hot_add_remove_disk.yml
   vars:
     disk_operation: 'present'
     disk_controller_type: "{{ new_disk_ctrl_type }}"
@@ -22,17 +37,18 @@
     unit_number: "{{ new_unit_number }}"
   when: not add_new_controller
 
-- include_tasks: wait_device_list_changed.yml
+- name: "Wait for hot-added disk being present in guest OS"
+  include_tasks: wait_device_list_changed.yml
   vars:
     device_list_before_change: "{{ guest_disk_list_before_hotadd }}"
     wait_device_state: "present"
 
-- name: "Get guest device list after hot add"
+- name: "Get guest disk list after hot-add"
   include_tasks: ../utils/get_device_list.yml
   vars:
     guest_device_type: "disk"
 
-- name: "Set the fact of guest device list after hot add"
+- name: "Set the fact of guest disk list after hot-add"
   ansible.builtin.set_fact:
     guest_disk_list_after_hotadd: "{{ guest_device_list }}"
 
@@ -42,7 +58,7 @@
       - guest_disk_list_after_hotadd | difference(guest_disk_list_before_hotadd) | length == 1
     fail_msg: "Guest OS failed to recognize the new hot-added {{ new_disk_ctrl_type }} disk"
 
-- name: "Print guest disk list after hot add"
+- name: "Print guest disk list after hot-add"
   ansible.builtin.debug: var=guest_disk_list_after_hotadd
 
 - name: "Set fact of the new guest disk info"
@@ -92,7 +108,7 @@
   ansible.builtin.set_fact:
     new_partition_name: "{{ partition_name }}"
     new_partition_device_path: "{{ partition_device_path }}"
-    new_partition_fstype: "ext4"
+    new_partition_fstype: "{{ 'ext4' if guest_os_family != 'FreeBSD' else 'ufs' }}"
     new_partition_uuid: "{{ partition_uuid }}"
 
 - name: "Test disk I/O on new disk {{ new_guest_disk_info.name }}"
@@ -100,41 +116,45 @@
   vars:
     test_disk_name: "{{ new_guest_disk_info.name }}"
 
-# After reboot disk boot order might be changed, but at now
-# community.vmware.vmware_guest_boot_info can't get the boot order info.
-# So comment this out until boot disk reordering is resolved.
-#- name: "Test file read/write on new partition {{ new_partition_device_path }}"
-#  include_tasks: test_file_read_write.yml
-#  vars:
-#    test_partition_name: "{{ new_partition_name }}"
-#    test_partition_uuid: "{{ new_partition_uuid }}"
-#    test_partition_device_path: "{{ new_partition_device_path }}"
-#    test_partition_fstype: "{{ new_partition_fstype }}"
+- name: "Test file read and write on new partition {{ new_partition_device_path }}"
+  include_tasks: test_file_read_write.yml
 
-- include_tasks: ../../common/vm_hot_add_remove_disk.yml
+# Disk hot-remove
+- name: "Get guest disk list before hot-remove"
+  include_tasks: ../utils/get_device_list.yml
+  vars:
+    guest_device_type: "disk"
+
+- name: "Set the fact of guest device before hot-remove"
+  ansible.builtin.set_fact:
+    guest_disk_list_before_hotremove: "{{ guest_device_list }}"
+
+- name: "Hot remove the new disk from VM"
+  include_tasks: ../../common/vm_hot_add_remove_disk.yml
   vars:
     disk_operation: 'absent'
     ctrl_number: "{{ new_ctrl_number }}"
     unit_number: "{{ new_unit_number }}"
     disk_controller_type: "{{ new_disk_ctrl_type }}"
 
-- include_tasks: wait_device_list_changed.yml
+- name: "Wait for disk being absent in guest OS"
+  include_tasks: wait_device_list_changed.yml
   vars:
     device_list_before_change: "{{ guest_disk_list_after_hotadd }}"
     wait_device_name: "{{ new_guest_disk_info.name }}"
     wait_device_state: "absent"
 
-- name: "Get guest device list after hot add"
+- name: "Get guest disk list after hot-remove"
   include_tasks: ../utils/get_device_list.yml
   vars:
     guest_device_type: "disk"
 
-- name: "Set the fact of guest device list after hot add"
+- name: "Set the fact of guest disk list after hot-remove"
   ansible.builtin.set_fact:
     guest_disk_list_after_hotremove: "{{ guest_device_list }}"
 
 - name: "Check new disk is removed from guest OS"
   ansible.builtin.assert:
     that:
-      - guest_disk_list_after_hotremove | difference(guest_disk_list_before_hotadd) | length == 0
+      - guest_disk_list_before_hotremove | difference(guest_disk_list_after_hotremove) | length == 1
     fail_msg: "After disk hot-remove, the Guest OS still can see it"

--- a/linux/vhba_hot_add_remove/test_file_read_write.yml
+++ b/linux/vhba_hot_add_remove/test_file_read_write.yml
@@ -55,24 +55,49 @@
 - name: "Reboot guest OS to check file content again"
   include_tasks: ../utils/reboot.yml
 
-- name: "Get new partition path with UUID {{ new_partition_uuid }} after reboot"
-  ansible.builtin.shell: "blkid -U {{ new_partition_uuid }}"
-  changed_when: false
-  delegate_to: "{{ vm_guest_ip }}"
-  register: blkid_uuid_result
+- name: "Get new partition device path and mount path after reboot on {{ guest_os_ansible_distribution }}"
+  when: guest_os_family != 'FreeBSD'
+  block:
+    - name: "Get new partition path with UUID {{ new_partition_uuid }} after reboot"
+      ansible.builtin.shell: "blkid -U {{ new_partition_uuid }}"
+      changed_when: false
+      delegate_to: "{{ vm_guest_ip }}"
+      register: blkid_uuid_result
 
-- name: "Check guest device with UUID {{ new_partition_uuid }} exists"
-  ansible.builtin.assert:
-    that:
-      - blkid_uuid_result is defined
-      - blkid_uuid_result.stdout is defined
-      - blkid_uuid_result.stdout
-    fail_msg: "Failed to find guest device with UUID {{ new_partition_uuid }}"
+    - name: "Check partition with UUID {{ new_partition_uuid }} existing on {{ guest_os_ansible_distribution }}"
+      ansible.builtin.assert:
+        that:
+          - blkid_uuid_result is defined
+          - blkid_uuid_result.stdout is defined
+          - blkid_uuid_result.stdout
+        fail_msg: "Failed to find partition with UUID {{ new_partition_uuid }} on {{ guest_os_ansible_distribution }}"
 
-- name: "Set facts of test partition path and mount path after reboot"
-  ansible.builtin.set_fact:
-    new_partition_device_path: "{{ blkid_uuid_result.stdout }}"
-    new_partition_mount_path: "/mnt/{{ blkid_uuid_result.stdout.split('/')[-1] }}"
+    - name: "Set facts of test partition path and mount path after reboot"
+      ansible.builtin.set_fact:
+        new_partition_device_path: "{{ blkid_uuid_result.stdout }}"
+        new_partition_mount_path: "/mnt/{{ blkid_uuid_result.stdout.split('/')[-1] }}"
+
+- name: "Get new partition device path and mount path after reboot on FreeBSD"
+  when: guest_os_family == 'FreeBSD'
+  block:
+    - name: "Get disk partition info by UUID on FreeBSD"
+      include_tasks: ../utils/freebsd_get_partition_info.yml
+      vars:
+        disk_partition_uuid: "{{ new_partition_uuid }}"
+
+    - name: "Check partition with UUID {{ new_partition_uuid }} existing on FreeBSD"
+      ansible.builtin.assert:
+        that:
+          - disk_partition_info.name is defined
+          - disk_partition_info.name
+          - disk_partition_info.config.rawuuid is defined
+          - disk_partition_info.config.rawuuid == new_partition_uuid
+        fail_msg: "Failed to get partition by UUID {{ new_partition_uuid }} on FreeBSD"
+
+    - name: "Set facts of test partition path and mount path after reboot"
+      ansible.builtin.set_fact:
+        new_partition_device_path: "/dev/{{ disk_partition_info.name }}"
+        new_partition_mount_path: "/mnt/{{ disk_partition_info.name }}"
 
 - name: "Set fact of test file path after reboot"
   ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/test_file_read_write.yml
+++ b/linux/vhba_hot_add_remove/test_file_read_write.yml
@@ -123,6 +123,12 @@
       - read_file_content == test_file_content
     fail_msg: "{{ test_file_path }} file content is {{ read_file_content }}, not expected {{ test_file_content }}"
 
+- name: "Remove file {{ test_file_path }} from guest OS"
+  ansible.builtin.file:
+    path: "{{ test_file_path }}"
+    state: absent
+  delegate_to: "{{ vm_guest_ip }}"
+
 - name: "Unmount device {{ new_partition_device_path }}"
   include_tasks: ../utils/set_mount_point.yml
   vars:

--- a/linux/vhba_hot_add_remove/test_file_read_write.yml
+++ b/linux/vhba_hot_add_remove/test_file_read_write.yml
@@ -4,23 +4,23 @@
 # Description:
 #   Test file read/write on new disk partition
 # Parameters:
-#   test_partition_name: The partition name
-#   test_partition_uuid: The partition UUID
-#   test_partition_device_path: The partition device path to test file read/write
-#   test_partition_fstype: The filesystem type of the partition
+#   new_partition_name: The partition name
+#   new_partition_device_path: The partition device path
+#   new_partition_uuid: The partition UUID
+#   new_partition_fstype: The filesystem type of the partition
 #
-- name: "Set the facts for testing read and write"
+- name: "Set facts for testing read and write file on new partition"
   ansible.builtin.set_fact:
-    test_mount_path: "/mnt/{{ test_partition_name }}"
-    test_file_path: "/mnt/{{ test_partition_name }}/test_{{ test_partition_name }}.txt"
-    test_file_content: "This is a test file to test new partition {{ test_partition_device_path }}"
+    new_partition_mount_path: "/mnt/{{ new_partition_name }}"
+    test_file_path: "/mnt/{{ new_partition_name }}/test_{{ new_partition_uuid }}.txt"
+    test_file_content: "This is a test file to test new disk partition with UUID {{ new_partition_uuid }}"
 
-- name: "Mount {{ test_partition_device_path }} to {{ test_mount_path }}"
+- name: "Mount {{ new_partition_device_path }} to {{ new_partition_mount_path }}"
   include_tasks: ../utils/set_mount_point.yml
   vars:
-    mount_point_path: "{{ test_mount_path }}"
-    mount_point_src: "{{ test_partition_device_path }}"
-    mount_fstype: "{{ test_partition_fstype }}"
+    mount_point_path: "{{ new_partition_mount_path }}"
+    mount_point_src: "{{ new_partition_device_path }}"
+    mount_fstype: "{{ new_partition_fstype }}"
     mount_state: "mounted"
 
 - name: "Create new file {{ test_file_path }}"
@@ -46,40 +46,44 @@
       - read_file_content == test_file_content
     fail_msg: "{{ test_file_path }} file content is {{ read_file_content }}, not expected {{ test_file_content }}"
 
-- name: "Unmount device {{ test_partition_device_path }}"
+- name: "Unmount device {{ new_partition_device_path }}"
   include_tasks: ../utils/set_mount_point.yml
   vars:
-    mount_point_path: "{{ test_mount_path }}"
+    mount_point_path: "{{ new_partition_mount_path }}"
     mount_state: "absent"
 
 - name: "Reboot guest OS to check file content again"
   include_tasks: ../utils/reboot.yml
 
-- name: "Get the partition device path with UUID {{ test_partition_uuid }} after reboot"
-  ansible.builtin.shell: "blkid -U {{ test_partition_uuid }}"
+- name: "Get new partition path with UUID {{ new_partition_uuid }} after reboot"
+  ansible.builtin.shell: "blkid -U {{ new_partition_uuid }}"
   changed_when: false
   delegate_to: "{{ vm_guest_ip }}"
   register: blkid_uuid_result
 
-- name: "Check the partition of UUID {{ test_partition_uuid }} exists"
+- name: "Check guest device with UUID {{ new_partition_uuid }} exists"
   ansible.builtin.assert:
     that:
       - blkid_uuid_result is defined
       - blkid_uuid_result.stdout is defined
       - blkid_uuid_result.stdout
-    fail_msg: "Failed to find partition with UUID {{ test_partition_uuid }}"
+    fail_msg: "Failed to find guest device with UUID {{ new_partition_uuid }}"
 
-- name: "Set the fact of partition name and device path after reboot"
+- name: "Set facts of test partition path and mount path after reboot"
   ansible.builtin.set_fact:
-    test_partition_device_path: "{{ blkid_uuid_result.stdout }}"
-    test_partition_name: "{{ (blkid_uuid_result.stdout | split('/'))[-1] }}"
+    new_partition_device_path: "{{ blkid_uuid_result.stdout }}"
+    new_partition_mount_path: "/mnt/{{ blkid_uuid_result.stdout.split('/')[-1] }}"
 
-- name: "Mount {{ test_partition_device_path }} to {{ test_mount_path }}"
+- name: "Set fact of test file path after reboot"
+  ansible.builtin.set_fact:
+    test_file_path: "{{ new_partition_mount_path }}/test_{{ new_partition_uuid }}.txt"
+
+- name: "Mount {{ new_partition_device_path }} to {{ new_partition_mount_path }}"
   include_tasks: ../utils/set_mount_point.yml
   vars:
-    mount_point_path: "{{ test_mount_path }}"
-    mount_point_src: "{{ test_partition_device_path }}"
-    mount_fstype: "{{ test_partition_fstype }}"
+    mount_point_path: "{{ new_partition_mount_path }}"
+    mount_point_src: "{{ new_partition_device_path }}"
+    mount_fstype: "{{ new_partition_fstype }}"
     mount_state: "mounted"
 
 - name: "Read content of file {{ test_file_path }} after guest OS reboot"
@@ -94,8 +98,8 @@
       - read_file_content == test_file_content
     fail_msg: "{{ test_file_path }} file content is {{ read_file_content }}, not expected {{ test_file_content }}"
 
-- name: "Unmount device {{ test_partition_device_path }}"
+- name: "Unmount device {{ new_partition_device_path }}"
   include_tasks: ../utils/set_mount_point.yml
   vars:
-    mount_point_path: "{{ test_mount_path }}"
+    mount_point_path: "{{ new_partition_mount_path }}"
     mount_state: "absent"

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -3,9 +3,11 @@
 ---
 - name: "Test case block"
   block:
-    - include_tasks: ../setup/test_setup.yml
+    - name: "Test setup"
+      include_tasks: ../setup/test_setup.yml
 
-    - include_tasks: ../../common/skip_test_case.yml
+    - name: "Skip test case for unsupported guest OS"
+      include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case because guest OS doesn't support {{ new_disk_ctrl_type }} controller"
         skip_reason: "Not Supported"
@@ -15,7 +17,8 @@
         - guest_os_ansible_distribution_major_ver | int >= 8
         - "'uek' not in guest_os_ansible_kernel"
 
-    - include_tasks: ../../common/skip_test_case.yml
+    - name: "Skip test case for unsupported hardware version"
+      include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Skip test case because VM with hardware version {{ vm_hardware_version_num }} doesn't support {{ new_disk_ctrl_type }} controller hot add or hot remove"
         skip_reason: "Not Supported"
@@ -25,18 +28,19 @@
            (guest_os_ansible_distribution == "VMware Photon OS" and vm_hardware_version_num | int < 19))
 
     - name: "Install SCSI command tools for rescan LSI Logic controller"
+      when:
+        - new_disk_ctrl_type == 'lsilogic'
+        - guest_os_ansible_distribution != 'Flatcar'
       block:
         - name: "Set SCSI command tools package name"
           ansible.builtin.set_fact:
             sg3_utils_pkg: "{{ 'sg3-utils' if guest_os_family in ['Debian', 'Astra Linux (Orel)'] else 'sg3_utils' }}"
 
-        - include_tasks: ../utils/install_uninstall_package.yml
+        - name: "Install SCSI command tools package {{ sg3_utils_pkg }}"
+          include_tasks: ../utils/install_uninstall_package.yml
           vars:
             package_list: ["{{ sg3_utils_pkg }}"]
             package_state: "present"
-      when:
-        - new_disk_ctrl_type == 'lsilogic'
-        - guest_os_ansible_distribution not in ['Flatcar', 'RHCOS', 'FreeBSD']
 
     - name: "Get file lsblk.sh for FreeBSD"
       when: guest_os_ansible_distribution == "FreeBSD"
@@ -58,7 +62,7 @@
 
         - name: Display the result of file lsblk.sh downloading
           ansible.builtin.debug: var=download_file_lsblk_result
- 
+
         - name: "Check download file lsblk.sh is successful"
           ansible.builtin.assert:
             that:
@@ -68,25 +72,47 @@
             fail_msg: >-
               Failed to download file lsblk.sh from url {{ freebsd_lsblk_download_url }}.
 
+    - name: "Get VM boot info"
+      include_tasks: ../../common/vm_get_boot_info.yml
+
+    - name: "Set VM boot order for BIOS firmware"
+      when: vm_firmware == 'bios'
+      block:
+        - name: "Get VM disks info"
+          include_tasks: ../../common/vm_get_disk_facts.yml
+
+        - name: "Set fact of VM boot disk info"
+          ansible.builtin.set_fact:
+            vm_boot_disk_info: "{{ vm_guest_disk_facts.guest_disk_info['0'] }}"
+
+        - name: "Set VM boot order in case hot added new controller disk changes the boot order"
+          include_tasks: ../../common/vm_set_boot_options.yml
+          vars:
+            boot_hdd_name: "{{ vm_boot_disk_info.label }}"
+            boot_order_list:
+              - disk
+
     - name: "Get the vHBA type for {{ new_disk_ctrl_type }} controller"
       ansible.builtin.set_fact:
         new_vhba_type: "{{ new_disk_ctrl_type if new_disk_ctrl_type in ['sata', 'nvme'] else 'scsi' }}"
 
-    # Get VM current disk controller info before doing hotadd testing
-    - include_tasks: ../../common/vm_get_disk_controller_facts.yml
+    - name: "Get VM disk controller info before hot-add"
+      include_tasks: ../../common/vm_get_disk_controller_facts.yml
 
     - name: "Set fact of VM disk controllers before hot adding tests"
       ansible.builtin.set_fact:
-        disk_controller_facts_old: "{{ disk_controller_facts['disk_controller_data'] }}"
+        disk_controllers_before_hotadd: "{{ disk_controller_facts['disk_controller_data'] }}"
 
-    - name: "Print VM controller facts before hot adding tests"
-      ansible.builtin.debug: var=disk_controller_facts_old
+    - name: "Print VM controller facts before hot-add"
+      ansible.builtin.debug: var=disk_controllers_before_hotadd
 
-    - include_tasks: ../../common/vm_get_new_vhba_bus_number.yml
+    - name: "Get new vHBA bus number"
+      include_tasks: ../../common/vm_get_new_vhba_bus_number.yml
       vars:
-        disk_controller_facts_data: "{{ disk_controller_facts_old }}"
+        disk_controller_facts_data: "{{ disk_controllers_before_hotadd }}"
 
-    - include_tasks: ../../common/skip_test_case.yml
+    - name: "Test case is blocked due to no available bus number"
+      include_tasks: ../../common/skip_test_case.yml
       vars:
         skip_msg: "Test case '{{ ansible_play_name }}' is blocked because not found available {{ new_vhba_type }} controllers bus number."
         skip_reason: "Blocked"
@@ -99,27 +125,15 @@
         new_ctrl_number: "{{ new_vhba_bus_number }}"
         new_unit_number: "0"
 
-    # Get current device list in guest OS
-    - include_tasks: ../utils/get_device_list.yml
-      vars:
-        guest_device_type: "disk"
-
-    - name: "Set the fact of guest disk list before hot add"
-      ansible.builtin.set_fact:
-        guest_disk_list_before_hotadd: "{{ guest_device_list }}"
-
-    - name: "Print guest disk list before hot add"
-      ansible.builtin.debug: var=guest_disk_list_before_hotadd
-
     - name: "Firstly hot add a new disk controller and disk at the same time"
       ansible.builtin.set_fact:
         add_new_controller: true
 
-    # Hot add a new controller and disk at the same time, run disk iozone test and then remove it
-    - include_tasks: hot_add_remove_disk.yml
+    - name: "Hot add a new controller and disk at the same time, test disk I/O and then remove it"
+      include_tasks: hot_add_remove_disk.yml
 
-    # Get VM disk controller info after hot adding
-    - include_tasks: ../../common/vm_get_disk_controller_facts.yml
+    - name: "Get VM disk controller info after hot-add"
+      include_tasks: ../../common/vm_get_disk_controller_facts.yml
 
     - name: "Print disk controller facts after disk hot adding"
       ansible.builtin.debug: var=disk_controller_facts['disk_controller_data']
@@ -135,11 +149,11 @@
       ansible.builtin.set_fact:
         add_new_controller: false
 
-    # Hot add a new disk on the previous added controller, run disk iozone test and then remove it
-    - include_tasks: hot_add_remove_disk.yml
+    - name: "Hot add a new disk on the previous added controller, test disk I/O and then remove it"
+      include_tasks: hot_add_remove_disk.yml
 
-    # Hot remove new added disk controller
-    - include_tasks: ../../common/vm_hot_add_remove_disk_ctrl.yml
+    - name: "Hot remove new added disk controller"
+      include_tasks: ../../common/vm_hot_add_remove_disk_ctrl.yml
       vars:
         disk_controller_ops: "absent"
         disk_controller_type: "{{ new_disk_ctrl_type }}"
@@ -147,16 +161,19 @@
 
     - name: "Set facts of disk controller on VM '{{ vm_name }}'"
       ansible.builtin.set_fact:
-        disk_controller_facts_new: "{{ disk_controller_facts['disk_controller_data'] }}"
+        disk_controllers_after_hotremove: "{{ disk_controller_facts['disk_controller_data'] }}"
 
     - name: "Print VM disk controller facts after controller hot removing"
-      ansible.builtin.debug: var=disk_controller_facts_new
+      ansible.builtin.debug: var=disk_controllers_after_hotremove
 
-    - name: "Check disk controller facts are same as before hot adding tests"
+    - name: "Check disk controller facts are same as before hot adding and removing tests"
       ansible.builtin.assert:
         that:
-          - disk_controller_facts_old[new_vhba_type] == disk_controller_facts_new[new_vhba_type]
-        fail_msg: "After tests VM disk controller fact is: {{ disk_controller_facts_new }}; before tests it's: {{ disk_controller_facts_old }}"
+          - disk_controllers_before_hotadd[new_vhba_type] == disk_controllers_after_hotremove[new_vhba_type]
+        fail_msg: >-
+          VM disk controllers were changed after testing, not expected unchanged.
+          VM disk controllers before hot-add are {{ disk_controllers_before_hotadd }},
+          VM disk controllers after hot-remove are {{ disk_controllers_after_hotremove }}.
   rescue:
-    - include_tasks: ../../common/test_rescue.yml
-
+    - name: "Test case failure"
+      include_tasks: ../../common/test_rescue.yml

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -30,7 +30,7 @@
     - name: "Install SCSI command tools for rescan LSI Logic controller"
       when:
         - new_disk_ctrl_type == 'lsilogic'
-        - guest_os_ansible_distribution != 'Flatcar'
+        - guest_os_ansible_distribution not in ['Flatcar', 'RHCOS', 'FreeBSD']
       block:
         - name: "Set SCSI command tools package name"
           ansible.builtin.set_fact:


### PR DESCRIPTION
The device boot order might be changed when adding new controller and disk to BIOS VM after reboot. So before vHBA testing, we need to set VM's boot order and make its boot disk as the first boot device, then we can enable file read/write after hot adding a new disk and reboot.