### PR TITLE
[Linux] Update known issue condition for unmapped guest full name

### DIFF
--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -25,13 +25,8 @@
   block:
     # The unmapped guest full name which at least includes Linux kernel version, OS pretty name
     # For VM with newer VMware Tools, the unmapped guest full name also includes OS name, version id and build id
-    # Here we only check linux kernel version and OS pretty name
-    - name: "Set unmapped guest full name for {{ vm_guest_os_distribution }} on ESXi {{ esxi_version }}"
-      ansible.builtin.set_fact:
-        unmapped_guest_fullname: "Linux {{ guest_os_ansible_kernel }} {{ guest_os_release.PRETTY_NAME }}"
-      when: guest_os_release.PRETTY_NAME | default('')
-
-    - name: "Test passed"
+    # Here we only check linux kernel version, OS pretty name or distro name
+    - name: "Test passed with unmapped guest full name on ESXi {{ esxi_version }}"
       block:
         - name: "Guest OS full name is unmapped"
           ansible.builtin.debug:
@@ -45,8 +40,11 @@
         - name: "Test passed on ESXi {{ esxi_version }}"
           ansible.builtin.meta: end_host
       when:
-        - unmapped_guest_fullname is defined and unmapped_guest_fullname
-        - unmapped_guest_fullname in guestinfo_guest_full_name
+        - guest_os_ansible_kernel and guest_os_ansible_kernel in guestinfo_guest_full_name
+        - ((guest_os_release.PRETTY_NAME is defined and guest_os_release.PRETTY_NAME and
+            guest_os_release.PRETTY_NAME in guestinfo_guest_full_name) or
+           (guest_os_release.NAME is defined and guest_os_release.NAME and
+            guest_os_release.NAME in guestinfo_guest_full_name))
   when:
     - not guestinfo_guest_id
     - ((esxi_version is version('6.7.0', '==') and

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -21,35 +21,31 @@
 
 # If the guest os full name is unmapped and displays OS detailed data on ESXi 6.7 GA and Update 1,
 # or on ESXi 7.0.0, that's expected. Test passed.
-- name: "Check unmapped guest OS full name on ESXi {{ esxi_version }} when guest id is empty"
-  block:
-    # The unmapped guest full name which at least includes Linux kernel version, OS pretty name
-    # For VM with newer VMware Tools, the unmapped guest full name also includes OS name, version id and build id
-    # Here we only check linux kernel version, OS pretty name or distro name
-    - name: "Test passed with unmapped guest full name on ESXi {{ esxi_version }}"
-      block:
-        - name: "Guest OS full name is unmapped"
-          ansible.builtin.debug:
-            msg: >-
-              Guest id is '{{ guestinfo_guest_id }}' on ESXi {{ esxi_version }}, and
-              guest OS full name is '{{ guestinfo_guest_full_name }}',  which shows
-              guest OS detailed information and is as expected on ESXi {{ esxi_version }}.
-              Test Passed.
-          tags:
-            - known_issue
-        - name: "Test passed on ESXi {{ esxi_version }}"
-          ansible.builtin.meta: end_host
-      when:
-        - guest_os_ansible_kernel and guest_os_ansible_kernel in guestinfo_guest_full_name
-        - ((guest_os_release.PRETTY_NAME is defined and guest_os_release.PRETTY_NAME and
-            guest_os_release.PRETTY_NAME in guestinfo_guest_full_name) or
-           (guest_os_release.NAME is defined and guest_os_release.NAME and
-            guest_os_release.NAME in guestinfo_guest_full_name))
+# The unmapped guest full name which at least includes Linux kernel version, OS pretty name
+# For VM with newer VMware Tools, the unmapped guest full name also includes OS name, version id and build id
+# Here we only check linux kernel version, OS pretty name or distro name
+- name: "Test passed with unmapped guest full name on ESXi {{ esxi_version }}"
   when:
     - not guestinfo_guest_id
-    - ((esxi_version is version('6.7.0', '==') and
-        esxi_update_version | int < 2) or
+    - ((esxi_version is version('6.7.0', '==') and esxi_update_version | int < 2) or
        esxi_version is version('7.0.0', '=='))
+    - guest_os_ansible_kernel and guest_os_ansible_kernel in guestinfo_guest_full_name
+    - ((guest_os_release.PRETTY_NAME is defined and guest_os_release.PRETTY_NAME and
+      guest_os_release.PRETTY_NAME in guestinfo_guest_full_name) or
+      (guest_os_release.NAME is defined and guest_os_release.NAME and
+      guest_os_release.NAME in guestinfo_guest_full_name))
+  block:
+    - name: "Guest OS full name is unmapped"
+      ansible.builtin.debug:
+        msg: >-
+          Guest id is '{{ guestinfo_guest_id }}' on ESXi {{ esxi_version }}, and
+          guest OS full name is '{{ guestinfo_guest_full_name }}',  which shows
+          guest OS detailed information and is as expected on ESXi {{ esxi_version }}.
+          Test Passed.
+      tags:
+        - known_issue
+    - name: "Test passed on ESXi {{ esxi_version }}"
+      ansible.builtin.meta: end_host
 
 - name: "Check guest id in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
   ansible.builtin.assert:


### PR DESCRIPTION
Fix check_os_fullname for Flatcar on ESXi 7.0GA.

```
+---------------------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Flatcar 3602.2.0 x86_64                                                     |
+---------------------------------------------------------------------------------------------------------+
| GUI Installed             | False                                                                       |
+---------------------------------------------------------------------------------------------------------+
| CloudInit Version         |                                                                             |
+---------------------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-17                                                                      |
+---------------------------------------------------------------------------------------------------------+
| VMTools Version           | 12.2.0 (build-21223074)                                                     |
+---------------------------------------------------------------------------------------------------------+
| Config Guest Id           | other3xLinux64Guest                                                         |
+---------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        |                                                                             |
+---------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Linux 5.15.133-flatcar Flatcar Container Linux by Kinvolk 3602.2.0 3602.2.0 |
|                           | 2023-10-02-1812 Flatcar Container Linux by Kinvolk 3602.2.0 (Oklo)          |
|                           | cpe:2.3:o:flatcar-linux:flatcar_linux:3602.2.0:*:*:*:*:*:*:*                |
+---------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                                  |
+---------------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                          |
|                           | bitness='64'                                                                |
|                           | buildNumber='2023-10-02-1812'                                               |
|                           | cpeString='cpe:2.3:o:flatcar-linux:flatcar_linux:3602.2.0:*:*:*:*:*:*:*'    |
|                           | distroAddlVersion='3602.2.0'                                                |
|                           | distroName='Flatcar Container Linux by Kinvolk'                             |
|                           | distroVersion='3602.2.0'                                                    |
|                           | familyName='Linux'                                                          |
|                           | kernelVersion='5.15.133-flatcar'                                            |
|                           | prettyName='Flatcar Container Linux by Kinvolk 3602.2.0 (Oklo)'             |
+---------------------------------------------------------------------------------------------------------+


Test Results (Total: 3, Passed: 2, Skipped: 1, Elapsed Time: 00:07:13)
+-------------------------------------------------------+
| ID | Name               |   Status        | Exec Time |
+-------------------------------------------------------+
|  1 | deploy_vm_ova      |   Passed        | 00:05:11  |
|  2 | ovt_verify_install | * Not Supported | 00:00:58  |
|  3 | check_os_fullname  |   Passed        | 00:00:46  |
+-------------------------------------------------------+
```