### PR TITLE
[Pardus] Support ansible testcases for Pardus 21.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | Fedora Server 36 and later                    | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | ProLinux Server 7.9, 8.5                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | FreeBSD 13 and later                          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Pardus 21.2 Server,XFCE Desktop and later (*) | :heavy_check_mark:               |                          |                                   |
+| Pardus 21.2 Server,XFCE Desktop and later     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | openSUSE Leap 15.3 and later                  | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | BCLinux 8.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | BCLinux-for-Euler 21.10                       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -233,7 +233,7 @@ d-i preseed/late_command string \
     echo "Install openssh-server ..." > /target/dev/ttyS0; \
     chroot /target apt-get install -y --no-upgrade openssh-server > /dev/ttyS0; \
     echo "Install packages ..." > /target/dev/ttyS0; \
-    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl python3-apt > /dev/ttyS0; \
+    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl python3-apt dbus > /dev/ttyS0; \
     if [ -f "/target/usr/bin/Xorg" ];\
         then\
             echo "Install package open-vm-tools-desktop ..." > /target/dev/ttyS0;\

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -233,7 +233,7 @@ d-i preseed/late_command string \
     echo "Install openssh-server ..." > /target/dev/ttyS0; \
     chroot /target apt-get install -y --no-upgrade openssh-server > /dev/ttyS0; \
     echo "Install packages ..." > /target/dev/ttyS0; \
-    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl > /dev/ttyS0; \
+    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl python3-apt > /dev/ttyS0; \
     if [ -f "/target/usr/bin/Xorg" ];\
         then\
             echo "Install package open-vm-tools-desktop ..." > /target/dev/ttyS0;\

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -233,7 +233,7 @@ d-i preseed/late_command string \
     echo "Install openssh-server ..." > /target/dev/ttyS0; \
     chroot /target apt-get install -y --no-upgrade openssh-server > /dev/ttyS0; \
     echo "Install packages ..." > /target/dev/ttyS0; \
-    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim > /dev/ttyS0; \
+    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl > /dev/ttyS0; \
     if [ -f "/target/usr/bin/Xorg" ];\
         then\
             echo "Install package open-vm-tools-desktop ..." > /target/dev/ttyS0;\

--- a/linux/network_device_ops/apply_new_network_config.yml
+++ b/linux/network_device_ops/apply_new_network_config.yml
@@ -78,11 +78,12 @@
         network_config_template: rhel_network_conf.j2
       when: guest_os_family == "RedHat"
 
-    - name: "Set fact of the network config template for Ubuntu desktop"
+    - name: "Set fact of the network config template for {{ guest_os_ansible_distribution }}"
       ansible.builtin.set_fact:
         network_config_template: debian_network_conf.j2
       when: >
         (guest_os_ansible_distribution == "Debian") or
+        (guest_os_ansible_distribution == "Pardus GNU/Linux") or
         (guest_os_ansible_distribution == "Ubuntu" and
          guest_os_with_gui is defined and guest_os_with_gui)
 
@@ -109,6 +110,9 @@
       when: guest_os_family == "FreeBSD"
 
     - name: "Create or update network config file for new network interface"
+      when:
+        - network_config_template
+        - network_config_path
       block:
         - name: "Create or update network config file '{{ network_config_path }}'"
           ansible.builtin.template:
@@ -125,9 +129,6 @@
     
         - name: "Print content of network config file '{{ network_config_path }}'"
           ansible.builtin.debug: var=network_config.stdout_lines
-      when:
-        - network_config_template
-        - network_config_path
 
 - name: "Apply new netplan configuration file in Ubuntu server"
   when:

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -49,10 +49,14 @@
         network_config_path: "/etc/network/interfaces"
       when: >
         (guest_os_ansible_distribution == "Debian") or
+        (guest_os_ansible_distribution == "Pardus GNU/Linux") or
         (guest_os_ansible_distribution == "Ubuntu" and
          guest_os_with_gui is defined and guest_os_with_gui)
 
     - name: "Set fact of network config file in Ubuntu server"
+      when:
+        - guest_os_ansible_distribution == "Ubuntu"
+        - guest_os_with_gui is defined and not guest_os_with_gui
       block:
         - name: "Get netplan config file in Ubuntu server"
           include_tasks: ../utils/get_netplan_config_file.yml
@@ -61,9 +65,6 @@
           ansible.builtin.set_fact:
             network_config_path: "{{ netplan_config_file }}"
           when: netplan_config_file is defined
-      when:
-        - guest_os_ansible_distribution == "Ubuntu"
-        - guest_os_with_gui is defined and not guest_os_with_gui
 
     - name: "Set fact of network config file for '{{ network_adapter_name }}' on SLE"
       ansible.builtin.set_fact:

--- a/linux/utils/get_network_manager.yml
+++ b/linux/utils/get_network_manager.yml
@@ -15,7 +15,7 @@
   when: guest_os_ansible_distribution in ["Debian", "Pardus GNU/Linux"]
 
 - name: "Set network device manager for {{ guest_os_ansible_distribution }}"
-  when: guest_os_ansible_distribution not in ["Debian", "FreeBSD"]
+  when: guest_os_ansible_distribution not in ["Debian", "FreeBSD", "Pardus GNU/Linux"]
   block:
     - include_tasks: get_service_info.yml
       vars:
@@ -31,6 +31,10 @@
         - service_info.state in ['active', 'running']
 
     - name: "Set network device manager for guest OS which doesn't have NetworkManager"
+      when: >
+        (not service_info or
+        service_info.state is undefined or
+        service_info.state not in ['active', 'running'])
       block:
         # SLES uses netplan to manage network interfaces
         - name: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} network device manager is wicked"
@@ -54,11 +58,7 @@
         - name: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} network device manager is systemd-networkd"
           ansible.builtin.set_fact:
             guest_os_network_manager: "systemd-networkd"
-          when: guest_os_ansible_distribution in ['VMware Photon OS', 'Flatcar'] 
-      when: >
-        (not service_info or
-        service_info.state is undefined or
-        service_info.state not in ['active', 'running'])
+          when: guest_os_ansible_distribution in ['VMware Photon OS', 'Flatcar']
 
 - name: "Set network device manager for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:

--- a/linux/utils/get_network_manager.yml
+++ b/linux/utils/get_network_manager.yml
@@ -12,7 +12,7 @@
 - name: "{{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} network device manager is traditional ifdown/ifup"
   ansible.builtin.set_fact:
     guest_os_network_manager: "traditional"
-  when: guest_os_ansible_distribution == "Debian"
+  when: guest_os_ansible_distribution in ["Debian", "Pardus GNU/Linux"]
 
 - name: "Set network device manager for {{ guest_os_ansible_distribution }}"
   when: guest_os_ansible_distribution not in ["Debian", "FreeBSD"]


### PR DESCRIPTION
Task:
Support ansible testcases for Pardus 21.x


Test result:
1. For pardus 21.5 XFCE
<img width="636" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/7b6271e2-07de-44c0-ad20-d706b66763b7">

2. For pardus 21.2 Server:
<img width="619" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/b816f438-40e7-4d51-b6e7-dbfbf0f89026">

Note:
For the failed testcases, it's 3rd issues
