### PR TITLE
Fix empty hardware version in collected OVF config info and guest_info.json

### DIFF
--- a/common/collect_ovf_vm_config.yml
+++ b/common/collect_ovf_vm_config.yml
@@ -32,7 +32,7 @@
         ovf_vm_hardware_config |
         combine({'Guest OS ID': vm_config.config.guestId | default(''),
                  'Guest OS Version': vm_config.config.guestFullName | default(''),
-                 'Hardware Version': vm_hardware_version | default(''),
+                 'Hardware Version': vm_config.config.version | default(''),
                  'CPU Number': vm_config.config.hardware.numCPU | default(''),
                  'CPU Cores per Socket': vm_config.config.hardware.numCoresPerSocket | default(''),
                  'CPU Hot Add Enabled': vm_config.config.cpuHotAddEnabled | default(''),

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -924,16 +924,18 @@ class CallbackModule(CallbackBase):
                     self._last_test_id in self.test_runs):
                     # Update deploy_vm test case name
                     self.test_runs[self._last_test_id].name = non_empty_facts['current_testcase_name']
-                elif task_file == "vm_get_guest_info.yml":
+
+                if (self._ansible_gosv_facts.get('esxi_build','') and
+                    self._ansible_gosv_facts.get('vm_hardware_version','') and
+                    self._ansible_gosv_facts.get('guestinfo_vmtools_info', '')):
                     # Save guest info
                     vm_guest_info = VmGuestInfo(self._ansible_gosv_facts)
-                    if vm_guest_info.VMTools_Version:
-                        guestinfo_hash = str(hash("{}{}{}".format(vm_guest_info.ESXi_Build,
-                                                                  vm_guest_info.VMTools_Version,
-                                                                  vm_guest_info.Hardware_Version)))
+                    guestinfo_hash = str(hash("{}{}{}".format(vm_guest_info.ESXi_Build,
+                                                              vm_guest_info.VMTools_Version,
+                                                              vm_guest_info.Hardware_Version)))
 
-                        if guestinfo_hash not in self.collected_guest_info:
-                            self.collected_guest_info[guestinfo_hash] = vm_guest_info
+                    if guestinfo_hash not in self.collected_guest_info:
+                        self.collected_guest_info[guestinfo_hash] = vm_guest_info
 
         elif (task_file in ["deploy_vm.yml", "test_setup.yml"] and
               str(task.action) == "ansible.builtin.debug"):


### PR DESCRIPTION
The hardware version in collected OVF config info is empty without this fix, as below:
```
"ovf_vm_hardware_config": {
            "CPU Cores per Socket": 1,
            "CPU Hot Add Enabled": false,
            "CPU I/O MMU": false,
            "CPU Nested HV Enabled": false,
            "CPU Number": 2,
            "Firmware": "efi",
            "Guest OS ID": "rhel8_64Guest",
            "Guest OS Version": "Red Hat Enterprise Linux 8 (64-bit)",
            "Hardware Version": "",
            "Memory Hot Add Enabled": false,
            "Memory Size in MB": 4096,
            "Secure Boot": false,
            "VBS Enabled": false,
            "Virtual TPM": false
        }
```

With this fix:
```
"ovf_vm_hardware_config": {
            "CPU Cores per Socket": 1,
            "CPU Hot Add Enabled": false,
            "CPU I/O MMU": false,
            "CPU Nested HV Enabled": false,
            "CPU Number": 2,
            "Firmware": "efi",
            "Guest OS ID": "rhel8_64Guest",
            "Guest OS Version": "Red Hat Enterprise Linux 8 (64-bit)",
            "Hardware Version": "vmx-15",
            "Memory Hot Add Enabled": false,
            "Memory Size in MB": 4096,
            "Secure Boot": false,
            "VBS Enabled": false,
            "Virtual TPM": false
```
guest_info.json
```
[
    {
        "Guest_OS_Distribution": "",
        "ESXi_Version": "8.0.3",
        "ESXi_Build": "22375478",
        "Hardware_Version": "vmx-15",
        "VMTools_Version": "12.1.5 (build-20735119)",
        "Config_Guest_Id": "rhel8_64Guest",
        "GuestInfo_Guest_Id": "rhel8_64Guest",
        "GuestInfo_Guest_Full_Name": "Red Hat Enterprise Linux 8 (64-bit)",
        "GuestInfo_Guest_Family": "linuxGuest",
        "GuestInfo_Detailed_Data": ""
    }
]
```