### PR TITLE
[FreeBSD 14] The default nvme disk name is changed in FreeBSD 14 which cause the failure for autoinstall

### DIFF
--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -3,7 +3,6 @@ debug=yes
 
 export ZFSBOOT_PARTITION_SCHEME="GPT"
 export ZFSBOOT_VDEV_TYPE=stripe
-export ZFSBOOT_SWAP_SIZE=2g
 export nonInteractive="YES"
 export ZFSBOOT_CONFIRM_LAYOUT=0
 

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -1,0 +1,155 @@
+
+debug=yes
+
+export ZFSBOOT_PARTITION_SCHEME="GPT"
+export ZFSBOOT_VDEV_TYPE=stripe
+export ZFSBOOT_SWAP_SIZE=2g
+export nonInteractive="YES"
+export ZFSBOOT_CONFIRM_LAYOUT=0
+
+{% if boot_disk_controller == 'nvme' %}
+export ZFSBOOT_DISKS=nvd0
+{% elif boot_disk_controller == 'sata' or boot_disk_controller == 'ide' %}
+export ZFSBOOT_DISKS=ada0
+{% else %}
+export ZFSBOOT_DISKS=da0
+{% endif %}
+
+{% if guest_id.find('64Guest') != -1 %}
+DISTRIBUTIONS="kernel.txz base.txz kernel-dbg.txz lib32.txz src.txz ports.txz"
+export ZFSBOOT_BOOT_TYPE="BIOS+UEFI"
+{% else %}
+DISTRIBUTIONS="kernel.txz base.txz kernel-dbg.txz src.txz ports.txz"
+export ZFSBOOT_BOOT_TYPE="BIOS"
+{% endif %}
+
+#!/bin/sh
+# Set hostname
+sysrc hostname="FreeBSD-{{ hostname_timestamp }}"
+
+# Set Time Zone to UTC
+echo "Setting Time Zone to UTC ..."
+/bin/cp /usr/share/zoneinfo/UTC /etc/localtime
+/usr/bin/touch /etc/wall_cmos_clock
+/sbin/adjkerntz -a
+
+echo "Set network interface with DHCP IP assignment ..." > /dev/ttyu0
+ifdev=$(ifconfig | grep '^[a-z]' | cut -d: -f1 | head -n 1)
+echo "Get ifname ${ifdev}" > /dev/ttyu0
+sysrc ifconfig_${ifdev}=DHCP
+
+# Get DHCP for nic0
+echo "Get IP with dhclient ..." > /dev/ttyu0
+dhclient ${ifdev}
+sleep 15
+echo "Check network ..." > /dev/ttyu0
+ifconfig > /dev/ttyu0
+
+# Set Proxy.
+{% if http_proxy_vm is defined and http_proxy_vm %}
+setenv HTTP_PROXY {{ http_proxy_vm }}
+{% endif %}
+
+# Installing packages
+echo "Installing packages ..." > /dev/ttyu0
+env ASSUME_ALWAYS_YES=YES pkg bootstrap -y
+
+# Hit issue: reset by peer during install packages
+# The open-vm-tools is not installed by default
+mkdir -p /usr/local/etc/pkg/repos
+mount > /dev/ttyu0
+cp -rf /dist/packages/repos/FreeBSD_install_cdrom.conf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
+env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
+
+# We install packages from ISO image
+# Different packages between the 32bit image and 64bit image
+packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
+for package_to_install in $packages_to_install
+do
+    echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
+    env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
+    ret=$?
+    if [ $ret == 0 ]
+    then    
+        echo "Succeed to install the package($package_to_install)" > /dev/ttyu0
+    else
+        echo "Failed to install the package($package_to_install)" > /dev/ttyu0
+    fi
+done
+
+# Disable ISO repo and enable default repo
+rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
+env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
+packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+for package_to_install in $packages_to_install
+do
+    ret=1
+    try_count=1
+    until [ $ret -eq 0 ]
+    do
+        echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
+        env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
+        ret=$?
+        try_count=$((try_count+1))
+    done
+    echo "The package($package_to_install) is already installed" > /dev/ttyu0
+done
+
+# Add new user. 
+{% if new_user is defined and new_user != 'root' %}
+echo "{{ vm_password }}" | pw useradd {{ new_user }} -s /bin/sh -d /home/{{ new_user }} -m -g wheel -h 0
+echo '{{ new_user }} ALL=(ALL:ALL) ALL' >> /usr/local/etc/sudoers
+{% endif %}
+
+# Set password of root user
+echo "{{ vm_password }}" | pw -V /etc usermod root -h 0
+
+# Enable root login via ssh
+echo "Enable root login via ssh ..." > /dev/ttyu0
+mkdir -p -m 700 /root/.ssh
+echo "{{ ssh_public_key }}" > /root/.ssh/authorized_keys
+chown -R root /root/.ssh
+chmod 0644 /root/.ssh/authorized_keys
+# We can't ssh to VM with empty password for root user
+sed -i .bak -e 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+sed -i '' -e 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Enable service
+echo "Enable service ..." > /dev/ttyu0
+sysrc sshd_enable="YES"
+sysrc ntpd_enable="YES"
+sysrc ntpd_sync_on_start="YES"
+
+# Eanble ZFS
+sysrc zfs_enable="YES"
+
+# Configure KDE desktop
+echo "proc      /proc       procfs  rw  0   0" >> /etc/fstab
+sysrc dbus_enable="YES"
+sysrc sddm_enable="YES"
+
+# Autologin to desktop environment
+echo "[Autologin]" >> /usr/local/etc/sddm.conf
+echo "User={{ new_user }}" >> /usr/local/etc/sddm.conf
+echo "Session=plasma.desktop" >> /usr/local/etc/sddm.conf
+
+# Enable GEOM label
+echo "Enable disk label ..." > /dev/ttyu0
+sed -i '' 's/kern.geom.label.disk_ident.enable="0"/kern.geom.label.disk_ident.enable="1"/' /boot/loader.conf
+sed -i '' 's/kern.geom.label.gptid.enable="0"/kern.geom.label.gptid.enable="1"/' /boot/loader.conf
+echo 'kern.geom.label.gpt.enable="1"' >>/boot/loader.conf
+echo 'kern.geom.label.ufs.enable="1"' >>/boot/loader.conf
+echo 'kern.geom.label.ufsid.enable="1"' >>/boot/loader.conf
+
+# Reducing boot menu delay
+echo "Reducing boot menu delay ..." > /dev/ttyu0
+echo 'autoboot_delay="3"' >> /boot/loader.conf
+
+echo "Display /boot/loader.conf content"
+cat /boot/loader.conf > /dev/ttyu0
+
+echo "End of installerconfig" > /dev/ttyu0
+echo "{{ autoinstall_complete_msg }}" > /dev/ttyu0
+
+# Power off system when autoinstall completes
+poweroff

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -3,7 +3,6 @@ debug=yes
 
 export ZFSBOOT_PARTITION_SCHEME="GPT"
 export ZFSBOOT_VDEV_TYPE=stripe
-export ZFSBOOT_SWAP_SIZE=2g
 export nonInteractive="YES"
 export ZFSBOOT_CONFIRM_LAYOUT=0
 

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -7,15 +7,8 @@ export ZFSBOOT_SWAP_SIZE=2g
 export nonInteractive="YES"
 export ZFSBOOT_CONFIRM_LAYOUT=0
 
-{% set freebsd_major_version = 14 %}
-{% if guest_os_type is defined and guest_os_type %}
-{% set freebsd_major_version = guest_os_type.split('-')[1].split('.')[0] %}
-{% endif %}
-
-{% if boot_disk_controller == 'nvme' and freebsd_major_version >= 14 %}
+{% if boot_disk_controller == 'nvme' %}
 export ZFSBOOT_DISKS=nda0
-{% elif boot_disk_controller == 'nvme' %}
-export ZFSBOOT_DISKS=nvd0
 {% elif boot_disk_controller == 'sata' or boot_disk_controller == 'ide' %}
 export ZFSBOOT_DISKS=ada0
 {% else %}

--- a/autoinstall/FreeBSD/installerconfig
+++ b/autoinstall/FreeBSD/installerconfig
@@ -9,7 +9,7 @@ export ZFSBOOT_CONFIRM_LAYOUT=0
 
 {% set freebsd_major_version = 14 %}
 {% if guest_os_type is defined and guest_os_type %}
-{% set freebsd_major_version = `echo $guest_os_type | cut -d- -f2 | cut -d. -f1` %}
+{% set freebsd_major_version = guest_os_type.split('-')[1].split('.')[0] %}
 {% endif %}
 
 {% if boot_disk_controller == 'nvme' and freebsd_major_version >= 14 %}

--- a/autoinstall/FreeBSD/installerconfig
+++ b/autoinstall/FreeBSD/installerconfig
@@ -7,10 +7,9 @@ export ZFSBOOT_SWAP_SIZE=2g
 export nonInteractive="YES"
 export ZFSBOOT_CONFIRM_LAYOUT=0
 
+{% set freebsd_major_version = 14 %}
 {% if guest_os_type is defined and guest_os_type %}
-freebsd_major_version=`echo $guest_os_type | cut -d- -f2 | cut -d. -f1`
-{% else %}
-freebsd_major_version=14
+{% set freebsd_major_version = `echo $guest_os_type | cut -d- -f2 | cut -d. -f1` %}
 {% endif %}
 
 {% if boot_disk_controller == 'nvme' and freebsd_major_version >= 14 %}

--- a/autoinstall/FreeBSD/installerconfig
+++ b/autoinstall/FreeBSD/installerconfig
@@ -7,7 +7,15 @@ export ZFSBOOT_SWAP_SIZE=2g
 export nonInteractive="YES"
 export ZFSBOOT_CONFIRM_LAYOUT=0
 
-{% if boot_disk_controller == 'nvme' %}
+{% if guest_os_type is defined and guest_os_type %}
+freebsd_major_version=`echo $guest_os_type | cut -d- -f2 | cut -d. -f1`
+{% else %}
+freebsd_major_version=14
+{% endif %}
+
+{% if boot_disk_controller == 'nvme' and freebsd_major_version >= 14 %}
+export ZFSBOOT_DISKS=nda0
+{% elif boot_disk_controller == 'nvme' %}
 export ZFSBOOT_DISKS=nvd0
 {% elif boot_disk_controller == 'sata' or boot_disk_controller == 'ide' %}
 export ZFSBOOT_DISKS=ada0

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -17,11 +17,12 @@
 16. For UnionTech OS Server 20 1050a unattend auto-install, please use file UOS/Server/20/1050a/ks.cfg.
 17. For UnionTech OS Server 20 1050e unattend auto-install, please use file UOS/Server/20/1050e/ks.cfg.
 18. For Fedora Server 36 or later unattend auto-install, please use file Fedora/36/Server/ks.cfg.
-19. For FreeBSD 13 or later unattend auto-install, please use file FreeBSD/installerconfig.
-20. For Pardus 21.2 Server and XFCE Desktop or later unattend auto-install, please use file Pardus/preseed.cfg.
-21. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
-22. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
-23. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
+19. For FreeBSD 13, please use file FreeBSD/13/installerconfig.
+20. For FreeBSD 14 or later unattend auto-install, please use file FreeBSD/14/installerconfig.
+21. For Pardus 21.2 Server and XFCE Desktop or later unattend auto-install, please use file Pardus/preseed.cfg.
+22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
+23. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
+24. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -17,7 +17,7 @@
 16. For UnionTech OS Server 20 1050a unattend auto-install, please use file UOS/Server/20/1050a/ks.cfg.
 17. For UnionTech OS Server 20 1050e unattend auto-install, please use file UOS/Server/20/1050e/ks.cfg.
 18. For Fedora Server 36 or later unattend auto-install, please use file Fedora/36/Server/ks.cfg.
-19. For FreeBSD 13, please use file FreeBSD/13/installerconfig.
+19. For FreeBSD 13 unattend auto-install, please use file FreeBSD/13/installerconfig.
 20. For FreeBSD 14 or later unattend auto-install, please use file FreeBSD/14/installerconfig.
 21. For Pardus 21.2 Server and XFCE Desktop or later unattend auto-install, please use file Pardus/preseed.cfg.
 22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -60,11 +60,6 @@
             unattend_install_conf: "Debian/10/preseed.cfg"
           when: guest_id is match("debian1\\d+")
 
-        - name: "Set default unattend install conf file for FreeBSD"
-          ansible.builtin.set_fact:
-            unattend_install_conf: "FreeBSD/installerconfig"
-          when: guest_id is match('freebsd.*')
-
     - name: "Display warning message about undefined unattend_install_conf"
       ansible.builtin.debug:
         msg: "unattend_install_conf is not defined or set to a file path, will not generate unattend ISO file"


### PR DESCRIPTION
The nvme disk name in FreeBSD 13 is nvd0, but in FreeBSD it is changed to nda0.
We need to change autoinstall for FreeBSD 14.


Test result:
<img width="594" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/a4c0f910-0a25-4504-b60e-08b0141b32e1">
