### PR TITLE
Print error message when reverting VM snapshot failed

### DIFF
--- a/common/vm_revert_snapshot.yml
+++ b/common/vm_revert_snapshot.yml
@@ -23,7 +23,7 @@
     name: "{{ vm_name }}"
     state: revert
     snapshot_name: "{{ snapshot_name }}"
-  ignore_errors: True
+  ignore_errors: true
   register: revert_result
 
 - name: "Display revert snapshot result"
@@ -53,6 +53,7 @@
       ansible.builtin.debug:
         msg: "Snapshot '{{ snapshot_name }}' does not exist. Ignore this failure because 'skip_if_not_exist' is set to True"
       when:
+        - skip_if_not_exist
         - snapshot_not_exists_error
 
     # Other failures

--- a/common/vm_revert_snapshot.yml
+++ b/common/vm_revert_snapshot.yml
@@ -7,7 +7,7 @@
 #   skip_if_not_exist: if set to true, revert snapshot task will not fail when snapshot doesn't exist.
 #   Default value is false.
 #
-- name: Set fact of revert to snapshot failed if not exist
+- name: "Set fact of skipping not existing snapshot to false"
   ansible.builtin.set_fact:
     skip_if_not_exist: false
   when: skip_if_not_exist is undefined
@@ -23,38 +23,48 @@
     name: "{{ vm_name }}"
     state: revert
     snapshot_name: "{{ snapshot_name }}"
-  ignore_errors: true
+  ignore_errors: True
   register: revert_result
+
 - name: "Display revert snapshot result"
   ansible.builtin.debug: var=revert_result
   when: enable_debug is defined and enable_debug
 
-- name: "Handle revert snasphot failure"
-  block:
-    - name: "Check snasphot not exist failure message"
-      ansible.builtin.set_fact:
-        msg_no_snapshots: "{{ revert_result.msg | regex_search('does not have any snapshots to revert') }}"
-        msg_not_find_snapshot: "{{ revert_result.msg | regex_search('Couldn.t find any snapshots with specified name') }}"
+- name: "Initialize the fact whether there is snapshot not-exist error"
+  ansible.builtin.set_fact:
+    snapshot_not_exists_error: False
 
-    - name: "Ignore snapshot not exist failure"
-      ansible.builtin.debug:
-        msg: "Snapshot '{{ snapshot_name }}' not exist, but 'skip_if_not_exist' is set to True"
+# When VM has snapshot but doesn't have the snapshot to revert
+# revert_result.failed is false not true. So here use
+# revert_result.changed to check whether reverting snapshot failed
+- name: "Handle revert snasphot failure"
+  when: revert_result.changed is undefined or not revert_result.changed
+  block:
+    - name: "Check there is error message about snasphot not existing"
+      ansible.builtin.set_fact:
+        snapshot_not_exists_error: >-
+         {{ revert_result.msg is match(".*does not have any snapshots to revert to.") | bool or
+            revert_result.msg is match("Couldn't find any snapshots with specified name.*") | bool }}
       when:
-        - skip_if_not_exist
-        - msg_no_snapshots or msg_not_find_snapshot
+        - revert_result.msg is defined
+        - revert_result.msg
+
+    - name: "Ignore snapshot reverting failure due to inexistence of snapshot {{ snapshot_name }}"
+      ansible.builtin.debug:
+        msg: "Snapshot '{{ snapshot_name }}' does not exist. Ignore this failure because 'skip_if_not_exist' is set to True"
+      when:
+        - snapshot_not_exists_error
 
     # Other failures
-    - name: "Revert snapshot failed"
+    - name: "Failed to revert snapshot to {{ snapshot_name }}"
       ansible.builtin.fail:
-        msg: "Revert to snapshot '{{ snapshot_name }}' failed"
-  when:
-    - "'failed' in revert_result"
-    - revert_result.failed
-    - "'msg' in revert_result"
+        msg: "Failed to revert to snapshot '{{ snapshot_name }}' because of error: {{ revert_result.msg | default('unknown failure') }}"
+      when: not skip_if_not_exist or not snapshot_not_exists_error
 
-# Get snapshot facts until current snapshot is the expected one
-# after revert to snapshot
-- include_tasks: vm_wait_expected_snapshot.yml
+- name: "Wait for VM current snapshot is the expected one after revert to snapshot"
+  include_tasks: vm_wait_expected_snapshot.yml
   vars:
     expected_snapshot_name: "{{ snapshot_name }}"
-  when: revert_result.changed
+  when:
+    - revert_result.changed is defined
+    - revert_result.changed


### PR DESCRIPTION
We need to capture the error message while reverting VM snapshot failed, and print it into failed_tasks.log.

```

TASK [Display revert snapshot result] **************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_revert_snapshot.yml:29
ok: [localhost] => {
    "revert_result": {
        "changed": false,
        "failed": true,
        "msg": "The operation cannot be allowed at the current time because the virtual machine has a question pending: \n 'msg.hbacommon.outofspace:There is no more space for virtual disk 'Ansible_winsrv_vbs_80ga-000003.vmdk'. You might be able to continue this session by freeing disk space on the relevant volume, and clicking Retry. Click Cancel to terminate this session.\n'."
    }
}

TASK [Initialize the fact whether there is snapshot not-exist error] *******************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_revert_snapshot.yml:33
ok: [localhost] => {
    "ansible_facts": {
        "snapshot_not_exists_error": false
    },
    "changed": false
}

TASK [Check there is error message about snasphot not existing] ************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_revert_snapshot.yml:43
ok: [localhost] => {
    "ansible_facts": {
        "snapshot_not_exists_error": false
    },
    "changed": false
}

TASK [Failed to revert snapshot to BaseSnapshot] ***************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_revert_snapshot.yml:59
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Failed to revert to snapshot 'BaseSnapshot' because of error: The operation cannot be allowed at the current time because the virtual machine has a question pending: \n 'msg.hbacommon.outofspace:There is no more space for virtual disk 'Ansible_winsrv_vbs_80ga-000003.vmdk'. You might be able to continue this session by freeing disk space on the relevant volume, and clicking Retry. Click Cancel to terminate this session.\n'."
}
```