### PR TITLE
[Linux] Fix undefined variables at rescue or always block when test_setup failed

### DIFF
--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -65,7 +65,8 @@
           when: guest_os_ansible_distribution == "FreeBSD"
 
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml
       always:
         - name: "Dump inbox drivers versions into a json file"
           when:

--- a/linux/check_inbox_driver/check_inbox_driver.yml
+++ b/linux/check_inbox_driver/check_inbox_driver.yml
@@ -10,16 +10,16 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: "Initialized inbox drivers' versions dict"
-      ansible.builtin.set_fact:
-        inbox_drivers_versions: {}
-
     - name: "Test case block"
       block:
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
           vars:
             skip_test_no_vmtools: false
+
+        - name: "Initialized inbox drivers' versions dict"
+          ansible.builtin.set_fact:
+            inbox_drivers_versions: {}
 
         - name: "Get OS release"
           include_tasks: get_os_release.yml
@@ -59,7 +59,7 @@
         - name: "Get Linux inbox drivers"
           include_tasks: get_inbox_drivers.yml
           when: guest_os_ansible_distribution != "FreeBSD"
-        
+
         - name: "Get FreeBSD inbox drivers"
           include_tasks: get_freebsd_inbox_drivers.yml
           when: guest_os_ansible_distribution == "FreeBSD"
@@ -67,23 +67,28 @@
       rescue:
         - include_tasks: ../../common/test_rescue.yml
       always:
-        - name: "Print inbox drivers versions"
-          ansible.builtin.debug: var=inbox_drivers_versions
+        - name: "Dump inbox drivers versions into a json file"
+          when:
+            - inbox_drivers_versions is defined
+            - inbox_drivers_versions | length > 0
+          block:
+            - name: "Print inbox drivers versions"
+              ansible.builtin.debug: var=inbox_drivers_versions
 
-        - name: "Create test case log direcotry"
-          include_tasks: ../../common/create_directory.yml
-          vars:
-            dir_path: "{{ current_test_log_folder }}"
+            - name: "Create test case log direcotry"
+              include_tasks: ../../common/create_directory.yml
+              vars:
+                dir_path: "{{ current_test_log_folder }}"
 
-        - name: "Set fact of the output file path"
-          ansible.builtin.set_fact:
-            os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace('/','-').replace(' ','-') | lower }}.json"
+            - name: "Set fact of the output file path"
+              ansible.builtin.set_fact:
+                os_release_info_file_path: "{{ current_test_log_folder }}/{{ inbox_drivers_versions['Release'].replace('/','-').replace(' ','-') | lower }}.json"
 
-        - name: "The inbox drivers versions will be dump to a json file"
-          ansible.builtin.debug: var=os_release_info_file_path
+            - name: "The inbox drivers versions will be dump to a json file"
+              ansible.builtin.debug: var=os_release_info_file_path
 
-        - name: "Dump inbox drivers versions"
-          ansible.builtin.copy:
-            dest: "{{ os_release_info_file_path }}"
-            content: "{{ [inbox_drivers_versions] | to_nice_json }}"
-            mode: '0644'
+            - name: "Dump inbox drivers versions"
+              ansible.builtin.copy:
+                dest: "{{ os_release_info_file_path }}"
+                content: "{{ [inbox_drivers_versions] | to_nice_json }}"
+                mode: '0644'

--- a/linux/utils/freebsd_get_partition_info.yml
+++ b/linux/utils/freebsd_get_partition_info.yml
@@ -29,7 +29,13 @@
 
 - name: "Set fact of disk partition info"
   ansible.builtin.set_fact:
-    freebsd_geom_part_list: "{{ freebsd_geom_list | map(attribute='provider') | flatten }}"
+    freebsd_geom_part_list: >-
+      {{
+        freebsd_geom_list |
+        selectattr('provider', 'defined') |
+        map(attribute='provider') |
+        flatten
+      }}
 
 - name: "Set fact of disk partition info by name"
   ansible.builtin.set_fact:

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -50,3 +50,6 @@
           include_tasks: ../utils/collect_vgauth_logs.yml
           vars:
             vgauth_log_file_src: "{{ vgauth_latest_log_file }}"
+          when:
+            - vgauth_latest_log_file is defined
+            - vgauth_latest_log_file


### PR DESCRIPTION
If test case fails at test_setup, some variables used in rescue or always block may be not defined but used, which would lead to variable undefined error. This fix is to add conditions to use those variables.