### PR TITLE
Fix dict item names in community.vmware.vmware_vm_config_option result

### DIFF
--- a/common/esxi_get_guest_config_options.yml
+++ b/common/esxi_get_guest_config_options.yml
@@ -223,7 +223,7 @@
             - guest_supported_disk_ctrls.matches is defined
             - guest_supported_disk_ctrls.matches | length > 0
 
-        - name: "Get supported disk controllers for guest id {{ guest_id }}"
+        - name: "Get supported network adapters for guest id {{ guest_id }}"
           community.general.xml:
             path: "{{ tmp_config_option_file }}"
             xpath: "{{ guest_config_options_xpath }}/supportedEthernetCard/e"

--- a/common/esxi_get_guest_config_options.yml
+++ b/common/esxi_get_guest_config_options.yml
@@ -9,38 +9,40 @@
 #   guest_config_options: The guest ID config options for a hardware version
 # Example output:
 #  "guest_config_options": {
-#      "default_cdrom_controller": "sata",
-#      "default_cpu_cores_per_socket": "1",
+#      "default_cdrom_controller": "ide",
 #      "default_cpu_number": 1,
-#      "default_cpu_socket": "1",
 #      "default_disk_controller": "paravirtual",
-#      "default_disk_size_in_mb": "16384",
-#      "default_firmware": "efi",
-#      "default_memory_in_mb": "2048",
-#      "default_network_adapter": "vmxnet3",
-#      "default_secure_boot": "true",
-#      "default_usb_controller": null,
-#      "guest_fullname": "CentOS 8 (64-bit)",
-#      "guest_id": "centos8_64Guest",
-#      "hardware_version": "vmx-19",
-#      "rec_persistent_memory": "8192",
-#      "rec_vram_kb": "8192",
+#      "default_ethernet": "vmxnet3",
+#      "default_secure_boot": false,
+#      "default_usb_controller": "",
+#      "guest_fullname": "Other 5.x Linux (64-bit)",
+#      "guest_id": "other5xLinux64Guest",
+#      "hardware_version": "vmx-21",
+#      "rec_cpu_cores_per_socket": 1,
+#      "rec_cpu_socket": 1,
+#      "rec_disk_mb": 16384,
+#      "rec_firmware": "efi",
+#      "rec_memory_mb": 1024,
+#      "rec_persistent_memory": 8192,
+#      "rec_vram_kb": 4096,
 #      "support_disk_controller": [
+#          "lsilogic",
 #          "paravirtual",
-#          "ide",
+#          "lsilogicsas",
 #          "sata",
-#          "nvme"
+#          "nvme",
+#          "ide"
 #      ],
 #      "support_ethernet_card": [
+#          "vmxnet3",
 #          "e1000e",
 #          "sriov",
-#          "vmxnet3",
 #          "pvrdma"
 #      ],
-#      "support_min_persistent_mem_mb": "4",
-#      "support_persistent_memory": "true",
-#      "support_secure_boot": "true",
-#      "support_tpm_20": "true",
+#      "support_min_persistent_mem_mb": 4,
+#      "support_persistent_memory": true,
+#      "support_secure_boot": true,
+#      "support_tpm_20": true,
 #      "support_usb_controller": [
 #          "usb2",
 #          "usb3"
@@ -74,21 +76,18 @@
 
 - name: "Set fact of guest ID {{ guest_id }} default config options on hardware version {{ hardware_version }}"
   ansible.builtin.set_fact:
-    guest_config_options: >-
-      {{
-        get_config_options_result.instance["Recommended config options"].keys()
-        | map('lower')
-        | map("replace", " ", "_")
-        | zip(get_config_options_result.instance["Recommended config options"].values())
-        | items2dict(key_name=0, value_name=1)
-      }}
+    guest_config_options: "{{ get_config_options_result.instance.recommended_config_options }}"
   when:
     - get_config_options_result is defined
     - get_config_options_result.instance is defined
-    - get_config_options_result.instance["Recommended config options"] is defined
+    - get_config_options_result.instance.recommended_config_options is defined
 
-# Get config options from config file
-- block:
+- name: "Get config options from config file"
+  when: >
+    (get_config_options_result is undefined) or
+    (get_config_options_result.instance is undefined) or
+    (get_config_options_result.instance.recommended_config_options is undefined)
+  block:
     - name: "Initialize variables for getting guest ID default configs"
       ansible.builtin.set_fact:
         vm_config_option_esx_hw: "/etc/vmware/hostd/env/vmconfigoption-esx-hw{{ esxi_hardware_version }}.xml"
@@ -110,15 +109,16 @@
           vim.vm.device.VirtualUSBController: 'usb2'
           vim.vm.device.VirtualUSBXHCIController: 'usb3'
         vm_config_name:
+          id: "guest_id"
           recommendedCdromController: "default_cdrom_controller"
-          numRecommendedCoresPerSocket: "default_cpu_cores_per_socket"
-          numRecommendedPhysicalSockets: "default_cpu_socket"
+          numRecommendedCoresPerSocket: "rec_cpu_cores_per_socket"
+          numRecommendedPhysicalSockets: "rec_cpu_socket"
           recommendedUSBController: "default_usb_controller"
           recommendedDiskController: "default_disk_controller"
-          recommendedDiskSizeMB: "default_disk_size_in_mb"
-          recommendedFirmware: "default_firmware"
-          recommendedMemMB: "default_memory_in_mb"
-          recommendedEthernetCard: "default_network_adapter"
+          recommendedDiskSizeMB: "rec_disk_mb"
+          recommendedFirmware: "rec_firmware"
+          recommendedMemMB: "rec_memory_mb"
+          recommendedEthernetCard: "default_ethernet"
           defaultSecureBoot: "default_secure_boot"
           supportsSecureBoot: "support_secure_boot"
           fullName: "guest_fullname"
@@ -126,14 +126,6 @@
           supportedMinPersistentMemoryMB: "support_min_persistent_mem_mb"
           persistentMemorySupported: "support_persistent_memory"
           supportsTPM20: "support_tpm_20"
-
-    - name: "Initialize VM default config options"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            vm_config_name.values() | zip_longest([])
-            | items2dict(key_name=0, value_name=1)
-          }}
 
     # Create a temp file to store config options
     - include_tasks: create_temp_file_dir.yml
@@ -154,135 +146,142 @@
     - name: "Get default config option from guest OS descriptor for guest id {{ guest_id }}"
       community.general.xml:
         path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/{{ item }}"
+        xpath: "{{ guest_config_options_xpath }}/*"
         content: text
+      ignore_errors: true
       register: guest_os_descriptor
-      ignore_errors: true
-      loop: "{{ vm_config_name.keys() }}"
 
-    - name: "Set fact for VM default config with guest id {{ guest_id }}"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            guest_config_options
-            | combine({vm_config_name[item.key]:
-                       vm_device_types[item.value] if item.value in vm_device_types else item.value})
-          }}
-      with_items: "{{ guest_os_descriptor.results | map(attribute='matches') | select('defined') | flatten | map('dict2items') }}"
+    - name: "Set facts of guest OS config options"
+      when: not guest_os_descriptor.failed
+      block:
+        - name: "Initialize VM default config options"
+          ansible.builtin.set_fact:
+            guest_config_options: >-
+              {{
+                vm_config_name.values() | zip_longest([]) |
+                items2dict(key_name=0, value_name=1) |
+                combine({'hardware_version': 'vmx-' ~  esxi_hardware_version})
+              }}
 
-    - name: "Get default video RAM size in KB for guest id {{ guest_id }}"
-      community.general.xml:
-        path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/vRAMSizeInKB/defaultValue"
-        content: text
-      register: guest_vram_size
-      ignore_errors: true
+        - name: "Set fact of guest OS default config options"
+          ansible.builtin.set_fact:
+            guest_default_configs: >-
+              {{
+                guest_os_descriptor.matches |
+                map('dict2items') |
+                flatten |
+                selectattr('key', 'in', vm_config_name.keys()) |
+                items2dict
+              }}
 
-    - name: "Set default video RAM size in KB for guest id {{ guest_id }}"
-      ansible.builtin.set_fact:
-        guest_config_options: "{{ guest_config_options | combine({'rec_vram_kb': guest_vram_size.matches[0].defaultValue}) }}"
-      when:
-        - guest_vram_size is defined
-        - guest_vram_size.matches is defined
-        - guest_vram_size.matches | length > 0
+        - name: "Set fact for VM default config with guest id {{ guest_id }}"
+          ansible.builtin.set_fact:
+            guest_config_options: >-
+              {{
+                guest_config_options
+                | combine({vm_config_name[item.key]:
+                           vm_device_types[item.value] if item.value in vm_device_types else item.value})
+              }}
+          with_dict: "{{ guest_default_configs }}"
 
-    - name: "Get supported disk controllers for guest id {{ guest_id }}"
-      community.general.xml:
-        path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/supportedDiskControllerList/e"
-        content: text
-      register: guest_supported_disk_ctrls
-      ignore_errors: true
+        - name: "Get default video RAM size in KB for guest id {{ guest_id }}"
+          community.general.xml:
+            path: "{{ tmp_config_option_file }}"
+            xpath: "{{ guest_config_options_xpath }}/vRAMSizeInKB/defaultValue"
+            content: text
+          register: guest_vram_size
+          ignore_errors: true
 
-    - name: "Set supported disk controllers for guest id {{ guest_id }}"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            guest_config_options
-            | combine({
-                 'support_disk_controller':
-                   guest_supported_disk_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                    })
-           }}
-      when:
-        - guest_supported_disk_ctrls is defined
-        - guest_supported_disk_ctrls.matches is defined
-        - guest_supported_disk_ctrls.matches | length > 0
+        - name: "Set default video RAM size in KB for guest id {{ guest_id }}"
+          ansible.builtin.set_fact:
+            guest_config_options: "{{ guest_config_options | combine({'rec_vram_kb': guest_vram_size.matches[0].defaultValue}) }}"
+          when:
+            - guest_vram_size is defined
+            - guest_vram_size.matches is defined
+            - guest_vram_size.matches | length > 0
 
-    - name: "Get supported disk controllers for guest id {{ guest_id }}"
-      community.general.xml:
-        path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/supportedEthernetCard/e"
-        content: text
-      register: guest_supported_ethernet_card
-      ignore_errors: true
+        - name: "Get supported disk controllers for guest id {{ guest_id }}"
+          community.general.xml:
+            path: "{{ tmp_config_option_file }}"
+            xpath: "{{ guest_config_options_xpath }}/supportedDiskControllerList/e"
+            content: text
+          register: guest_supported_disk_ctrls
+          ignore_errors: true
 
-    - name: "Set supported network adapters for guest id {{ guest_id }}"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            guest_config_options
-            | combine({
-                 'support_ethernet_card':
-                   guest_supported_ethernet_card.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                      })
-           }}
-      when:
-        - guest_supported_ethernet_card is defined
-        - guest_supported_ethernet_card.matches is defined
-        - guest_supported_ethernet_card.matches | length > 0
+        - name: "Set supported disk controllers for guest id {{ guest_id }}"
+          ansible.builtin.set_fact:
+            guest_config_options: >-
+              {{
+                guest_config_options
+                | combine({
+                     'support_disk_controller':
+                       guest_supported_disk_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
+                        })
+               }}
+          when:
+            - guest_supported_disk_ctrls is defined
+            - guest_supported_disk_ctrls.matches is defined
+            - guest_supported_disk_ctrls.matches | length > 0
 
-    - name: "Get supported USB controllers for guest id {{ guest_id }}"
-      community.general.xml:
-        path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/supportedUSBControllerList/e"
-        content: text
-      register: guest_supported_usb_ctrls
-      ignore_errors: true
+        - name: "Get supported disk controllers for guest id {{ guest_id }}"
+          community.general.xml:
+            path: "{{ tmp_config_option_file }}"
+            xpath: "{{ guest_config_options_xpath }}/supportedEthernetCard/e"
+            content: text
+          register: guest_supported_ethernet_card
+          ignore_errors: true
 
-    - name: "Set supported USB controllers for guest id {{ guest_id }}"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            guest_config_options
-            | combine({
-                 'support_usb_controller':
-                   guest_supported_usb_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                      })
-           }}
-      when:
-        - guest_supported_usb_ctrls is defined
-        - guest_supported_usb_ctrls.matches is defined
-        - guest_supported_usb_ctrls.matches | length > 0
+        - name: "Set supported network adapters for guest id {{ guest_id }}"
+          ansible.builtin.set_fact:
+            guest_config_options: >-
+              {{
+                guest_config_options
+                | combine({
+                     'support_ethernet_card':
+                       guest_supported_ethernet_card.matches | map(attribute='e') | map('extract', vm_device_types) | list
+                          })
+               }}
+          when:
+            - guest_supported_ethernet_card is defined
+            - guest_supported_ethernet_card.matches is defined
+            - guest_supported_ethernet_card.matches | length > 0
 
-    - name: "Combine guest_id and hardware version into guest_config_options"
-      ansible.builtin.set_fact:
-        guest_config_options: >-
-          {{
-            guest_config_options
-            | combine({
-                 'guest_id': guest_id,
-                 'hardware_version': 'vmx-' ~  esxi_hardware_version
-                 })
-           }}
+        - name: "Get supported USB controllers for guest id {{ guest_id }}"
+          community.general.xml:
+            path: "{{ tmp_config_option_file }}"
+            xpath: "{{ guest_config_options_xpath }}/supportedUSBControllerList/e"
+            content: text
+          register: guest_supported_usb_ctrls
+          ignore_errors: true
+
+        - name: "Set supported USB controllers for guest id {{ guest_id }}"
+          ansible.builtin.set_fact:
+            guest_config_options: >-
+              {{
+                guest_config_options
+                | combine({
+                     'support_usb_controller':
+                       guest_supported_usb_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
+                          })
+               }}
+          when:
+            - guest_supported_usb_ctrls is defined
+            - guest_supported_usb_ctrls.matches is defined
+            - guest_supported_usb_ctrls.matches | length > 0
 
     - name: "Remove temporary config option file"
       ansible.builtin.file:
         path: "{{ tmp_config_option_file }}"
         state: absent
-  when: >
-    (get_config_options_result is undefined) or
-    (get_config_options_result.instance is undefined) or
-    (get_config_options_result.instance["Recommended config options"]) is undefined
 
 - name: "Set default CPU number for VM with guest id {{ guest_id }}"
   ansible.builtin.set_fact:
-    guest_config_options: "{{ guest_config_options | combine({'default_cpu_number': (guest_config_options.default_cpu_cores_per_socket | int) * (guest_config_options.default_cpu_socket | int) }) }}"
+    guest_config_options: "{{ guest_config_options | combine({'default_cpu_number': (guest_config_options.rec_cpu_cores_per_socket | int) * (guest_config_options.rec_cpu_socket | int) }) }}"
   when:
-    - guest_config_options.default_cpu_cores_per_socket is defined
-    - guest_config_options.default_cpu_cores_per_socket | int >= 1
-    - guest_config_options.default_cpu_socket is defined
-    - guest_config_options.default_cpu_socket | int >= 1
+    - guest_config_options.rec_cpu_cores_per_socket is defined
+    - guest_config_options.rec_cpu_cores_per_socket | int >= 1
+    - guest_config_options.rec_cpu_socket is defined
+    - guest_config_options.rec_cpu_socket | int >= 1
 
 - name: "Print guest id {{ guest_id }} config options on hardware version {{ esxi_hardware_version }}"
   ansible.builtin.debug: var=guest_config_options

--- a/common/esxi_get_guest_ids.yml
+++ b/common/esxi_get_guest_ids.yml
@@ -39,7 +39,11 @@
     - get_guest_os_ids_result.instance is defined
     - get_guest_os_ids_result.instance | length > 0
 
-- block:
+- name: "Get ESXi supported guest IDs from config options file"
+  when: >
+    get_guest_os_ids_result.instance is undefined or
+    get_guest_os_ids_result.failed
+  block:
     - name: "Initialize variables for getting hardware version supported guest IDs"
       ansible.builtin.set_fact:
         vm_config_option_esx_hw: "/etc/vmware/hostd/env/vmconfigoption-esx-hw{{ esxi_hardware_version }}.xml"
@@ -57,9 +61,6 @@
     - name: "Set fact of ESXi supported guest IDs for hardware version {{ esxi_hardware_version }}"
       ansible.builtin.set_fact:
         esxi_guest_ids: "{{ guest_os_desc_ids_result.matches | map(attribute='id') | list }}"
-  when: >
-    get_guest_os_ids_result is undefined or
-    get_guest_os_ids_result.failed
 
 - name: "Print ESXi server supported guest IDs on hardware version {{ esxi_hardware_version }}"
   ansible.builtin.debug: var=esxi_guest_ids

--- a/common/esxi_get_hardware_versions.yml
+++ b/common/esxi_get_hardware_versions.yml
@@ -27,6 +27,7 @@
 - name: "Set facts of ESXi server supported hardware versions"
   when:
     - get_hardware_versions_result is defined
+    - get_hardware_versions_result.instance is defined
     - get_hardware_versions_result.instance.supported_hardware_versions is defined
     - get_hardware_versions_result.instance.default_hardware_version is defined
   block:

--- a/common/esxi_get_hardware_versions.yml
+++ b/common/esxi_get_hardware_versions.yml
@@ -24,23 +24,24 @@
     get_hardware_versions: true
   register: get_hardware_versions_result
 
-- block:
+- name: "Set facts of ESXi server supported hardware versions"
+  when:
+    - get_hardware_versions_result is defined
+    - get_hardware_versions_result.instance.supported_hardware_versions is defined
+    - get_hardware_versions_result.instance.default_hardware_version is defined
+  block:
     - name: "Set fact of ESXi server supported hardware versions and default hardware version"
       ansible.builtin.set_fact:
-        esxi_hardware_versions: "{{ get_hardware_versions_result.instance['Supported hardware versions'] | map('regex_replace', 'vmx-0?', '') | map('int') }}"
-        esxi_default_hardware_version: "{{ get_hardware_versions_result.instance['Default hardware version'] | regex_replace('vmx-0?', '') }}"
+        esxi_hardware_versions: "{{ get_hardware_versions_result.instance.supported_hardware_versions | map('regex_replace', 'vmx-0?', '') | map('int') }}"
+        esxi_default_hardware_version: "{{ get_hardware_versions_result.instance.default_hardware_version | regex_replace('vmx-0?', '') }}"
 
     - name: "Set fact of ESXi server latest hardware version"
       ansible.builtin.set_fact:
         esxi_latest_hardware_version: "{{ esxi_hardware_versions | max }}"
       when: esxi_hardware_versions | length > 0
-  when:
-    - get_hardware_versions_result is defined
-    - get_hardware_versions_result.instance is defined
-    - get_hardware_versions_result.instance['Supported hardware versions'] is defined
-    - get_hardware_versions_result.instance['Default hardware version'] is defined
 
-- ansible.builtin.debug:
+- name: "Display ESXi server supported hardware versions"
+  ansible.builtin.debug:
     msg:
       - "ESXi server supported hardware versions: {{ esxi_hardware_versions }}"
       - "ESXi server latest hardware version: {{ esxi_latest_hardware_version }}"


### PR DESCRIPTION
Fix #440 

Getting hardware versions:
```
2023-09-19 20:00:11,019 | TASK [test_debug][Display ESXi server supported hardware versions] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_hardware_versions.yml:43
ok: [localhost] => { 
    "msg": [
        "ESXi server supported hardware versions: [4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]",
        "ESXi server latest hardware version: 17", 
        "ESXi server default hardware version: 17"
    ]    
}
```

Tested with ESXi 7.0GA, getting guest ids and guest config options from xml file:
```
2023-09-19 20:00:16,019 | TASK [test_debug][Print ESXi server supported guest IDs on hardware version 17]
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_guest_ids.yml:65
ok: [localhost] => {
    "esxi_guest_ids": [
        "amazonlinux2_64Guest",
        "windows2019srv_64Guest",
        "windows9Server64Guest",
        "windows8Server64Guest",
        "windows7Server64Guest",
        "winLonghorn64Guest",
        "winLonghornGuest",
        "winNetEnterprise64Guest",
        "winNetEnterpriseGuest",
...

2023-09-19 20:00:24,019 | TASK [test_debug][Print guest id other4xLinux64Guest config options on hardware version 17] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_guest_config_options.yml:282
ok: [localhost] => {
    "guest_config_options": {
        "default_cdrom_controller": "ide",
        "default_cpu_number": 1,
        "default_disk_controller": "paravirtual",
        "default_ethernet": "vmxnet3",
        "default_secure_boot": "true",
        "default_usb_controller": null,
        "guest_fullname": "Other 4.x or later Linux (64-bit)",
        "guest_id": "other4xLinux64Guest",
        "hardware_version": "vmx-17",
        "rec_cpu_cores_per_socket": "1",
        "rec_cpu_socket": "1",
        "rec_disk_mb": "16384",
        "rec_firmware": "efi",
        "rec_memory_mb": "1024",
        "rec_persistent_memory": "8192",
        "rec_vram_kb": "4096",
        "support_disk_controller": [
            "paravirtual",
            "lsilogic",
            "lsilogicsas",
            "ide",
            "sata",
            "nvme"
        ],
        "support_ethernet_card": [
            "e1000e",
            "sriov",
            "vmxnet3",
            "pvrdma"
        ],
        "support_min_persistent_mem_mb": "4",
        "support_persistent_memory": "true",
        "support_secure_boot": "true",
        "support_tpm_20": "false",
        "support_usb_controller": [
            "usb2",
            "usb3"
        ]
    }
}
```

Tested with ESXi 8.0, getting guest ids and guest config options by ansible module:
```
2023-09-19 20:02:10,019 | TASK [test_debug][Print ESXi server supported guest IDs on hardware version 17] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_guest_ids.yml:65
ok: [localhost] => {
    "esxi_guest_ids": [
        "amazonlinux2_64Guest",
        "windows2019srv_64Guest",
        "windows9Server64Guest",
        "windows8Server64Guest",
        "windows7Server64Guest",
        "winLonghorn64Guest",
        "winLonghornGuest",
        "winNetEnterprise64Guest",
        "winNetEnterpriseGuest",
        "winNetDatacenter64Guest",
        "winNetDatacenterGuest",
        "winNetStandard64Guest",
        "winNetStandardGuest",
...

2023-09-19 20:02:13,019 | TASK [test_debug][Print guest id other4xLinux64Guest config options on hardware version 17] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_guest_config_options.yml:282
ok: [localhost] => {
    "guest_config_options": {
        "default_cdrom_controller": "",
        "default_cpu_number": 1,
        "default_disk_controller": "paravirtual",
        "default_ethernet": "vmxnet3",
        "default_secure_boot": true,
        "default_usb_controller": "",
        "guest_fullname": "Other 4.x or later Linux (64-bit)",
        "guest_id": "other4xLinux64Guest",
        "hardware_version": "vmx-17",
        "rec_cpu_cores_per_socket": 1,
        "rec_cpu_socket": 1,
        "rec_disk_mb": 16384,
        "rec_firmware": "efi",
        "rec_memory_mb": 1024,
        "rec_persistent_memory": 8192,
        "rec_vram_kb": 4096,
        "support_disk_controller": [
            "lsilogic",
            "paravirtual",
            "lsilogicsas",
            "sata",
            "nvme"
        ],
        "support_ethernet_card": [
            "vmxnet3",
            "e1000e",
            "sriov",
            "pvrdma"
        ],
        "support_min_persistent_mem_mb": 4,
        "support_persistent_memory": true,
        "support_secure_boot": true,
        "support_tpm_20": true,
        "support_usb_controller": [
            "usb2",
            "usb3"
        ]
    }
}
```