### PR TITLE
[Pardus] the offical repo is changed for pardus 23.0

### DIFF
--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -225,14 +225,14 @@ d-i preseed/late_command string \
             echo "Add offical repo ..." > /target/dev/ttyS0;\
             codename=$(cat /target/etc/os-release | grep PARDUS_CODENAME | cut -d= -f2);\
             major_version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d= -f2 | tr -d '"' | cut -d. -f1);\
-            if [ $major_version -ge 23 ]; then
+            if [ $major_version -ge 23 ]; then\
                 echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free no-free-firmware" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/pardus $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/guvenlik $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
-            else
+            else\
                 echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/guvenlik $codename main contrib non-free" >> /target/etc/apt/sources.list;\
-            fi
+            fi; \
             cat /target/etc/apt/sources.list > /target/dev/ttyS0;\
     fi; \
     echo "Update repository ..." > /target/dev/ttyS0; \

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -227,8 +227,8 @@ d-i preseed/late_command string \
             major_version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d= -f2 | tr -d '"' | cut -d. -f1);\
             if [ $major_version -ge 23 ]; then\
                 echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free no-free-firmware" >> /target/etc/apt/sources.list;\
-                echo "deb http://depo.pardus.org.tr/pardus $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
-                echo "deb http://depo.pardus.org.tr/guvenlik $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/pardus ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/guvenlik ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
             else\
                 echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/guvenlik $codename main contrib non-free" >> /target/etc/apt/sources.list;\

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -226,7 +226,7 @@ d-i preseed/late_command string \
             codename=$(cat /target/etc/os-release | grep PARDUS_CODENAME | cut -d= -f2);\
             major_version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d= -f2 | tr -d '"' | cut -d. -f1);\
             if [ $major_version -ge 23 ]; then\
-                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free no-free-firmware" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/pardus ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
                 echo "deb http://depo.pardus.org.tr/guvenlik ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
             else\

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -224,8 +224,15 @@ d-i preseed/late_command string \
         then\
             echo "Add offical repo ..." > /target/dev/ttyS0;\
             codename=$(cat /target/etc/os-release | grep PARDUS_CODENAME | cut -d= -f2);\
-            echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free" >> /target/etc/apt/sources.list;\
-            echo "deb http://depo.pardus.org.tr/guvenlik $codename main contrib non-free" >> /target/etc/apt/sources.list;\
+            major_version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d= -f2 | tr -d '"' | cut -d. -f1);\
+            if [ $major_version -ge 23 ]; then
+                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free no-free-firmware" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/pardus $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/guvenlik $(codename)-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
+            else
+                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free" >> /target/etc/apt/sources.list;\
+                echo "deb http://depo.pardus.org.tr/guvenlik $codename main contrib non-free" >> /target/etc/apt/sources.list;\
+            fi
             cat /target/etc/apt/sources.list > /target/dev/ttyS0;\
     fi; \
     echo "Update repository ..." > /target/dev/ttyS0; \

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -39,6 +39,8 @@
                guest_os_ansible_distribution_major_ver | int >= 22)
         - not (guest_os_ansible_distribution == "Debian" and
                guest_os_ansible_distribution_major_ver | int >= 12)
+        - not (guest_os_ansible_distribution == "Pardus GNU/Linux" and
+               guest_os_ansible_distribution_major_ver | int >= 23)
       block:
         - name: "Rescan all scsi devices"
           ansible.builtin.command: "/usr/bin/rescan-scsi-bus.sh -a -r"

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -57,7 +57,9 @@
          (guest_os_ansible_distribution == "Ubuntu" and
           guest_os_ansible_distribution_major_ver | int >= 22) or
          (guest_os_ansible_distribution == "Debian" and
-          guest_os_ansible_distribution_major_ver | int >= 12))
+          guest_os_ansible_distribution_major_ver | int >= 12) or
+         (guest_os_ansible_distribution == "Pardus GNU/Linux" and
+          guest_os_ansible_distribution_major_ver | int >= 23))
       block:
         - name: "Rescan all hard disks"
           ansible.builtin.shell: |


### PR DESCRIPTION
Issue:
The official repo is changed in pardus 23.0 which cause the failure to install packages during autoinstall.

Test result:
<img width="631" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/e7bf96f4-d079-43a4-8d1b-4b1d6a1bb239">
