### PR TITLE
[FreeBSD 13] Cannot mix incompatible Qt library (5.15.8) with this library (5.15.10)

### DIFF
--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -65,7 +65,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 for package_to_install in $packages_to_install
 do
-    echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
+    echo "Install package $package_to_install ..." > /dev/ttyu0
     env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
     ret=$?
     if [ $ret == 0 ]

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -62,7 +62,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
-packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
+packages_to_install='bash sudo xorg xf86-video-vmware'
 for package_to_install in $packages_to_install
 do
     echo "Install package $package_to_install ..." > /dev/ttyu0
@@ -79,7 +79,7 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 for package_to_install in $packages_to_install
 do
     ret=1

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -65,7 +65,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 for package_to_install in $packages_to_install
 do
-    echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
+    echo "Install package $package_to_install ..." > /dev/ttyu0
     env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
     ret=$?
     if [ $ret == 0 ]


### PR DESCRIPTION
Issue:
----------------
2023-10-12 03:58:05,012 | TASK [2_ovt_verify_status][Check process 'vmtoolsd -n vmusr' is running] 
task path: /home/worker/workspace/Ansible_Cycle_FreeBSD_13.x_64bit/ansible-vsphere-gos-validation/linux/utils/check_process_status.yml:34
fatal: [localhost]: FAILED! => {
    "assertion": "running_process_info | length >= 1",
    "changed": false,
    "evaluated_to": false,
    "msg": "User 'vmware' doesn't have running process 'vmtoolsd -n vmusr'"
}
error message:
User 'vmware' doesn't have running process 'vmtoolsd -n vmusr'


Root Cause
-----------------------
KDE5 is installed from ISO with use Qt library (5.15.8)
SDDM is installed from offical repo which use Qt (5.15.10)

The service SDDM is failed to start during bootup.

Check the sddm log: (/var/log/sddm.log)
[05:49:38.184] (II) DAEMON: Initializing...
[05:49:38.190] (EE) DAEMON: Cannot mix incompatible Qt library (5.15.8) with this library (5.15.10)


Resolution:
---------------------
Install kde5 and sddm from same repo (offical repo)


Result:
--------------------
test pass
 
<img width="829" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/283e7178-f0a3-4535-85ac-1eac6b5ae6da">
 