### PR TITLE
[Linux] Print more installer logs for Debian installer at early and late commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ pip install -r requirements.txt
 ```
 $ ansible-galaxy install -r requirements.yml
 ```
-4. Log in to local control machine as root or a user in sudoers
+4. Log in to local control machine as root or a user in sudoers, which must enable NOPASSWD for all commands
 
 ### Steps to Launch Testing
 1. Git clone project from github to your workspace on control machine.

--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -2,12 +2,17 @@
 #### Contents of the preconfiguration file (for bullseye)
 ### Localization
 # Preseeding only locale sets language, country and locale.
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 
 # The values can also be preseeded individually for greater flexibility.
 d-i debian-installer/language string en
 d-i debian-installer/country string US
-#d-i debian-installer/locale string en_GB.UTF-8
+
+# Use the following option to add additional boot parameters for the
+# installed system (if supported by the bootloader installer).
+# Note: options passed to the installer will be added automatically.
+# d-i debian-installer/add-kernel-opts string consoleblank=0
+
 # Optionally specify additional locales to be generated.
 d-i localechooser/supported-locales multiselect en_US.UTF-8
 
@@ -56,6 +61,7 @@ d-i netcfg/wireless_wep string
 ### Account setup
 # Root password encrypted using a crypt(3)  hash.
 d-i passwd/root-password-crypted password {{ vm_password_hash }}
+d-i passwd/root-login boolean true
 
 {% if new_user is defined and new_user != 'root' %}
 # To create a normal user account.
@@ -159,11 +165,10 @@ d-i apt-setup/enable-source-repositories boolean false
 
 ### Package selection
 #tasksel tasksel/first multiselect standard, web-server, kde-desktop
-tasksel tasksel/first multiselect standard, desktop
-tasksel tasksel/desktop multiselect gnome
+tasksel tasksel/first multiselect standard, desktop, gnome-desktop, ssh-server
 
 # Individual additional packages to install
-d-i pkgsel/include string build-essential vim locales openssh-server sg3-utils
+d-i pkgsel/include string build-essential vim locales sg3-utils wget
 # There is no open-vm-tools-desktop and cloud-init in CDROM of Debian 10 & 11
 # There is no open-vm-tools in CDROM of Debian 12
 # These packages will be installed in late_command
@@ -202,15 +207,6 @@ d-i debian-installer/exit/poweroff boolean true
 # which is useful in some situations.
 #d-i cdrom-detect/eject boolean false
 
-### Preseeding other packages
-# Depending on what software you choose to install, or if things go wrong
-# during the installation process, it's possible that other questions may
-# be asked. You can preseed those too, of course. To get a list of every
-# possible question that could be asked during an install, do an
-# installation, and then run these commands:
-   debconf-get-selections --installer > /target/root/preceed.cfg
-   debconf-get-selections >> /target/root/preceed.cfg
-
 #### Advanced options
 ### Running custom commands during the installation
 # d-i preseeding is inherently not secure. Nothing in the installer checks
@@ -220,54 +216,21 @@ d-i debian-installer/exit/poweroff boolean true
 # here's a way to run any shell command you'd like inside the installer,
 # automatically.
 
+# This first command is run as early as possible, just after
+# preseeding is read.
+d-i preseed/early_command string \
+    echo "Executing early command" >/dev/ttyS0; \
+    cp -a /cdrom/{{ pre_install_script_file }} /root/{{ pre_install_script_file }}; \
+    /bin/sh /root/{{ pre_install_script_file }} >/dev/ttyS0;
+
 # This command is run just before the install finishes, but when there is
 # still a usable /target directory. You can chroot to /target and use it
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
 d-i preseed/late_command string \
-{% if new_user is defined and new_user != 'root' %}
-    echo "Add new user {{ new_user }}" >/target/dev/ttyS0; \
-    echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/target/etc/sudoers.d/{{ new_user }}; \
-    echo "Add SSH authorized keys for user {{ new_user }}" >/target/dev/ttyS0; \
-    mkdir -p -m 700 /target/home/{{ new_user }}/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/home/{{ new_user }}/.ssh/authorized_keys; \
-    chown --recursive {{ new_user }}:{{ new_user }} /target/home/{{ new_user }}/.ssh; \
-    chmod 0644 /target/home/{{ new_user }}/.ssh/authorized_keys; \
-{% endif %}
-    echo "Add SSH authorized keys for root" >/target/dev/ttyS0; \
-    mkdir -p -m 700 /target/root/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/root/.ssh/authorized_keys; \
-    chown --recursive root:root /target/root/.ssh; \
-    chmod 0644 /target/root/.ssh/authorized_keys; \
-    if [ -f "/target/etc/os-release" ]; then \
-        version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | tr -d '"'); \
-        codename=$(cat /target/etc/os-release | grep VERSION_CODENAME | cut -d '=' -f 2 | tr -d '"'); \
-        echo "Debian release version is $version, codename is $codename" > /target/dev/ttyS0; \
-        search_ovt=$(in-target apt search open-vm-tools 2>/dev/null); \
-        printf "Search open-vm-tools packages in CDROM:\n$search_ovt" >/target/dev/ttyS0; \
-        if [ "$search_ovt" != "" ]; then \
-            echo "Install open-vm-tools from CDROM" > /target/dev/ttyS0; \
-            in-target apt install -y open-vm-tools >/dev/ttyS0; \
-        fi; \
-        echo "Add offical online repo ..." > /target/dev/ttyS0; \
-        echo "deb http://deb.debian.org/debian/ $codename main contrib" >> /target/etc/apt/sources.list; \
-        echo "Display APT source list" >/target/dev/ttyS0; \
-        cat /target/etc/apt/sources.list >/target/dev/ttyS0; \
-        echo "Update list of available packages" > /target/dev/ttyS0; \
-        in-target apt update >/dev/ttyS0; \
-        if [ "$search_ovt" == "" ]; then \
-            echo "Install open-vm-tools from online repo" > /target/dev/ttyS0; \
-            in-target apt install -y open-vm-tools >/dev/ttyS0; \
-        fi;\
-        echo "Install testing required packages from online repo" >/target/dev/ttyS0; \
-        in-target apt install -y open-vm-tools-desktop cloud-init \
-        locales-all rdma-core rdmacm-utils ibverbs-utils >/dev/ttyS0; \
-    fi; \
-    gnome_initial_cfg="/target/etc/xdg/autostart/gnome-initial-setup-first-login.desktop"; \
-    if [ -f "$gnome_initial_cfg" ]; then \
-        echo "Disable GNOME initial setup at first login" >/target/dev/ttyS0; \
-        sed -i "s/^X-GNOME-HiddenUnderSystemd *=.*/X-GNOME-HiddenUnderSystemd=false/" $gnome_initial_cfg; \
-    fi; \
-    in-target sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config; \
-    in-target sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config; \
-    echo "{{ autoinstall_complete_msg }}" >/target/dev/ttyS0
+    echo "Executing late command" >/dev/ttyS0; \
+    cp -a /cdrom/{{ post_install_script_file }} /target/root/{{ post_install_script_file }}; \
+    in-target /bin/bash /root/{{ post_install_script_file }}; \
+    echo "Dump installer log:"; \
+    cat /var/log/syslog >/dev/ttyS0; \
+    echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0;

--- a/autoinstall/Pardus/preseed.cfg
+++ b/autoinstall/Pardus/preseed.cfg
@@ -160,7 +160,7 @@ tasksel tasksel/desktop multiselect xfce
 
 # Individual additional packages to install
 # There is no open-vm-tools-desktop openssh-server and cloud-init in CDROM
-#d-i pkgsel/include string build-essential open-vm-tools openssh-server sg3-utils vim
+d-i pkgsel/include string perl
 
 # Policy for applying updates. May be "none" (no automatic updates),
 # "unattended-upgrades" (install security updates automatically), or
@@ -194,16 +194,14 @@ d-i debian-installer/exit/poweroff boolean true
 
 # This will prevent the installer from ejecting the CD during the reboot,
 # which is useful in some situations.
-#d-i cdrom-detect/eject boolean true
+#d-i cdrom-detect/eject boolean false
 
-### Preseeding other packages
-# Depending on what software you choose to install, or if things go wrong
-# during the installation process, it's possible that other questions may
-# be asked. You can preseed those too, of course. To get a list of every
-# possible question that could be asked during an install, do an
-# installation, and then run these commands:
-   debconf-get-selections --installer > /target/root/preceed.cfg
-   debconf-get-selections >> /target/root/preceed.cfg
+# This first command is run as early as possible, just after
+# preseeding is read.
+d-i preseed/early_command string \
+    echo "Executing early command" >/dev/ttyS0; \
+    cp -a /cdrom/{{ pre_install_script_file }} /root/{{ pre_install_script_file }}; \
+    /bin/sh /root/{{ pre_install_script_file }} >/dev/ttyS0;
 
 # This command is run just before the install finishes, but when there is
 # still a usable /target directory. You can chroot to /target and use it
@@ -211,52 +209,9 @@ d-i debian-installer/exit/poweroff boolean true
 # packages and run commands in the target system.
 # The packages not available in CDROM will be installed from online repo.
 d-i preseed/late_command string \
-    echo "Check network ..." > /target/dev/ttyS0; \
-    ip addr show > /target/dev/ttyS0; \
-    echo "Linkup network ..." > /target/dev/ttyS0; \
-    chroot /target /sbin/ifconfig $(/sbin/ifconfig -a | grep '^[a-z]' | cut -d: -f1 | head -n 1) up; \
-    sleep 5; \
-    echo "Check network after linkup ..." > /target/dev/ttyS0; \
-    ip addr show > /target/dev/ttyS0; \
-    echo "Check file /etc/apt/sources.list ..." > /target/dev/ttyS0; \
-    cat /target/etc/apt/sources.list > /target/dev/ttyS0; \
-    if [ -f "/target/etc/os-release" ];\
-        then\
-            echo "Add offical repo ..." > /target/dev/ttyS0;\
-            codename=$(cat /target/etc/os-release | grep PARDUS_CODENAME | cut -d= -f2);\
-            major_version=$(cat /target/etc/os-release | grep VERSION_ID | cut -d= -f2 | tr -d '"' | cut -d. -f1);\
-            if [ $major_version -ge 23 ]; then\
-                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
-                echo "deb http://depo.pardus.org.tr/pardus ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
-                echo "deb http://depo.pardus.org.tr/guvenlik ${codename}-deb main contrib non-free non-free-firmware" >> /target/etc/apt/sources.list;\
-            else\
-                echo "deb http://depo.pardus.org.tr/pardus $codename main contrib non-free" >> /target/etc/apt/sources.list;\
-                echo "deb http://depo.pardus.org.tr/guvenlik $codename main contrib non-free" >> /target/etc/apt/sources.list;\
-            fi; \
-            cat /target/etc/apt/sources.list > /target/dev/ttyS0;\
-    fi; \
-    echo "Update repository ..." > /target/dev/ttyS0; \
-    chroot /target apt-get update -y > /dev/ttyS0; \
-    echo "Install openssh-server ..." > /target/dev/ttyS0; \
-    chroot /target apt-get install -y --no-upgrade openssh-server > /dev/ttyS0; \
-    echo "Install packages ..." > /target/dev/ttyS0; \
-    chroot /target apt-get install -y --force-yes build-essential open-vm-tools sg3-utils vim perl python3-apt dbus > /dev/ttyS0; \
-    if [ -f "/target/usr/bin/Xorg" ];\
-        then\
-            echo "Install package open-vm-tools-desktop ..." > /target/dev/ttyS0;\
-            chroot /target apt-get install -y open-vm-tools-desktop > /target/dev/ttyS0;\
-    fi; \
-    {% if new_user is defined and new_user != 'root' %}
-    echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/target/etc/sudoers.d/{{ new_user }}; \
-    mkdir -p -m 700 /target/home/{{ new_user }}/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/home/{{ new_user }}/.ssh/authorized_keys; \
-    {% endif %}
-    mkdir -p -m 700 /target/root/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/root/.ssh/authorized_keys; \
-    chown --recursive root:root /target/root/.ssh; \
-    chmod 0644 /target/root/.ssh/authorized_keys; \
-    echo "Config sshd to enable root login ..." > /target/dev/ttyS0; \
-    touch /target/etc/ssh/sshd_config.d/root.conf; \
-    echo "PasswordAuthentication yes" >> /target/etc/ssh/sshd_config.d/root.conf; \
-    echo "PermitRootLogin yes" >> /target/etc/ssh/sshd_config.d/root.conf; \
-    echo "{{ autoinstall_complete_msg }}" > /target/dev/ttyS0
+    echo "Executing late command" >/dev/ttyS0; \
+    cp -a /cdrom/{{ post_install_script_file }} /target/root/{{ post_install_script_file }}; \
+    in-target /bin/bash /root/{{ post_install_script_file }}; \
+    echo "Dump installer log:"; \
+    cat /var/log/syslog >/dev/ttyS0; \
+    echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0;

--- a/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
+++ b/autoinstall/Ubuntu/Desktop/Ubiquity/ubuntu.seed
@@ -1,5 +1,6 @@
 ### Step 1 : Localization
-d-i debian-installer/locale string en_US
+#d-i debian-installer/locale string en_US
+d-i debian-installer/language string en
 ubiquity languagechooser/language-name select English (US)
 ubiquity countrychooser/shortlist select US
 ubiquity localechooser/supported-locales multiselect en_US.UTF8
@@ -42,6 +43,7 @@ d-i passwd/root-login boolean true
 d-i passwd/root-password-crypted password {{ vm_password_md5 }}
 d-i user-setup/allow-password-weak boolean true
 
+# Package selection
 d-i pkgsel/language-packs multiselect en, zh
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select none
@@ -52,30 +54,26 @@ d-i pkgsel/upgrade select none
 d-i pkgsel/updatedb boolean false
 
 d-i finish-install/keep-consoles boolean true
-
 # Bootloader
 # This is fairly safe to set, it makes grub install automatically to the MBR
 # if no other operating system is detected on the machine.
 d-i grub-installer/only_debian boolean true
 
-# Install package
+# This first command is run as early as possible, just after
+# preseeding is read.
+d-i preseed/early_command string \
+    echo "Executing early command" >/dev/ttyS0; \
+    cp -a /cdrom/preseed/{{ pre_install_script_file }} /root/{{ pre_install_script_file }}; \
+    /bin/sh /root/{{ pre_install_script_file }} >/dev/ttyS0;
+
+# Execute post install script on success
 ubiquity ubiquity/success_command \
-    in-target apt-get update -y; \
-    in-target apt-get install -y --force-yes build-essential vim locales cloud-init openssh-server open-vm-tools open-vm-tools-desktop rdma-core rdmacm-utils ibverbs-utils; \
-{% if new_user is defined and new_user != 'root' %}
-    in-target su root; \
-    in-target echo "{{ vm_password }}"; \
-    echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/target/etc/sudoers.d/{{ new_user }}; \
-    mkdir -p -m 700 /target/home/{{ new_user }}/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/home/{{ new_user }}/.ssh/authorized_keys; \
-{% endif %}
-    mkdir -p -m 700 /target/root/.ssh; \
-    echo "{{ ssh_public_key }}" > /target/root/.ssh/authorized_keys; \
-    in-target chown --recursive root:root /root/.ssh; \
-    in-target chmod 0644 /root/.ssh/authorized_keys; \
-    in-target sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config; \
-    in-target sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config; \
-    echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
+    echo "Executing Ubiquity success command" >/dev/ttyS0; \
+    cp -a /cdrom/preseed/{{ post_install_script_file }} /target/root/{{ post_install_script_file }}; \
+    in-target /bin/bash /root/{{ post_install_script_file }}; \
+    echo "Dump installer log:" >/dev/ttyS0; \
+    cat /var/log/syslog >/dev/ttyS0; \
+    echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0;
 
 d-i finish-install/reboot_in_progress note
 d-i cdrom-detect/eject boolean true

--- a/common/delete_local_file.yml
+++ b/common/delete_local_file.yml
@@ -9,6 +9,7 @@
   ansible.builtin.file:
     path: "{{ local_path }}"
     state: absent
+  become: true
   register: delete_local_file_result
   ignore_errors: "{{ del_local_file_ignore_errors | default(false) }}"
 

--- a/common/delete_local_file.yml
+++ b/common/delete_local_file.yml
@@ -2,14 +2,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Task to remove local directory or file
+# Parameters:
+#   local_path: The local path to the directory or file to remove
+#
 - name: "Remove local path {{ local_path }}"
   ansible.builtin.file:
     path: "{{ local_path }}"
     state: absent
-  become: true
   register: delete_local_file_result
   ignore_errors: "{{ del_local_file_ignore_errors | default(false) }}"
 
-- name: Display the result of file removing
+- name: "Display the result of removing local directory or file"
   ansible.builtin.debug: var=delete_local_file_result
-  when: enable_debug is defined and enable_debug
+  when: enable_debug

--- a/common/vm_get_video_card.yml
+++ b/common/vm_get_video_card.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Gather information about VM video cart settings
+- name: "Gather information about VM video card settings"
   community.vmware.vmware_guest_video:
     hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"
@@ -10,7 +10,7 @@
     datacenter: "{{ vsphere_host_datacenter }}"
     name: "{{ vm_name }}"
     gather_video_facts: true
-  register: vm_video_cart_facts
+  register: vm_video_card_facts
 
-- name: Display VM video cart settings fact
-  ansible.builtin.debug: var=vm_video_cart_facts
+- name: "Display VM video card settings fact"
+  ansible.builtin.debug: var=vm_video_card_facts

--- a/common/vm_set_video_card.yml
+++ b/common/vm_set_video_card.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Configure VM video cart settings
+- name: "Configure VM video card settings"
   community.vmware.vmware_guest_video:
     hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"
@@ -13,7 +13,7 @@
     use_auto_detect: "{{ auto_detect | default(omit) }}"
     display_number: "{{ display_number | default(omit) }}"
     video_memory_mb: "{{ video_memory_mb | default(omit) }}"
-  register: vm_video_cart_facts
+  register: vm_video_card_facts
 
-- name: Display VM video cart settings fact
-  ansible.builtin.debug: var=vm_video_cart_facts
+- name: "Display VM video card settings fact"
+  ansible.builtin.debug: var=vm_video_card_facts

--- a/linux/deploy_vm/collect_vm_logs.yml
+++ b/linux/deploy_vm/collect_vm_logs.yml
@@ -24,8 +24,8 @@
         - name: "Get VM's guest info"
           include_tasks: ../../common/vm_get_guest_info.yml
           when:
-            - unattend_install_conf is defined
-            - unattend_install_conf | lower is not match('.*bclinux-for-euler.*')
+            - unattend_installer is defined
+            - unattend_installer != "BCLinux-for-Euler"
             - vmtools_is_running
 
         - name: "Collect cloud-init logs"
@@ -33,8 +33,7 @@
           when:
             - guestinfo_guest_id is defined
             - ((guestinfo_guest_id is match('ubuntu.*') and
-                unattend_install_conf is defined and
-                (unattend_install_conf is match('Ubuntu/Server/') or
-                 unattend_install_conf is match('Ubuntu/Desktop/Subiquity'))) or
+                unattend_installer is defined and
+                unattend_installer == 'Ubuntu-Subiquity') or
                (ova_guest_os_type is defined and
                 ova_guest_os_type in ['photon', 'ubuntu', 'amazon']))

--- a/linux/deploy_vm/create_unattend_install_conf_file.yml
+++ b/linux/deploy_vm/create_unattend_install_conf_file.yml
@@ -1,0 +1,39 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Create unattend install config file, and pre-install, post-install scripts
+# Parameters:
+#   extractor_log_path: The local log file path to extract call trace
+# Return:
+#   extractor_call_trace: The call trace extracted from the image file
+#
+- name: "Set facts of pre-install and post-install script files"
+  ansible.builtin.set_fact:
+    autoinstall_start_msg: "Autoinstall is started"
+    pre_install_script_file: "preseed_early_command.sh"
+    post_install_script_file: "preseed_late_command.sh"
+  when: unattend_installer in ['Ubuntu-Ubiquity', "Debian", "Pardus"]
+
+- name: "Create OS pre-install script"
+  ansible.builtin.template:
+    src: "templates/pre_install_scripts/{{ pre_install_script_file }}"
+    dest: "{{ unattend_iso_cache }}/{{ pre_install_script_file }}"
+    mode: "0755"
+  when:
+    - pre_install_script_file is defined
+    - pre_install_script_file
+
+- name: "Create OS post-install script"
+  ansible.builtin.template:
+    src: "templates/post_install_scripts/{{ post_install_script_file }}"
+    dest: "{{ unattend_iso_cache }}/{{ post_install_script_file }}"
+    mode: "0755"
+  when:
+    - post_install_script_file is defined
+    - post_install_script_file
+
+- name: "Create OS unattend install config file"
+  ansible.builtin.template:
+    src: "{{ unattend_install_template }}"
+    dest: "{{ new_unattend_install_conf }}"
+    mode: "0644"

--- a/linux/deploy_vm/create_unattend_install_conf_file.yml
+++ b/linux/deploy_vm/create_unattend_install_conf_file.yml
@@ -1,11 +1,7 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Create unattend install config file, and pre-install, post-install scripts
-# Parameters:
-#   extractor_log_path: The local log file path to extract call trace
-# Return:
-#   extractor_call_trace: The call trace extracted from the image file
+# Create pre-install script, post-install script and unattend install config file
 #
 - name: "Set facts of pre-install and post-install script files"
   ansible.builtin.set_fact:

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -14,14 +14,6 @@
   ansible.builtin.debug:
     msg: "The unattend install config file template is {{ unattend_install_template }}"
 
-- name: "Create temp folder for generating unattend install ISO file"
-  include_tasks: ../../common/create_temp_file_dir.yml
-  vars:
-    tmp_dir: "{{ local_cache }}"
-    tmp_state: "directory"
-    tmp_prefix: "unattend_iso_"
-
-# unattend_iso_cache is the local cache for creating unattend config files and ISOs
 # new_unattend_install_conf is the local file name of unattend install config file created from template
 # unattend_iso_file_name and unattend_iso_file_path are the new generated unattend install ISO file name and path,
 #   which is used by OS in RHEL family, SUSE family, etc and Ubuntu Desktop or Server using Subiquity installer.
@@ -33,7 +25,6 @@
 #   and no separate unattend install ISO needed.
 - name: "Initialize facts for unattend install config files and ISO files"
   ansible.builtin.set_fact:
-    unattend_iso_cache: "{{ tmp_path }}"
     new_unattend_install_conf: "{{ tmp_path }}/{{ unattend_install_template | basename }}"
     unattend_iso_file_name: ""
     unattend_iso_file_path: ""
@@ -161,20 +152,3 @@
     os_installation_iso_list: "{{ os_installation_iso_list + ['[' ~ datastore ~ '] ' ~ unattend_iso_file_name] }}"
     os_install_iso_list_len: "{{ os_install_iso_list_len | int + 1 }}"
   when: unattend_iso_file_name
-
-- name: "Remove ISO files from local cache folder {{ unattend_iso_cache }}"
-  include_tasks: ../../common/delete_local_file.yml
-  vars:
-    local_path: "{{ unattend_iso_cache }}/{{ item }}"
-  with_items: "{{ transferred_unattend_iso_list }}"
-
-- name: "Copy unattend install config files in cache folder to test log folder"
-  ansible.builtin.copy:
-    src: "{{ unattend_iso_cache }}/"
-    dest: "{{ current_test_log_folder }}/"
-  when: unattend_install_conf is not match('Ubuntu/Server/')
-
-- name: "Remove local cache folder {{ unattend_iso_cache }}"
-  include_tasks: ../../common/delete_local_file.yml
-  vars:
-    local_path: "{{ unattend_iso_cache }}"

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -1,28 +1,49 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of the absolute path to unattend install config file template"
+- name: "Set facts of the absolute path to unattend install config file template and installer type"
   ansible.builtin.set_fact:
     unattend_install_template: "{{ main_playbook_path }}/autoinstall/{{ unattend_install_conf }}"
+    unattend_installer: |-
+      {%- if unattend_install_conf is match('Ubuntu/Desktop/Ubiquity') -%}Ubuntu-Ubiquity
+      {%- elif unattend_install_conf is match('(Ubuntu/Server)|(Ubuntu/Desktop/Subiquity)') -%}Ubuntu-Subiquity
+      {%- else -%}{{ unattend_install_conf.split('/')[0] }}
+      {%- endif -%}
 
-- ansible.builtin.debug:
-    msg:
-      - "The unattend install config file is {{ unattend_install_template }}"
+- name: "Display unattend install config file template"
+  ansible.builtin.debug:
+    msg: "The unattend install config file template is {{ unattend_install_template }}"
+
+- name: "Create temp folder for generating unattend install ISO file"
+  include_tasks: ../../common/create_temp_file_dir.yml
+  vars:
+    tmp_dir: "{{ local_cache }}"
+    tmp_state: "directory"
+    tmp_prefix: "unattend_iso_"
+
+# unattend_iso_cache is the local cache for creating unattend config files and ISOs
+# new_unattend_install_conf is the local file name of unattend install config file created from template
+# unattend_iso_file_name and unattend_iso_file_path are the new generated unattend install ISO file name and path,
+#   which is used by OS in RHEL family, SUSE family, etc and Ubuntu Desktop or Server using Subiquity installer.
+#   Their automatic install needs 2 ISOs: one is the OS image ISO, and the other is the new generated unattend install
+#   ISO with unattend install config file in
+# new_os_installation_iso and new_os_installation_iso_path are the rebuilt OS ISO image file and path
+#   which is used by OS like Photon, Debian, Pardus, FreeBSD, Ubuntu Desktop using Ubiquity installer, etc.
+#   Their automatic install needs to rebuild OS image from original one by packing unattend install config file in it,
+#   and no separate unattend install ISO needed.
+- name: "Initialize facts for unattend install config files and ISO files"
+  ansible.builtin.set_fact:
+    unattend_iso_cache: "{{ tmp_path }}"
+    new_unattend_install_conf: "{{ tmp_path }}/{{ unattend_install_template | basename }}"
+    unattend_iso_file_name: ""
+    unattend_iso_file_path: ""
+    new_os_installation_iso: ""
+    new_os_installation_iso_path: ""
 
 # unattend_install_conf is not for Ubuntu Server, Ubuntu Desktop 23.04 and later
-- block:
-    - name: "Create temp folder for generating unattend install ISO file"
-      include_tasks: ../../common/create_temp_file_dir.yml
-      vars:
-        tmp_dir: "{{ local_cache }}"
-        tmp_state: "directory"
-        tmp_prefix: "unattend_iso_"
-
-    - name: "Set facts of unattend install cache and file names"
-      ansible.builtin.set_fact:
-        unattend_iso_cache: "{{ tmp_path }}"
-        unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ lookup('pipe','date +%s') }}.iso"
-
+- name: "Create unattend install ISO for {{ unattend_installer }}"
+  when: unattend_installer != "Ubuntu-Subiquity"
+  block:
     - name: "Set fact about installing desktop"
       ansible.builtin.set_fact:
         install_guest_with_desktop: true
@@ -30,141 +51,130 @@
         - guest_id in ['rhel8_64Guest', 'rhel9_64Guest']
         - unattend_install_conf is match('RHEL/8/server_with_GUI/')
 
-    - name: "Set fact of the absolute path of unattend install config file and ISO"
-      ansible.builtin.set_fact:
-        new_unattend_install_conf: "{{ unattend_iso_cache }}/{{ unattend_install_template.split('/')[-1] }}"
-        generated_unattend_iso: "{{ unattend_iso_cache }}/{{ unattend_iso_file_name }}"
-
-    - ansible.builtin.debug:
-        msg:
-          - "The unattend install config file to be generated is {{ new_unattend_install_conf }}"
-
     # For nvme boot disk, boot device name shoule be nvme0n1 instead of sda
     - name: "Set boot disk name"
       ansible.builtin.set_fact:
         boot_disk_name: "{{ 'nvme0n1' if boot_disk_controller == 'nvme' else 'sda' }}"
 
-    - name: "Create unattend config file from template"
-      ansible.builtin.template:
-        src: "{{ unattend_install_template }}"
-        dest: "{{ new_unattend_install_conf }}"
-        mode: "0644"
+    - name: "Create unattend install config file"
+      include_tasks: create_unattend_install_conf_file.yml
 
-    - name: "Print the content of unattend install config file"
-      ansible.builtin.debug:
-        msg: "{{ lookup('file', new_unattend_install_conf) | split('\n') }}"
+    - name: "Create unattend install ISO file for {{ unattend_installer }}"
+      when: unattend_installer not in ['Ubuntu-Ubiquity', 'Photon', 'Debian', 'FreeBSD', 'Pardus']
+      block:
+        - name: "Set fact of generated unattend install ISO file name"
+          ansible.builtin.set_fact:
+            unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ timestamp }}.iso"
 
-    - name: "Create a guest OS unattend install ISO file"
-      include_tasks: ../../common/create_iso.yml
-      vars:
-        create_iso_src: ["{{ new_unattend_install_conf }}"]
-        create_iso_dest: "{{ generated_unattend_iso }}"
-        create_iso_vol_ident: 'OEMDRV'
-      when:
-        - unattend_install_conf is not match('Photon')
-        - unattend_install_conf is not match('Debian')
-        - unattend_install_conf is not match('Ubuntu/Desktop/Ubiquity')
-        - unattend_install_conf is not match('FreeBSD')
-        - unattend_install_conf is not match('Pardus')
+        - name: "Set fact of the local path to new generated unattend install ISO"
+          ansible.builtin.set_fact:
+            unattend_iso_file_path: "{{ unattend_iso_cache }}/{{ unattend_iso_file_name }}"
 
-    - name: "Build unattend install config file into OS ISO image"
-      include_tasks: rebuild_unattend_install_iso.yml
-      vars:
-        rebuilt_unattend_iso_path: "{{ generated_unattend_iso }}"
-      when: >
-        unattend_install_conf is match('Photon') or
-        unattend_install_conf is match('Debian') or
-        unattend_install_conf is match('Ubuntu/Desktop/Ubiquity') or
-        unattend_install_conf is match('FreeBSD') or
-        unattend_install_conf is match('Pardus')
-  when:
-    - unattend_install_conf is not match('Ubuntu/Server/')
-    - unattend_install_conf is not match('Ubuntu/Desktop/Subiquity')
+        - name: "Create unattend install ISO file for {{ unattend_installer }}"
+          include_tasks: ../../common/create_iso.yml
+          vars:
+            create_iso_src: ["{{ new_unattend_install_conf }}"]
+            create_iso_dest: "{{ unattend_iso_file_path }}"
+            create_iso_vol_ident: 'OEMDRV'
+
+    - name: "Rebuild OS installation ISO for {{ unattend_installer }}"
+      when: unattend_installer in ['Ubuntu-Ubiquity', 'Photon', 'Debian', 'FreeBSD', 'Pardus']
+      block:
+        - name: "Set fact of the rebuilt new OS installation ISO file name"
+          ansible.builtin.set_fact:
+            new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ timestamp }}.iso"
+
+        - name: "Set fact of the local path to the rebuilt OS installation ISO file"
+          ansible.builtin.set_fact:
+            new_os_installation_iso_path: "{{ unattend_iso_cache }}/{{ new_os_installation_iso }}"
+
+        - name: "Rebuild OS ISO image with unattend install config file built-in for {{ unattend_installer }}"
+          include_tasks: rebuild_unattend_install_iso.yml
+          vars:
+            rebuilt_unattend_iso_path: "{{ new_os_installation_iso_path }}"
 
 # unattend_install_conf is for Ubuntu Server / Ubuntu desktop 23.04 or later
-- block:
+- name: "Create unattend install ISO for Ubuntu Server, Ubuntu desktop 23.04 or later"
+  when: unattend_installer == "Ubuntu-Subiquity"
+  block:
     - name: "Set fact for autoinstall start message to be printed to VM serial port"
       ansible.builtin.set_fact:
         autoinstall_start_msg: "Ubuntu autoinstall is started with IPv4 address:"
 
-    # Create the Ubuntu seed ISO to modify login information
-    - include_tasks: ../utils/create_seed_iso.yml
+    - name: "Create the Ubuntu seed ISO to modify login information"
+      include_tasks: ../utils/create_seed_iso.yml
       vars:
+        seed_iso_dir_path: "{{ unattend_iso_cache }}"
         user_data_template: "{{ unattend_install_template }}"
         local_hostname: "ubuntu-{{ hostname_timestamp }}"
 
-    - name: "Set fact of generated unattend install config file and seed ISO"
+    - name: "Set facts for generated unattend install ISO, config file and rebuilt OS installation ISO"
       ansible.builtin.set_fact:
         new_unattend_install_conf: "{{ user_data_path }}"
-        unattend_iso_cache: "{{ tmp_seed_dir }}"
-        generated_unattend_iso: "{{ seed_iso_path }}"
-        unattend_iso_file_name: "{{ lookup('pipe','date +%s') }}-{{ seed_iso_path | basename }}"
-        new_os_installation_iso: "{{ lookup('pipe','date +%s') }}_{{ os_installation_iso_list[0].split()[1] | basename }}"
+        unattend_iso_file_path: "{{ seed_iso_path }}"
+        unattend_iso_file_name: "{{ seed_iso_path | basename }}"
+        new_os_installation_iso: "{{ os_installation_iso_list[0].split()[1] | basename }}_{{ timestamp }}"
 
-    - include_tasks: rebuild_unattend_install_iso.yml
-      vars:
-        rebuilt_unattend_iso_path: "{{ unattend_iso_cache }}/{{ new_os_installation_iso }}"
-
-    # Upload Ubuntu fully automated install ISO to ESXi datastore
-    - include_tasks: ../../common/esxi_upload_datastore_file.yml
-      vars:
-        src_file_path: "{{ unattend_iso_cache }}/{{ new_os_installation_iso }}"
-        dest_file_path: "{{ new_os_installation_iso }}"
-        upload_file_timeout: 600
-
-    - name: "Replace original install ISO file with fully automated install ISO file"
+    - name: "Set fact of the local path to the rebuilt OS installation ISO file"
       ansible.builtin.set_fact:
-        os_installation_iso_list: ["[{{ datastore }}] {{ new_os_installation_iso }}"]
-        os_install_iso_list_len: 1
-  when: >
-    unattend_install_conf is match('Ubuntu/Server/') or
-    unattend_install_conf is match('Ubuntu/Desktop/Subiquity')
+        new_os_installation_iso_path: "{{ unattend_iso_cache }}/{{ new_os_installation_iso }}"
 
-- name: "Set fact of unattended install ISO path on datastore {{ datastore }}"
-  ansible.builtin.set_fact:
-    transferred_unattend_iso: "[{{ datastore }}] {{ unattend_iso_file_name }}"
+    - name: "Rebuild Ubuntu ISO for fully automated install"
+      include_tasks: rebuild_unattend_install_iso.yml
+      vars:
+        rebuilt_unattend_iso_path: "{{ new_os_installation_iso_path }}"
 
-- ansible.builtin.debug:
+- name: "Display facts of unattend install config file and ISOs"
+  ansible.builtin.debug:
     msg:
-      - "The unattend install ISO generated is {{ generated_unattend_iso }}"
-      - "The unattend install ISO will be uploaded to '{{ transferred_unattend_iso }}' on ESXi host"
+      - "The unattend install config file path is {{ new_unattend_install_conf }}"
+      - "The unattend install ISO file name is {{ unattend_iso_file_name }}"
+      - "The unattend install ISO file path is {{ unattend_iso_file_path }}"
+      - "The rebuilt OS installation ISO file name is {{ new_os_installation_iso }}"
+      - "The rebuilt OS installation ISO file path is {{ new_os_installation_iso_path }}"
 
-# Upload unattend install ISO to ESXi datastore
-- include_tasks: ../../common/esxi_upload_datastore_file.yml
+- name: "Set fact of unattend install ISO files to be uploaded to ESXi datastore"
+  ansible.builtin.set_fact:
+    transferred_unattend_iso_list: "{{ [unattend_iso_file_name, new_os_installation_iso] | select }}"
+
+- name: "Display unattend install ISO files to be uploaded to ESXi datastore"
+  ansible.builtin.debug:
+    msg: "The unattend install ISO to be uploaded to ESXi datastore {{ datastore }}: {{ transferred_unattend_iso_list }}"
+
+- name: "Upload unattend install ISO files to ESXi datastore"
+  include_tasks: ../../common/esxi_upload_datastore_file.yml
   vars:
-    src_file_path: "{{ generated_unattend_iso }}"
-    dest_file_path: "{{ unattend_iso_file_name }}"
+    src_file_path: "{{ unattend_iso_cache }}/{{ item }}"
+    dest_file_path: "{{ item }}"
     upload_file_timeout: 600
+  with_items: "{{ transferred_unattend_iso_list }}"
 
-- name: "Append generated unattend ISO file to the list"
+- name: "Replace original OS installation ISO file with new rebuilt ISO file"
   ansible.builtin.set_fact:
-    os_installation_iso_list: "{{ os_installation_iso_list + [transferred_unattend_iso] }}"
-    os_install_iso_list_len: "{{ os_install_iso_list_len | int + 1 }}"
-  when:
-    - unattend_install_conf is not match('Photon')
-    - unattend_install_conf is not match('Debian')
-    - unattend_install_conf is not match('Ubuntu/Desktop/Ubiquity')
-    - unattend_install_conf is not match('FreeBSD')
-    - unattend_install_conf is not match('Pardus')
-
-- name: "Replace original install ISO file with unattend install ISO file"
-  ansible.builtin.set_fact:
-    os_installation_iso_list: "{{ [transferred_unattend_iso] }}"
+    os_installation_iso_list:
+      - "[{{ datastore }}] {{ new_os_installation_iso }}"
     os_install_iso_list_len: 1
-  when: >
-    unattend_install_conf is match('Photon') or
-    unattend_install_conf is match('Debian') or
-    unattend_install_conf is match('Ubuntu/Desktop/Ubiquity') or
-    unattend_install_conf is match('FreeBSD') or
-    unattend_install_conf is match('Pardus')
+  when: new_os_installation_iso
 
-- name: "Copy generated unattend install config file to log folder"
+- name: "Append generated unattend install ISO file to OS installation ISO list"
+  ansible.builtin.set_fact:
+    os_installation_iso_list: "{{ os_installation_iso_list + ['[' ~ datastore ~ '] ' ~ unattend_iso_file_name] }}"
+    os_install_iso_list_len: "{{ os_install_iso_list_len | int + 1 }}"
+  when: unattend_iso_file_name
+
+- name: "Remove ISO files from local cache folder {{ unattend_iso_cache }}"
+  include_tasks: ../../common/delete_local_file.yml
+  vars:
+    local_path: "{{ unattend_iso_cache }}/{{ item }}"
+  with_items: "{{ transferred_unattend_iso_list }}"
+
+- name: "Copy unattend install config files in cache folder to test log folder"
   ansible.builtin.copy:
-    src: "{{ new_unattend_install_conf }}"
-    dest: "{{ current_test_log_folder }}/{{ new_unattend_install_conf | basename }}"
+    src: "{{ unattend_iso_cache }}/"
+    dest: "{{ current_test_log_folder }}/"
   when: unattend_install_conf is not match('Ubuntu/Server/')
 
-- name: "Remove cache folder {{ unattend_iso_cache }}"
-  ansible.builtin.file:
-    path: "{{ unattend_iso_cache }}"
-    state: absent
+- name: "Remove local cache folder {{ unattend_iso_cache }}"
+  include_tasks: ../../common/delete_local_file.yml
+  vars:
+    local_path: "{{ unattend_iso_cache }}"

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -12,17 +12,22 @@
 
 - name: "Display unattend install config file template"
   ansible.builtin.debug:
-    msg: "The unattend install config file template is {{ unattend_install_template }}"
+    msg:
+      - "The unattend install config file template is {{ unattend_install_template }}"
+      - "The unattend installer is {{ unattend_installer }}"
 
-# new_unattend_install_conf is the local file name of unattend install config file created from template
-# unattend_iso_file_name and unattend_iso_file_path are the new generated unattend install ISO file name and path,
-#   which is used by OS in RHEL family, SUSE family, etc and Ubuntu Desktop or Server using Subiquity installer.
-#   Their automatic install needs 2 ISOs: one is the OS image ISO, and the other is the new generated unattend install
-#   ISO with unattend install config file in
-# new_os_installation_iso and new_os_installation_iso_path are the rebuilt OS ISO image file and path
-#   which is used by OS like Photon, Debian, Pardus, FreeBSD, Ubuntu Desktop using Ubiquity installer, etc.
-#   Their automatic install needs to rebuild OS image from original one by packing unattend install config file in it,
-#   and no separate unattend install ISO needed.
+# 1. new_unattend_install_conf is the local file name of unattend install config file created from template.
+# 2. unattend_iso_file_name and unattend_iso_file_path are the new generated unattend install ISO file name
+# and path, which is used by OS in RHEL family, SUSE family, etc. Their automatic install just needs to pack
+# unattend install config file into a separate unattend install ISO, and then make this ISO be connected to
+# the 2nd CDROM of the VM.
+# 3. new_os_installation_iso and new_os_installation_iso_path are the rebuilt OS ISO image file and path,
+# which is used by OS like Photon, Debian, Pardus, FreeBSD, Ubuntu Desktop using Ubiquity installer, etc.
+# Their automatic install needs to rebuild OS image from original one by packing unattend install config file
+# into it, and no separate unattend install ISO needed. VM only needs to connect its 1st CDROM with the
+# rebuilt ISO.
+# 4. For Ubuntu Desktop or Server using Subiquity installer, their fully automatic install needs to rebuild
+# OS ISO image for changing boot command, and generate unattend install ISO with unattend install config file.
 - name: "Initialize facts for unattend install config files and ISO files"
   ansible.builtin.set_fact:
     new_unattend_install_conf: "{{ tmp_path }}/{{ unattend_install_template | basename }}"

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -30,7 +30,7 @@
 # OS ISO image for changing boot command, and generate unattend install ISO with unattend install config file.
 - name: "Initialize facts for unattend install config files and ISO files"
   ansible.builtin.set_fact:
-    new_unattend_install_conf: "{{ tmp_path }}/{{ unattend_install_template | basename }}"
+    new_unattend_install_conf: "{{ unattend_iso_cache }}/{{ unattend_install_template | basename }}"
     unattend_iso_file_name: ""
     unattend_iso_file_path: ""
     new_os_installation_iso: ""

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -109,7 +109,7 @@
         new_unattend_install_conf: "{{ user_data_path }}"
         unattend_iso_file_path: "{{ seed_iso_path }}"
         unattend_iso_file_name: "{{ seed_iso_path | basename }}"
-        new_os_installation_iso: "{{ os_installation_iso_list[0].split()[1] | basename }}_{{ timestamp }}"
+        new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ timestamp }}.iso"
 
     - name: "Set fact of the local path to the rebuilt OS installation ISO file"
       ansible.builtin.set_fact:

--- a/linux/deploy_vm/delete_unattend_install_iso.yml
+++ b/linux/deploy_vm/delete_unattend_install_iso.yml
@@ -1,38 +1,27 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Delete unattend install ISO file
+# Delete unattend install ISO file from ESXi datastore
 #
-# By default, it's attached to the last CDROM in composed VM CDROMs list
-- name: "Set fact of the controller and unit number of CDROM attaching unattend install ISO"
-  ansible.builtin.set_fact:
-    unattend_iso_cdrom_ctl_num: "{{ vm_cdroms[os_install_iso_list_len | int - 1].controller_number }}"
-    unattend_iso_cdrom_unit_num: "{{ vm_cdroms[os_install_iso_list_len | int - 1].unit_number }}"
-
-# Change CDROM type from iso to client
-- include_tasks: ../../common/vm_configure_cdrom.yml
+- name: "Reconfigure CDROM to client device"
+  include_tasks: ../../common/vm_configure_cdrom.yml
   vars:
     cdrom_type: client
-    cdrom_controller_num: "{{ unattend_iso_cdrom_ctl_num | int }}"
-    cdrom_unit_num: "{{ unattend_iso_cdrom_unit_num | int }}"
+    cdrom_controller_num: "{{ vm_cdrom.controller_number | int }}"
+    cdrom_unit_num: "{{ vm_cdrom.unit_number | int }}"
     cdrom_state: present
+  with_items: "{{ vm_cdroms }}"
+  loop_control:
+    loop_var: vm_cdrom
 
-# Delete unattend install iso on ESXi datastore
 # It could fail but doesn't affect tests, see https://kb.vmware.com/s/article/78653
-- include_tasks: ../../common/esxi_check_delete_datastore_file.yml
+- name: "Delete uploaded unattend install ISO from ESXi datastore"
+  include_tasks: ../../common/esxi_check_delete_datastore_file.yml
   vars:
     file_in_datastore: "{{ datastore }}"
-    file_in_datastore_path: "{{ unattend_iso_file_name }}"
+    file_in_datastore_path: "{{ unattend_iso }}"
     file_in_datastore_ops: "absent"
     file_in_datastore_ignore_failed: true
-
-- include_tasks: ../../common/esxi_check_delete_datastore_file.yml
-  vars:
-    file_in_datastore: "{{ datastore }}"
-    file_in_datastore_path: "{{ new_os_installation_iso }}"
-    file_in_datastore_ops: "absent"
-    file_in_datastore_ignore_failed: true
-  when:
-    - unattend_install_conf is match('Ubuntu/Server') or unattend_install_conf is match('Ubuntu/Desktop/Subiquity')
-    - new_os_installation_iso is defined
-    - new_os_installation_iso
+  with_items: "{{ transferred_unattend_iso_list }}"
+  loop_control:
+    loop_var: unattend_iso

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -6,6 +6,8 @@
   gather_facts: false
   collections:
     - community.general
+  vars:
+    timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   tasks:
     - name: "Set current test case index, name and log folder"
       include_tasks: ../../common/set_current_testcase_facts.yml
@@ -25,7 +27,7 @@
 
     - name: "Set fact of timestamp for VM hostname"
       ansible.builtin.set_fact:
-        hostname_timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
+        hostname_timestamp: "{{ timestamp }}"
 
     - name: "Get SSH public key from localhost"
       include_tasks: ../utils/get_local_ssh_public_key.yml

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -80,6 +80,15 @@
             - unattend_iso_cache is defined
             - unattend_iso_cache
           block:
+            # Remove original OS ISO image downloaded from ESXi datastore
+            - name: "Remove source ISO image from local cache"
+              include_tasks: ../../common/delete_local_file.yml
+              vars:
+                local_path: "{{ src_iso_file_path }}"
+              when:
+                - src_iso_file_path is defined
+                - src_iso_file_path
+
             - name: "Remove ISO files from local cache folder {{ unattend_iso_cache }}"
               include_tasks: ../../common/delete_local_file.yml
               vars:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -21,27 +21,100 @@
         skip_reason: "Skipped"
       when: new_vm is undefined or (not new_vm | bool)
 
-    # Change vm_username to root if it is not. And add a new user after VM deployment
-    - name: "Set user account for new VM"
-      include_tasks: set_new_vm_user_account.yml
+    - name: "Test case block"
+      block:
+        # Change vm_username to root if it is not. And add a new user after VM deployment
+        - name: "Set user account for new VM"
+          include_tasks: set_new_vm_user_account.yml
 
-    - name: "Set fact of timestamp for VM hostname"
-      ansible.builtin.set_fact:
-        hostname_timestamp: "{{ timestamp }}"
+        - name: "Set fact of timestamp for VM hostname"
+          ansible.builtin.set_fact:
+            hostname_timestamp: "{{ timestamp }}"
 
-    - name: "Get SSH public key from localhost"
-      include_tasks: ../utils/get_local_ssh_public_key.yml
+        - name: "Get SSH public key from localhost"
+          include_tasks: ../utils/get_local_ssh_public_key.yml
 
-    - name: "Deploy VM by creating a new VM and install OS from ISO image on it"
-      include_tasks: deploy_vm_from_iso.yml
-      when: (vm_deploy_method is undefined) or (vm_deploy_method == "iso")
+        - name: "Create temp folder for generating unattend install ISO file"
+          include_tasks: ../../common/create_temp_file_dir.yml
+          vars:
+            tmp_dir: "{{ local_cache }}"
+            tmp_state: "directory"
+            tmp_prefix: "unattend_iso_"
 
-    # OVA deployment is applicable for OS releases which have OVA deliverables, e.g.
-    # VMware Photon OS, Ubuntu cloud image, Flatcar, or Amazon Linux, etc
-    - name: "Deploy VM from an OVA template"
-      include_tasks: deploy_vm_from_ova.yml
-      when: (vm_deploy_method is defined) and (vm_deploy_method == "ova")
+        - name: "Initialize fact of unattend install cache folder"
+          ansible.builtin.set_fact:
+            unattend_iso_cache: "{{ tmp_path }}"
 
-    - name: "Print VM guest IP address"
-      ansible.builtin.debug: var=vm_guest_ip
-      when: vm_guest_ip is defined and vm_guest_ip
+        - name: "Deploy VM by creating a new VM and install OS from ISO image on it"
+          include_tasks: deploy_vm_from_iso.yml
+          when: (vm_deploy_method is undefined) or (vm_deploy_method == "iso")
+
+        # OVA deployment is applicable for OS releases which have OVA deliverables, e.g.
+        # VMware Photon OS, Ubuntu cloud image, Flatcar, or Amazon Linux, etc
+        - name: "Deploy VM from an OVA template"
+          include_tasks: deploy_vm_from_ova.yml
+          when: (vm_deploy_method is defined) and (vm_deploy_method == "ova")
+
+        - name: "Take a screenshot when VM deployment succeeds"
+          include_tasks: ../../common/vm_take_screenshot.yml
+          vars:
+            vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
+
+        - name: "Print VM guest IP address"
+          ansible.builtin.debug: var=vm_guest_ip
+          when: vm_guest_ip is defined and vm_guest_ip
+      rescue:
+        - name: "Collect serial port log at test failure"
+          include_tasks: collect_serial_port_log.yml
+
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml
+          vars:
+            exit_testing_when_fail: true
+      always:
+        - name: "Collect VM deployment logs"
+          include_tasks: collect_vm_logs.yml
+
+        - name: "Clean up local cache"
+          when:
+            - unattend_iso_cache is defined
+            - unattend_iso_cache
+          block:
+            - name: "Remove ISO files from local cache folder {{ unattend_iso_cache }}"
+              include_tasks: ../../common/delete_local_file.yml
+              vars:
+                local_path: "{{ unattend_iso_cache }}/{{ item }}"
+              with_items: "{{ transferred_unattend_iso_list }}"
+              when:
+                - transferred_unattend_iso_list is defined
+                - transferred_unattend_iso_list
+
+            - name: "Copy unattend install config files in cache folder to test log folder"
+              ansible.builtin.copy:
+                src: "{{ unattend_iso_cache }}/"
+                dest: "{{ current_test_log_folder }}/"
+
+            - name: "Remove local cache folder {{ unattend_iso_cache }}"
+              include_tasks: ../../common/delete_local_file.yml
+              vars:
+                local_path: "{{ unattend_iso_cache }}"
+
+        - name: "Unmount NFS share folder and remove mount folder"
+          when:
+            - nfs_mount_dir is defined
+            - nfs_mount_dir
+          block:
+            - name: "Umount NFS share points"
+              include_tasks: ../../common/local_unmount.yml
+              vars:
+                mount_path: "{{ nfs_mount_dir }}"
+                local_unmount_ignore_errors: true
+              when:
+                - nfs_mounted is defined
+                - nfs_mounted | bool
+
+            - name: "Remove the mount folder"
+              include_tasks: ../../common/delete_local_file.yml
+              vars:
+                local_path: "{{ nfs_mount_dir }}"
+                del_local_file_ignore_errors: true

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -284,7 +284,8 @@
     - guest_os_ansible_distribution_ver == "9.0"
     - "'uek' in guest_os_ansible_kernel"
   block:
-    - include_tasks: ../../common/vm_take_snapshot.yml
+    - name: "Take a snapshot before upgrading UEK"
+      include_tasks: ../../common/vm_take_snapshot.yml
       vars:
         snapshot_name: "OL_9.0GA_UEK"
 

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -38,315 +38,320 @@
   ansible.builtin.set_fact:
     install_guest_with_desktop: false
 
-- name: "Test case block"
+- name: "Get OS installation ISO file list"
+  include_tasks: ../../common/get_iso_file_list.yml
+
+- name: "Prepare for Ubuntu installation"
+  include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
+  when: guest_id is match('ubuntu.*')
+
+- name: "Set default unattend install conf file"
+  when: unattend_install_conf is undefined or not unattend_install_conf
   block:
-    - name: "Get OS installation ISO file list"
-      include_tasks: ../../common/get_iso_file_list.yml
-
-    - name: "Prepare for Ubuntu installation"
-      include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
-      when: guest_id is match('ubuntu.*')
-
-    - name: "Set default unattend install conf file"
-      when: unattend_install_conf is undefined or not unattend_install_conf
-      block:
-        - name: "Set default unattend install conf file for VMware Photon OS"
-          ansible.builtin.set_fact:
-            unattend_install_conf: "Photon/ks.cfg"
-          when: guest_id == 'vmwarePhoton64Guest'
-
-        - name: "Set default unattend install conf file for Debian"
-          ansible.builtin.set_fact:
-            unattend_install_conf: "Debian/10/preseed.cfg"
-          when: guest_id is match("debian1\\d+")
-
-    - name: "Display warning message about undefined unattend_install_conf"
-      ansible.builtin.debug:
-        msg: "unattend_install_conf is not defined or set to a file path, will not generate unattend ISO file"
-      when: unattend_install_conf is undefined or not unattend_install_conf
-
-    - name: "Generate unattend install ISO file"
-      include_tasks: create_unattend_install_iso.yml
-      when: unattend_install_conf is defined and unattend_install_conf
-
-    - name: "Compose VM CDROMs to mount OS install ISO files"
-      include_tasks: ../../common/compose_vm_cdroms.yml
-
-    - name: "Create a new VM with boot disk of controller type {{ boot_disk_controller }}"
-      include_tasks: ../../common/vm_create.yml
-      vars:
-        memory_mb: "{{ vm_memory_mb }}"
-
-    - name: "Get VM info"
-      include_tasks: ../../common/vm_get_vm_info.yml
-
-    - name: "Set fact of vm_exists to True"
+    - name: "Set default unattend install conf file for VMware Photon OS"
       ansible.builtin.set_fact:
-        vm_exists: true
+        unattend_install_conf: "Photon/ks.cfg"
+      when: guest_id == 'vmwarePhoton64Guest'
 
-    - name: "Add a serial port to monitor autoinstall process"
-      include_tasks: ../../common/vm_add_serial_port.yml
+    - name: "Set default unattend install conf file for Debian"
+      ansible.builtin.set_fact:
+        unattend_install_conf: "Debian/10/preseed.cfg"
+      when: guest_id is match("debian1\\d+")
 
-    - name: "Set video memory size"
-      when: install_guest_with_desktop
-      block:
-        - name: "Get VM's video card info"
-          include_tasks: ../../common/vm_get_video_card.yml
+- name: "Display warning message about undefined unattend_install_conf"
+  ansible.builtin.debug:
+    msg: "unattend_install_conf is not defined or set to a file path, will not generate unattend ISO file"
+  when: unattend_install_conf is undefined or not unattend_install_conf
 
-        - name: "Get VM default video memory size"
-          ansible.builtin.set_fact:
-            vm_default_video_memory_mb: "{{ (vm_video_cart_facts.instance.video_memory | int) / 1024 }}"
+- name: "Generate unattend install ISO file"
+  include_tasks: create_unattend_install_iso.yml
+  when: unattend_install_conf is defined and unattend_install_conf
 
-        - name: "Increase VM's video card memory to 8 MB in case desktop can't be loaded"
-          include_tasks: ../../common/vm_set_video_card.yml
-          vars:
-            video_memory_mb: 8
-          when: vm_default_video_memory_mb | int < 8
+- name: "Compose VM CDROMs to mount OS install ISO files"
+  include_tasks: ../../common/compose_vm_cdroms.yml
 
-    - name: "Enable secure boot on VM"
-      include_tasks: ../../common/vm_set_boot_options.yml
+- name: "Create a new VM with boot disk of controller type {{ boot_disk_controller }}"
+  include_tasks: ../../common/vm_create.yml
+  vars:
+    memory_mb: "{{ vm_memory_mb }}"
+
+- name: "Get VM info"
+  include_tasks: ../../common/vm_get_vm_info.yml
+
+- name: "Set fact of vm_exists to True"
+  ansible.builtin.set_fact:
+    vm_exists: true
+
+- name: "Add a serial port to monitor autoinstall process"
+  include_tasks: ../../common/vm_add_serial_port.yml
+
+- name: "Set video memory size"
+  when: install_guest_with_desktop
+  block:
+    - name: "Get VM's video card info"
+      include_tasks: ../../common/vm_get_video_card.yml
+
+    - name: "Get VM default video memory size"
+      ansible.builtin.set_fact:
+        vm_default_video_memory_mb: "{{ (vm_video_cart_facts.instance.video_memory | int) / 1024 }}"
+
+    - name: "Increase VM's video card memory to 8 MB in case desktop can't be loaded"
+      include_tasks: ../../common/vm_set_video_card.yml
       vars:
-        secure_boot_enabled_set: true
-      when:
-        - firmware is defined and firmware | lower == 'efi'
-        - secureboot_enabled is defined and secureboot_enabled
+        video_memory_mb: 8
+      when: vm_default_video_memory_mb | int < 8
 
-    - name: "Add virtual TPM device"
-      include_tasks: ../../common/vm_add_vtpm_device.yml
-      vars:
-        vc_cert_path: "{{ current_test_log_folder }}"
-      when:
-        - firmware is defined and firmware | lower == 'efi'
-        - virtual_tpm is defined and virtual_tpm | bool
+- name: "Enable secure boot on VM"
+  include_tasks: ../../common/vm_set_boot_options.yml
+  vars:
+    secure_boot_enabled_set: true
+  when:
+    - firmware is defined and firmware | lower == 'efi'
+    - secureboot_enabled is defined and secureboot_enabled
 
-    - name: "Power on VM"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'powered-on'
+- name: "Add virtual TPM device"
+  include_tasks: ../../common/vm_add_vtpm_device.yml
+  vars:
+    vc_cert_path: "{{ current_test_log_folder }}"
+  when:
+    - firmware is defined and firmware | lower == 'efi'
+    - virtual_tpm is defined and virtual_tpm | bool
 
-    - name: "Sleep 5 seconds to wait boot screen display"
-      ansible.builtin.pause:
-        seconds: 5
+- name: "Power on VM"
+  include_tasks: ../../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'
 
-    - name: "Check Image APPROVED in vmware.log when VM secure boot is enabled"
-      include_tasks: ../../common/vm_wait_log_msg.yml
-      vars:
-        vm_wait_log_name: "vmware.log"
-        vm_wait_log_msg: "SECUREBOOT: Image APPROVED"
-        vm_wait_log_retries: 10
-        vm_wait_log_ignore_errors: false
-        vm_wait_log_hide_output: false
-      when:
-        - firmware is defined and firmware | lower == 'efi'
-        - secureboot_enabled is defined and secureboot_enabled
+- name: "Sleep 5 seconds to wait boot screen display"
+  ansible.builtin.pause:
+    seconds: 5
 
-    - name: "Install Ubuntu OS"
-      include_tasks: ubuntu/ubuntu_install_os.yml
-      when: guest_id is match('ubuntu.*')
+- name: "Check Image APPROVED in vmware.log when VM secure boot is enabled"
+  include_tasks: ../../common/vm_wait_log_msg.yml
+  vars:
+    vm_wait_log_name: "vmware.log"
+    vm_wait_log_msg: "SECUREBOOT: Image APPROVED"
+    vm_wait_log_retries: 10
+    vm_wait_log_ignore_errors: false
+    vm_wait_log_hide_output: false
+  when:
+    - firmware is defined and firmware | lower == 'efi'
+    - secureboot_enabled is defined and secureboot_enabled
 
-    # For SLES, OS installation with BIOS firmware, send key to boot
-    # screen to start new installation instead of booting from local
-    - name: "Select boot menu for SLES/SLED"
-      include_tasks: ../../common/vm_guest_send_key.yml
-      vars:
-        keys_send:
-          - DOWNARROW
-          - ENTER
-      when:
-        - unattend_installer is defined
-        - unattend_installer in ['SLE', 'openSUSE']
-        - firmware is defined and firmware|lower == "bios"
+- name: "Install Ubuntu OS"
+  include_tasks: ubuntu/ubuntu_install_os.yml
+  when: guest_id is match('ubuntu.*')
 
-    # For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
-    # disk check and start installation directly. RockyLinux is using Other 4.x or
-    # later Linux (64-bit) as guest OS type.
-    - name: "Select boot menu for RHEL or Fedora family OS"
-      include_tasks: ../../common/vm_guest_send_key.yml
-      vars:
-        keys_send:
-          - UPARROW
-          - ENTER
-      when:
-        - unattend_installer is defined
-        - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler', 'FusionOS']
+# For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
+# disk check and start installation directly. RockyLinux is using Other 4.x or
+# later Linux (64-bit) as guest OS type.
+- name: "Select boot menu for RHEL or Fedora family OS"
+  include_tasks: ../../common/vm_guest_send_key.yml
+  vars:
+    keys_send:
+      - UPARROW
+      - ENTER
+  when:
+    - unattend_installer is defined
+    - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler', 'FusionOS']
 
-    # For UnionTech OS, send key to boot screen
-    - name: "Select boot menu for UnionTech OS"
-      include_tasks: ../../common/vm_guest_send_key.yml
-      vars:
-        keys_send:
-          - ENTER
-      when:
-        - unattend_installer is defined
-        - unattend_installer == 'UOS'
+# For SLES, OS installation with BIOS firmware, send key to boot
+# screen to start new installation instead of booting from local
+- name: "Select boot menu for SLES/SLED"
+  include_tasks: ../../common/vm_guest_send_key.yml
+  vars:
+    keys_send:
+      - DOWNARROW
+      - ENTER
+  when:
+    - unattend_installer is defined
+    - unattend_installer in ['SLE', 'openSUSE']
+    - firmware is defined and firmware|lower == "bios"
+>>>>>>> 78670e7 (Move block-rescue-always to deploy_vm.yml)
 
-    - name: "Wait autoinstall complete message appear in serial port output file"
-      include_tasks: ../../common/vm_wait_log_msg.yml
-      vars:
-        vm_wait_log_name: "{{ vm_serial_port_output_file | basename }}"
-        vm_wait_log_msg: "{{ autoinstall_complete_msg }}"
-        vm_wait_log_delay: 30
-        vm_wait_log_retries: 120
+# For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
+# disk check and start installation directly. RockyLinux is using Other 4.x or
+# later Linux (64-bit) as guest OS type.
+- name: "Select boot menu for RHEL or Fedora family OS"
+  include_tasks: ../../common/vm_guest_send_key.yml
+  vars:
+    keys_send:
+      - UPARROW
+      - ENTER
+  when:
+    - unattend_installer is defined
+    - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler']
 
-    - name: "Take a screenshot when autoinstall complete message is received"
-      include_tasks: ../../common/vm_take_screenshot.yml
-      vars:
-        vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
+# For UnionTech OS, send key to boot screen
+- name: "Select boot menu for UnionTech OS"
+  include_tasks: ../../common/vm_guest_send_key.yml
+  vars:
+    keys_send:
+      - ENTER
+  when:
+    - unattend_installer is defined
+    - unattend_installer == 'UOS'
 
-    # VMware Photon OS kickstart file can't add shutdown action,
-    # so here needs to shutdown it separately
-    - name: "Shutdown VMware Photon OS VM after auto install completes"
-      when:
-        - unattend_installer is defined
-        - unattend_installer == 'Photon'
-      block:
-        - name: "Wait for guest full name on VMware Photon OS VM"
-          include_tasks: ../../common/vm_wait_guest_fullname.yml
+- name: "Wait autoinstall complete message appear in serial port output file"
+  include_tasks: ../../common/vm_wait_log_msg.yml
+  vars:
+    vm_wait_log_name: "{{ vm_serial_port_output_file | basename }}"
+    vm_wait_log_msg: "{{ autoinstall_complete_msg }}"
+    vm_wait_log_delay: 30
+    vm_wait_log_retries: 120
 
-        - name: "Get guest IP address"
-          include_tasks: ../../common/update_inventory.yml
-          vars:
-            update_inventory_timeout: 300
+- name: "Take a screenshot when autoinstall complete message is received"
+  include_tasks: ../../common/vm_take_screenshot.yml
+  vars:
+    vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
 
-        - name: "Shutdown guest OS to remove serial port"
-          include_tasks: ../utils/shutdown.yml
-
-    - name: "Wait for VM being powered off"
-      include_tasks: ../../common/vm_wait_power_state.yml
-      vars:
-        expected_power_status: 'poweredOff'
-        wait_power_state_timeout: 600
-
-    - name: "Delete unattend install ISO"
-      include_tasks: delete_unattend_install_iso.yml
-      when:
-        - transferred_unattend_iso_list is defined
-        - transferred_unattend_iso_list
-
-    - name: "Change the boot disk to be first boot device in boot order"
-      include_tasks: ../../common/vm_set_boot_options.yml
-      vars:
-        boot_order_list: ['disk']
-      when: guest_id is match('ubuntu.*')
-
-    - name: "Collect serial port log before removing serial port"
-      include_tasks: collect_serial_port_log.yml
-
-    - name: "Remove serial port"
-      include_tasks: ../../common/vm_remove_serial_port.yml
-
-    - name: "OS auto install is completed. Power on VM now"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'powered-on'
-
-    - name: "Wait for guest full name is collected"
+# VMware Photon OS kickstart file can't add shutdown action,
+# so here needs to shutdown it separately
+- name: "Shutdown VMware Photon OS VM after auto install completes"
+  when:
+    - unattend_installer is defined
+    - unattend_installer == 'Photon'
+  block:
+    - name: "Wait for guest full name on VMware Photon OS VM"
       include_tasks: ../../common/vm_wait_guest_fullname.yml
+<<<<<<< HEAD
       vars:
         vm_get_fullname_timeout: 600
       when:
         - unattend_install_conf is defined
         - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler|fusionos).*')
+=======
+>>>>>>> 78670e7 (Move block-rescue-always to deploy_vm.yml)
 
-    - name: "Get VM guest IPv4 address and add to in-memory inventory"
+    - name: "Get guest IP address"
       include_tasks: ../../common/update_inventory.yml
       vars:
-        update_inventory_timeout: 600
+        update_inventory_timeout: 300
 
-    - name: "Get Linux system info"
-      include_tasks: ../utils/get_linux_system_info.yml
+    - name: "Shutdown guest OS to remove serial port"
+      include_tasks: ../utils/shutdown.yml
 
-    - name: "Wait for guest OS service is ready"
-      when:
-        - guest_os_with_gui is defined
-        - (guest_os_family in ["RedHat", "Suse"] or
-           guest_os_ansible_distribution in ["Ubuntu", "Debian"])
-      block:
-        # For SLE, RHEL8/CentOS8/OracleLinux8 with desktop: display-manager
-        # service running at the end of installation to wait user login.
-        # Otherwise, systemd-logind service running at the end of installaiton
-        # to wait user login
-        - name: "Set fact of service name for waiting at first time of OS boot"
-          ansible.builtin.set_fact:
-            wait_service_name: |-
-              {%- if guest_os_with_gui -%}display-manager
-              {%- else -%}systemd-logind
-              {%- endif -%}
+- name: "Wait for VM being powered off"
+  include_tasks: ../../common/vm_wait_power_state.yml
+  vars:
+    expected_power_status: 'poweredOff'
+    wait_power_state_timeout: 600
 
-        - name: "Wait for service {{ wait_service_name }} is running"
-          include_tasks: ../utils/wait_for_service_status.yml
-          vars:
-            service_name: "{{ wait_service_name }}"
-            wait_service_status: "running"
+- name: "Delete unattend install ISO"
+  include_tasks: delete_unattend_install_iso.yml
+  when:
+    - transferred_unattend_iso_list is defined
+    - transferred_unattend_iso_list
 
-    - name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
-      when:
-        - guest_os_ansible_distribution == "OracleLinux"
-        - guest_os_ansible_distribution_ver == "9.0"
-        - "'uek' in guest_os_ansible_kernel"
-      block:
-        - include_tasks: ../../common/vm_take_snapshot.yml
-          vars:
-            snapshot_name: "OL_9.0GA_UEK"
+- name: "Change the boot disk to be first boot device in boot order"
+  include_tasks: ../../common/vm_set_boot_options.yml
+  vars:
+    boot_order_list: ['disk']
+  when: guest_id is match('ubuntu.*')
 
-        - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
-          ansible.builtin.set_fact:
-            ol9_uekr7_is_upgraded: false
-            ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
+- name: "Collect serial port log before removing serial port"
+  include_tasks: collect_serial_port_log.yml
 
-        - name: "Add Oracle Linux online repos for upgrading kernel"
-          include_tasks: ../utils/add_official_online_repo.yml
+- name: "Remove serial port"
+  include_tasks: ../../common/vm_remove_serial_port.yml
 
-        - name: "Update Oracle Linux 9.0 to latest UEK R7"
-          ansible.builtin.shell: "yum update --nogpgcheck -y"
-          register: ol9_uekr7_upgrade_result
-          delegate_to: "{{ vm_guest_ip }}"
+- name: "OS auto install is completed. Power on VM now"
+  include_tasks: ../../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'
 
-        - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
-          ansible.builtin.set_fact:
-            ol9_uekr7_is_upgraded: true
-          when:
-            - ol9_uekr7_upgrade_result is defined
-            - ol9_uekr7_upgrade_result.rc is defined
-            - ol9_uekr7_upgrade_result.rc == 0
+- name: "Wait for guest full name is collected"
+  include_tasks: ../../common/vm_wait_guest_fullname.yml
+  vars:
+    vm_get_fullname_timeout: 600
+  when:
+    - unattend_install_conf is defined
+    - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler).*')
 
-        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
-          when: ol9_uekr7_is_upgraded
-          block:
-            - name: "Reboot Oracle Linux"
-              include_tasks: ../utils/reboot.yml
+- name: "Get VM guest IPv4 address and add to in-memory inventory"
+  include_tasks: ../../common/update_inventory.yml
+  vars:
+    update_inventory_timeout: 600
 
-            - name: "Update VM guest IPv4 address in in-memory inventory"
-              include_tasks: ../../common/update_inventory.yml
+- name: "Get Linux system info"
+  include_tasks: ../utils/get_linux_system_info.yml
 
-            - name: "Refresh Linux system info"
-              include_tasks: ../utils/get_linux_system_info.yml
+- name: "Wait for guest OS service is ready"
+  when:
+    - guest_os_with_gui is defined
+    - (guest_os_family in ["RedHat", "Suse"] or
+       guest_os_ansible_distribution in ["Ubuntu", "Debian"])
+  block:
+    # For SLE, RHEL8/CentOS8/OracleLinux8 with desktop: display-manager
+    # service running at the end of installation to wait user login.
+    # Otherwise, systemd-logind service running at the end of installaiton
+    # to wait user login
+    - name: "Set fact of service name for waiting at first time of OS boot"
+      ansible.builtin.set_fact:
+        wait_service_name: |-
+          {%- if guest_os_with_gui -%}display-manager
+          {%- else -%}systemd-logind
+          {%- endif -%}
 
-            - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
-              ansible.builtin.set_fact:
-                ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
-
-            - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
-              ansible.builtin.assert:
-                that:
-                  - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
-                fail_msg: >-
-                  Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
-                  version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
-                  version is '{{ ol9_uekr7_after_upgrade }}'.
-
-    - name: "Take a screenshot when OS deployment finishes"
-      include_tasks: ../../common/vm_take_screenshot.yml
+    - name: "Wait for service {{ wait_service_name }} is running"
+      include_tasks: ../utils/wait_for_service_status.yml
       vars:
-        vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
-  rescue:
-    - name: "Collect serial port log at test failure"
-      include_tasks: collect_serial_port_log.yml
+        service_name: "{{ wait_service_name }}"
+        wait_service_status: "running"
 
-    - name: "Test case failure"
-      include_tasks: ../../common/test_rescue.yml
+- name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
+  when:
+    - guest_os_ansible_distribution == "OracleLinux"
+    - guest_os_ansible_distribution_ver == "9.0"
+    - "'uek' in guest_os_ansible_kernel"
+  block:
+    - include_tasks: ../../common/vm_take_snapshot.yml
       vars:
-        exit_testing_when_fail: true
-  always:
-    - name: "Collect VM deployment logs"
-      include_tasks: collect_vm_logs.yml
+        snapshot_name: "OL_9.0GA_UEK"
+
+    - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
+      ansible.builtin.set_fact:
+        ol9_uekr7_is_upgraded: false
+        ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
+
+    - name: "Add Oracle Linux online repos for upgrading kernel"
+      include_tasks: ../utils/add_official_online_repo.yml
+
+    - name: "Update Oracle Linux 9.0 to latest UEK R7"
+      ansible.builtin.shell: "yum update --nogpgcheck -y"
+      register: ol9_uekr7_upgrade_result
+      delegate_to: "{{ vm_guest_ip }}"
+
+    - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
+      ansible.builtin.set_fact:
+        ol9_uekr7_is_upgraded: true
+      when:
+        - ol9_uekr7_upgrade_result is defined
+        - ol9_uekr7_upgrade_result.rc is defined
+        - ol9_uekr7_upgrade_result.rc == 0
+
+    - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
+      when: ol9_uekr7_is_upgraded
+      block:
+        - name: "Reboot Oracle Linux"
+          include_tasks: ../utils/reboot.yml
+
+        - name: "Update VM guest IPv4 address in in-memory inventory"
+          include_tasks: ../../common/update_inventory.yml
+
+        - name: "Refresh Linux system info"
+          include_tasks: ../utils/get_linux_system_info.yml
+
+        - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
+          ansible.builtin.set_fact:
+            ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
+
+        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
+          ansible.builtin.assert:
+            that:
+              - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
+            fail_msg: >-
+              Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
+              version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
+              version is '{{ ol9_uekr7_after_upgrade }}'.
+

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -93,7 +93,7 @@
 
     - name: "Get VM default video memory size"
       ansible.builtin.set_fact:
-        vm_default_video_memory_mb: "{{ (vm_video_cart_facts.instance.video_memory | int) / 1024 }}"
+        vm_default_video_memory_mb: "{{ (vm_video_card_facts.instance.video_memory | int) / 1024 }}"
 
     - name: "Increase VM's video card memory to 8 MB in case desktop can't be loaded"
       include_tasks: ../../common/vm_set_video_card.yml
@@ -142,19 +142,6 @@
   include_tasks: ubuntu/ubuntu_install_os.yml
   when: guest_id is match('ubuntu.*')
 
-# For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
-# disk check and start installation directly. RockyLinux is using Other 4.x or
-# later Linux (64-bit) as guest OS type.
-- name: "Select boot menu for RHEL or Fedora family OS"
-  include_tasks: ../../common/vm_guest_send_key.yml
-  vars:
-    keys_send:
-      - UPARROW
-      - ENTER
-  when:
-    - unattend_installer is defined
-    - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler', 'FusionOS']
-
 # For SLES, OS installation with BIOS firmware, send key to boot
 # screen to start new installation instead of booting from local
 - name: "Select boot menu for SLES/SLED"
@@ -167,11 +154,9 @@
     - unattend_installer is defined
     - unattend_installer in ['SLE', 'openSUSE']
     - firmware is defined and firmware|lower == "bios"
->>>>>>> 78670e7 (Move block-rescue-always to deploy_vm.yml)
 
-# For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
-# disk check and start installation directly. RockyLinux is using Other 4.x or
-# later Linux (64-bit) as guest OS type.
+# For RHEL, Fedora or RHEL-like OS, send key to boot screen to skip 
+# disk check and start installation directly.
 - name: "Select boot menu for RHEL or Fedora family OS"
   include_tasks: ../../common/vm_guest_send_key.yml
   vars:
@@ -180,7 +165,7 @@
       - ENTER
   when:
     - unattend_installer is defined
-    - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler']
+    - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler', 'FusionOS']
 
 # For UnionTech OS, send key to boot screen
 - name: "Select boot menu for UnionTech OS"
@@ -214,14 +199,8 @@
   block:
     - name: "Wait for guest full name on VMware Photon OS VM"
       include_tasks: ../../common/vm_wait_guest_fullname.yml
-<<<<<<< HEAD
       vars:
         vm_get_fullname_timeout: 600
-      when:
-        - unattend_install_conf is defined
-        - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler|fusionos).*')
-=======
->>>>>>> 78670e7 (Move block-rescue-always to deploy_vm.yml)
 
     - name: "Get guest IP address"
       include_tasks: ../../common/update_inventory.yml
@@ -266,7 +245,7 @@
     vm_get_fullname_timeout: 600
   when:
     - unattend_install_conf is defined
-    - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler).*')
+    - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler|fusionos).*')
 
 - name: "Get VM guest IPv4 address and add to in-memory inventory"
   include_tasks: ../../common/update_inventory.yml

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -153,8 +153,8 @@
           - DOWNARROW
           - ENTER
       when:
-        - unattend_install_conf is defined
-        - ('SLE' in unattend_install_conf or 'openSUSE' in unattend_install_conf)
+        - unattend_installer is defined
+        - unattend_installer in ['SLE', 'openSUSE']
         - firmware is defined and firmware|lower == "bios"
 
     # For RHEL, CentOS, RockyLinux, OracleLinux, send key to boot screen to not do
@@ -167,12 +167,8 @@
           - UPARROW
           - ENTER
       when:
-        - unattend_install_conf is defined
-        - (('RHEL' in unattend_install_conf) or
-           ('CentOS' in unattend_install_conf) or
-           ('Fedora' in unattend_install_conf) or
-           ('FusionOS' in unattend_install_conf) or
-           ('BCLinux' in unattend_install_conf))
+        - unattend_installer is defined
+        - unattend_installer in ['RHEL', 'CentOS', 'Fedora', 'BCLinux', 'BCLinux-for-Euler', 'FusionOS']
 
     # For UnionTech OS, send key to boot screen
     - name: "Select boot menu for UnionTech OS"
@@ -181,8 +177,8 @@
         keys_send:
           - ENTER
       when:
-        - unattend_install_conf is defined
-        - ('UOS' in unattend_install_conf)
+        - unattend_installer is defined
+        - unattend_installer == 'UOS'
 
     - name: "Wait autoinstall complete message appear in serial port output file"
       include_tasks: ../../common/vm_wait_log_msg.yml
@@ -201,8 +197,8 @@
     # so here needs to shutdown it separately
     - name: "Shutdown VMware Photon OS VM after auto install completes"
       when:
-        - unattend_install_conf is defined
-        - unattend_install_conf is match('Photon')
+        - unattend_installer is defined
+        - unattend_installer == 'Photon'
       block:
         - name: "Wait for guest full name on VMware Photon OS VM"
           include_tasks: ../../common/vm_wait_guest_fullname.yml
@@ -224,8 +220,8 @@
     - name: "Delete unattend install ISO"
       include_tasks: delete_unattend_install_iso.yml
       when:
-        - transferred_unattend_iso is defined
-        - transferred_unattend_iso
+        - transferred_unattend_iso_list is defined
+        - transferred_unattend_iso_list
 
     - name: "Change the boot disk to be first boot device in boot order"
       include_tasks: ../../common/vm_set_boot_options.yml
@@ -338,6 +334,11 @@
                   Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
                   version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
                   version is '{{ ol9_uekr7_after_upgrade }}'.
+
+    - name: "Take a screenshot when OS deployment finishes"
+      include_tasks: ../../common/vm_take_screenshot.yml
+      vars:
+        vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
   rescue:
     - name: "Collect serial port log at test failure"
       include_tasks: collect_serial_port_log.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -7,166 +7,139 @@
   ansible.builtin.set_fact:
     current_testcase_name: "deploy_vm_ova"
 
-- name: "Test case block"
+# OVA file on local machine
+- name: "Get OVA path and file name"
+  ansible.builtin.set_fact:
+    vm_ova_path: "{{ ova_path | realpath }}"
+    vm_ova_name: "{{ ova_path | basename }}"
+  when: ova_nfs_server_path is undefined or not ova_nfs_server_path
+
+# OVA file on NFS server
+- name: "Get OVA path and file name after mounting NFS storage at local"
+  when: ova_nfs_server_path is defined and ova_nfs_server_path
   block:
-    # OVA file on local machine
+    - name: "Mount NFS storage at local"
+      include_tasks: ../../common/mount_nfs_storage_local.yml
+      vars:
+        nfs_server_path: "{{ ova_nfs_server_path }}"
     - name: "Get OVA path and file name"
       ansible.builtin.set_fact:
-        vm_ova_path: "{{ ova_path | realpath }}"
+        vm_ova_path: "{{ nfs_mount_dir }}/{{ ova_path }}"
         vm_ova_name: "{{ ova_path | basename }}"
-      when: ova_nfs_server_path is undefined or not ova_nfs_server_path
+# Check OVA file exists
+- name: "Check for {{ vm_ova_path }} existence"
+  ansible.builtin.stat:
+    path: "{{ vm_ova_path }}"
+  register: vm_ova_stat
+  failed_when: not vm_ova_stat.stat.exists
 
-    # OVA file on NFS server
-    - name: "Get OVA path and file name after mounting NFS storage at local"
-      when: ova_nfs_server_path is defined and ova_nfs_server_path
-      block:
-        - name: "Mount NFS storage at local"
-          include_tasks: ../../common/mount_nfs_storage_local.yml
-          vars:
-            nfs_server_path: "{{ ova_nfs_server_path }}"
-        - name: "Get OVA path and file name"
-          ansible.builtin.set_fact:
-            vm_ova_path: "{{ nfs_mount_dir }}/{{ ova_path }}"
-            vm_ova_name: "{{ ova_path | basename }}"
-    # Check OVA file exists
-    - name: "Check for {{ vm_ova_path }} existence"
-      ansible.builtin.stat:
-        path: "{{ vm_ova_path }}"
-      register: vm_ova_stat
-      failed_when: not vm_ova_stat.stat.exists
+- name: "Deploy a new VM from OVA"
+  include_tasks: ../../common/ovf_deploy.yml
+  vars:
+    ovf_path: "{{ vm_ova_path }}"
+    ovf_vm_name: "{{ vm_name }}"
+    deploy_datastore: "{{ datastore }}"
 
-    - name: "Deploy a new VM from OVA"
-      include_tasks: ../../common/ovf_deploy.yml
-      vars:
-        ovf_path: "{{ vm_ova_path }}"
-        ovf_vm_name: "{{ vm_name }}"
-        deploy_datastore: "{{ datastore }}"
+- name: "Set fact of vm_exists to True"
+  ansible.builtin.set_fact:
+    vm_exists: true
 
-    - name: "Set fact of vm_exists to True"
-      ansible.builtin.set_fact:
-        vm_exists: true
+# Take a snapshot after OVA deploy
+# Reconfiguration must be performed at VM first time boot
+- name: "Set fact of the base snapshot name"
+  ansible.builtin.set_fact:
+    base_snapshot_for_reconfig: "FreshDeployedFromOVA"
 
-    # Take a snapshot after OVA deploy
-    # Reconfiguration must be performed at VM first time boot
-    - name: "Set fact of the base snapshot name"
-      ansible.builtin.set_fact:
-        base_snapshot_for_reconfig: "FreshDeployedFromOVA"
+- name: "Take snapshot after OVA deployment"
+  include_tasks: ../../common/vm_take_snapshot.yml
+  vars:
+    snapshot_name: "{{ base_snapshot_for_reconfig }}"
 
-    - name: "Take snapshot after OVA deployment"
-      include_tasks: ../../common/vm_take_snapshot.yml
-      vars:
-        snapshot_name: "{{ base_snapshot_for_reconfig }}"
+- name: "Collect OVA configs"
+  include_tasks: "../../common/collect_ovf_vm_config.yml"
+  vars:
+    ovf_vm_hardware_config_path: "{{ current_test_log_folder }}"
 
-    - name: "Collect OVA configs"
-      include_tasks: "../../common/collect_ovf_vm_config.yml"
-      vars:
-        ovf_vm_hardware_config_path: "{{ current_test_log_folder }}"
+- name: "Get VM info"
+  include_tasks: ../../common/vm_get_vm_info.yml
 
-    - name: "Get VM info"
-      include_tasks: ../../common/vm_get_vm_info.yml
+- name: "Try to get OS type from guest info"
+  include_tasks: get_ova_guest_os_type.yml
 
-    - name: "Try to get OS type from guest info"
-      include_tasks: get_ova_guest_os_type.yml
+# Revert to snapshot "FreshDeployedFromOVA" to
+# proceed the following tasks so that VM's reconfiguration can be
+# performed at the first time boot.
+- name: "Revert to snapshot '{{ base_snapshot_for_reconfig }}' for VM reconfig"
+  include_tasks: ../../common/vm_revert_snapshot.yml
+  vars:
+    snapshot_name: "{{ base_snapshot_for_reconfig }}"
 
-    # Revert to snapshot "FreshDeployedFromOVA" to
-    # proceed the following tasks so that VM's reconfiguration can be
-    # performed at the first time boot.
-    - name: "Revert to snapshot '{{ base_snapshot_for_reconfig }}' for VM reconfig"
-      include_tasks: ../../common/vm_revert_snapshot.yml
-      vars:
-        snapshot_name: "{{ base_snapshot_for_reconfig }}"
+# Upgrade VM hardware version
+# Note:
+# Known issue on Ubuntu cloud image OVA deployed VM, after upgrade hardware version,
+# VM will hang during booting, tracked in this issue:
+# https://bugs.launchpad.net/cloud-images/+bug/1898871
+- name: "Upgrade VM's hardware version to {{ hardware_version }}"
+  include_tasks: upgrade_ova_vm_hwv.yml
+  when:
+    - hardware_version is defined
+    - (hardware_version == "latest" or
+       (vm_hardware_version_num | int < hardware_version | int))
 
-    # Upgrade VM hardware version
-    # Note:
-    # Known issue on Ubuntu cloud image OVA deployed VM, after upgrade hardware version,
-    # VM will hang during booting, tracked in this issue:
-    # https://bugs.launchpad.net/cloud-images/+bug/1898871
-    - name: "Upgrade VM's hardware version to {{ hardware_version }}"
-      include_tasks: upgrade_ova_vm_hwv.yml
-      when:
-        - hardware_version is defined
-        - (hardware_version == "latest" or
-           (vm_hardware_version_num | int < hardware_version | int))
+# Add serial port for collecting messages
+- name: "Add a serial port for VM"
+  include_tasks: ../../common/vm_add_serial_port.yml
 
-    # Add serial port for collecting messages
-    - name: "Add a serial port for VM"
-      include_tasks: ../../common/vm_add_serial_port.yml
+- name: "Reconfigure VM with cloud-init"
+  include_tasks: reconfigure_vm_with_cloudinit.yml
+  when: ova_guest_os_type in ['photon', 'ubuntu', 'amazon']
 
-    - name: "Reconfigure VM with cloud-init"
-      include_tasks: reconfigure_vm_with_cloudinit.yml
-      when: ova_guest_os_type in ['photon', 'ubuntu', 'amazon']
+- name: "Reconfigure VM with Ignition"
+  include_tasks: reconfigure_vm_with_ignition.yml
+  when: ova_guest_os_type in ['flatcar', 'rhcos']
 
-    - name: "Reconfigure VM with Ignition"
-      include_tasks: reconfigure_vm_with_ignition.yml
-      when: ova_guest_os_type in ['flatcar', 'rhcos']
+- name: "Warning about unknown guest OS type"
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: The guest OS type of the OVA doesn't match known guest OS type for
+      reconfiguration. Please add it if needed or the following tests might fail.
+  when: ova_guest_os_type == 'unknown'
 
-    - name: "Warning about unknown guest OS type"
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: The guest OS type of the OVA doesn't match known guest OS type for
-          reconfiguration. Please add it if needed or the following tests might fail.
-      when: ova_guest_os_type == 'unknown'
+- name: "Shutdown guest OS"
+  include_tasks: ../utils/shutdown.yml
 
-    - name: "Collect VM deployment logs"
-      include_tasks: collect_vm_logs.yml
+- name: "Collect serial port log before removing serial port"
+  include_tasks: collect_serial_port_log.yml
 
-    - name: "Shutdown guest OS"
-      include_tasks: ../utils/shutdown.yml
+- name: "Remove serial port from VM"
+  include_tasks: ../../common/vm_remove_serial_port.yml
 
-    - name: "Collect serial port log before removing serial port"
-      include_tasks: collect_serial_port_log.yml
+# The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+- name: "Remove existing CDROMs"
+  include_tasks: ../../common/vm_configure_cdrom.yml
+  vars:
+    cdrom_type: client
+    cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+    cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+    cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+    cdrom_state: absent
+  with_items: "{{ vm_existing_cdrom_list }}"
+  loop_control:
+    loop_var: vm_cdrom
+  when:
+    - guest_os_ansible_distribution == "Ubuntu"
+    - vm_existing_cdrom_list is defined
+    - vm_existing_cdrom_list | length > 0
 
-    - name: "Remove serial port from VM"
-      include_tasks: ../../common/vm_remove_serial_port.yml
+- name: "Power on VM"
+  include_tasks: ../../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'
 
-    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
-    - name: "Remove existing CDROMs"
-      include_tasks: ../../common/vm_configure_cdrom.yml
-      vars:
-        cdrom_type: client
-        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
-        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
-        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
-        cdrom_state: absent
-      with_items: "{{ vm_existing_cdrom_list }}"
-      loop_control:
-        loop_var: vm_cdrom
-      when:
-        - guest_os_ansible_distribution == "Ubuntu"
-        - vm_existing_cdrom_list is defined
-        - vm_existing_cdrom_list | length > 0
+- name: "Wait for VM's guest full name is displayed in guest info"
+  include_tasks: ../../common/vm_wait_guest_fullname.yml
 
-    - name: "Power on VM"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'powered-on'
-  rescue:
-    # If test case failed before collecting VM cloud-init logs,
-    # the logs need to be collected at rescue
-    - name: "Collect VM deployment logs"
-      include_tasks: collect_vm_logs.yml
-      when: cloudinit_logs_local_path is undefined
-
-    - name: "Collect serial port log at test failure"
-      include_tasks: collect_serial_port_log.yml
-
-    - name: "Test case failure"
-      include_tasks: ../../common/test_rescue.yml
-      vars:
-        exit_testing_when_fail: true
-  always:
-    - name: "Unmount NFS share folder and remove mount folder"
-      when: nfs_mount_dir is defined and nfs_mount_dir
-      block:
-        - name: "Umount NFS share points"
-          include_tasks: ../../common/local_unmount.yml
-          vars:
-            mount_path: "{{ nfs_mount_dir }}"
-            local_unmount_ignore_errors: true
-          when: nfs_mounted is defined and nfs_mounted | bool
-
-        - name: "Remove the mount folder"
-          include_tasks: ../../common/delete_local_file.yml
-          vars:
-            local_path: "{{ nfs_mount_dir }}"
-            del_local_file_ignore_errors: true
+- name: "Update VM's guest IP after reset"
+  include_tasks: ../../common/update_inventory.yml
+  vars:
+    update_inventory_timeout: 300

--- a/linux/deploy_vm/rebuild_debian_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_debian_unattend_install_iso.yml
@@ -24,7 +24,7 @@
     replace: "timeout 1"
 
 - name: "Search string in md5sum.txt"
-  ansible.builtin.shell: grep '/install.386/' {{ src_iso_file_dir }}/md5sum.txt
+  ansible.builtin.shell: "grep '/install.386/' {{ src_iso_file_dir }}/md5sum.txt"
   ignore_errors: true
   register: result_search_str
 
@@ -46,6 +46,7 @@
     regexp: "default .*"
     replace: "default installgui"
 
+# Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
 - name: "Update Debian grub.cfg for autoinstall"
   ansible.builtin.blockinfile:
     path: "{{ src_iso_file_dir }}/grub.cfg"
@@ -54,15 +55,16 @@
       set timeout=5
       menuentry "Automated installation" --id autoinstall {
           set background_color=black
-          linux    /{{ debian_install_type }}/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} vga=788 --- quiet
-          initrd   /{{ debian_install_type }}/gtk/initrd.gz
+          linux /{{ debian_install_type }}/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} vga=788 "DPMS=-s 0" --- quiet
+          initrd /{{ debian_install_type }}/gtk/initrd.gz
       }
 
+# Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
 - name: "Update boot menu with preseed.cfg for Debian"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/gtk.cfg"
-    regexp: '(.*)(initrd.gz )(.*)'
-    replace: "\\1\\2 auto=true file=/cdrom/{{ unattend_install_file_name }} \\3"
+    regexp: 'initrd.gz'
+    replace: 'initrd.gz auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0"'
 
 - name: "Update md5sum for Debian ISO files"
   ansible.builtin.shell: "{{ item }}"
@@ -73,12 +75,12 @@
     - "echo \"`md5sum grub.cfg | awk '{print $1}'` ./boot/grub/grub.cfg\" >>md5sum.txt"
   args:
     chdir: "{{ src_iso_file_dir }}"
-  register: update_initrd_output
+  register: update_md5sum_result
 
-- name: "Print command output for updating initrd"
-  ansible.builtin.debug: var=update_initrd_output
+- name: "Print command output for updating files' md5sum"
+  ansible.builtin.debug: var=update_md5sum_result
 
-- name: "Customize the ISO"
+- name: "Rebuild Debian ISO image with fully auto install configs"
   community.general.iso_customize:
     src_iso: "{{ src_iso_file_path }}"
     dest_iso: "{{ rebuilt_unattend_iso_path }}"
@@ -93,3 +95,7 @@
         dest_file: "md5sum.txt"
       - src_file: "{{ new_unattend_install_conf }}"
         dest_file: "{{ unattend_install_file_name }}"
+      - src_file: "{{ src_iso_file_dir }}/{{ pre_install_script_file }}"
+        dest_file: "{{ pre_install_script_file }}"
+      - src_file: "{{ src_iso_file_dir }}/{{ post_install_script_file }}"
+        dest_file: "{{ post_install_script_file }}"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -39,16 +39,17 @@
     - "install_en.cfg"
     - "install.cfg"
 
+# Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
 - name: "Update boot parameters with preseed.cfg"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/{{ item }}"
-    regexp: '(.*)(append )(.*)'
-    replace: "\\1\\2 auto=true file=/cdrom/{{ unattend_install_file_name }} \\3"
+    regexp: 'append'
+    replace: 'append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0"'
   with_items:
     - "install_en.cfg"
     - "install.cfg"
 
-- name: "Update default memuentry for grub.cfg"
+- name: "Update default memu entry for grub.cfg"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/grub.cfg"
     regexp: "set default=0"
@@ -60,6 +61,7 @@
     insertafter: "^submenu.*English.*{#"
     line: '  set default="autoinstall"'
 
+# Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
 - name: "Update boot parameters for autoinstall"
   ansible.builtin.blockinfile:
     path: "{{ src_iso_file_dir }}/grub.cfg"
@@ -68,8 +70,8 @@
       # menuentry for unattended installation
         menuentry "Automated installation" --id autoinstall {
           set background_color=black
-          linux    /install/gtk/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 --- quiet
-          initrd   /install/gtk/initrd.gz
+          linux  /install/gtk/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
+          initrd /install/gtk/initrd.gz
         }
 
 - name: "Update md5sum for Pardus ISO files"
@@ -85,10 +87,10 @@
     - "echo \"`md5sum install.cfg | awk '{print $1}'` ./isolinux/install.cfg\" >>md5sum.txt"
   args:
     chdir: "{{ src_iso_file_dir }}"
-  register: update_initrd_output
+  register: update_md5sum_result
 
-- name: "Print command output for updating initrd"
-  ansible.builtin.debug: var=update_initrd_output
+- name: "Print command output for updating files' md5sum"
+  ansible.builtin.debug: var=update_md5sum_result
 
 - name: "Customize the ISO"
   community.general.iso_customize:
@@ -107,4 +109,7 @@
         dest_file: "md5sum.txt"
       - src_file: "{{ new_unattend_install_conf }}"
         dest_file: "{{ unattend_install_file_name }}"
-
+      - src_file: "{{ src_iso_file_dir }}/{{ pre_install_script_file }}"
+        dest_file: "{{ pre_install_script_file }}"
+      - src_file: "{{ src_iso_file_dir }}/{{ post_install_script_file }}"
+        dest_file: "{{ post_install_script_file }}"

--- a/linux/deploy_vm/rebuild_ubuntu_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_ubuntu_unattend_install_iso.yml
@@ -7,175 +7,132 @@
 #   src_iso_file_path: Local path of source ISO image file
 #   src_iso_file_dir: Local dir of source ISO image file
 #
-- name: "Rebuild ISO for Ubuntu 20.04 ~ 22.10 desktop"
+- name: "Extract boot config file boot/grub/grub.cfg and md5sum.txt from ISO"
+  community.general.iso_extract:
+    image: "{{ src_iso_file_path }}"
+    dest: "{{ src_iso_file_dir }}"
+    files:
+      - "boot/grub/grub.cfg"
+      - "md5sum.txt"
+
+- name: "Try to extract BIOS boot config file isolinux/txt.cfg from ISO"
+  community.general.iso_extract:
+    image: "{{ src_iso_file_path }}"
+    dest: "{{ src_iso_file_dir }}"
+    files:
+      - "isolinux/txt.cfg"
+  ignore_errors: true
+  register: extract_bios_cfg
+
+- name: "Set fact of BIOS boot config file isolinux.cfg exists or not"
+  ansible.builtin.set_fact:
+    ubuntu_bios_cfg_exist: "{{ extract_bios_cfg.failed is defined and not extract_bios_cfg.failed }}"
+
+- name: "Set timeout to 5 seconds at boot menu in boot/grub/grub.cfg"
+  ansible.builtin.replace:
+    path: "{{ unattend_iso_cache }}/grub.cfg"
+    regexp: 'set timeout=.*'
+    replace: "set timeout=5"
+
+- name: "Rebuild ISO for Ubuntu desktop using Ubiquity installer"
+  when: unattend_installer == "Ubuntu-Ubiquity"
   block:
-    - name: "Extract specific files inside ISO"
-      community.general.iso_extract:
-        image: "{{ src_iso_file_path }}"
-        dest: "{{ src_iso_file_dir }}"
-        files:
-          - "boot/grub/grub.cfg"
+    # casper command options can be found at https://manpages.ubuntu.com/manpages/jammy/man7/casper.7.html
+    - name: "Set fact of boot command options for Ubiquity installer"
+      ansible.builtin.set_fact:
+        ubiquity_boot_options: >-
+          boot=casper fsck.mode=skip debug-ubiquity automatic-ubiquity
+          quiet splash noprompt --- console=ttyS0,115200n8
 
-    - name: "Modify boot entry"
-      ansible.builtin.replace:
+    - name: "Add menu entry for autoinstall in boot/grub/grub.cfg"
+      ansible.builtin.blockinfile:
         path: "{{ src_iso_file_dir }}/grub.cfg"
-        regexp: "set timeout=[1-9][0-9]{0,1}"
-        replace: "default=0\nset timeout=2"
+        insertafter: "set timeout=.*"
+        block: |
+          set default="autoinstall"
+          menuentry "Automated installation" --id autoinstall {
+            set gfxpayload=keep
+            linux /casper/vmlinuz file=/cdrom/preseed/ubuntu.seed {{ ubiquity_boot_options }}
+            initrd /casper/initrd
+          }
 
-    - name: "Modify boot options"
+    - name: "Add menu entry for autoinstall in isolinux/txt.cfg"
       ansible.builtin.replace:
-        path: "{{ src_iso_file_dir }}/grub.cfg"
-        regexp: "file=/cdrom/preseed/ubuntu.seed maybe-ubiquity quiet splash ---"
-        replace: "file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity quiet splash noprompt --- console=ttyS0,115200n8"
+        path: "{{ src_iso_file_dir }}/txt.cfg"
+        regexp: 'default live'
+        replace: |
+          default live-install
+          label live-install
+            menu label ^Automated Install Ubuntu
+            kernel /casper/vmlinuz
+            append file=/cdrom/preseed/ubuntu.seed initrd=/casper/initrd {{ ubiquity_boot_options }}
+      when: ubuntu_bios_cfg_exist | bool
 
-    - name: "Print the content of modified file grub.cfg"
-      ansible.builtin.debug:
-        msg: "{{ lookup('file', src_iso_file_dir + '/grub.cfg') }}"
-
-    - name: "Extract isolinux/isolinux.cfg inside ISO for old releases"
-      community.general.iso_extract:
-        image: "{{ src_iso_file_path }}"
-        dest: "{{ src_iso_file_dir }}"
-        files:
-          - "isolinux/isolinux.cfg"
-      ignore_errors: true
-      register: result_extract_file
-
-    - name: "Modify isolinux.cfg for some old releases such as Ubuntu 20.04 when the firmware is bios"
-      block:
-        - name: "Modify boot option"
-          ansible.builtin.blockinfile:
-            path: "{{ src_iso_file_dir }}/isolinux.cfg"
-            insertafter: "^#.*etc.*"
-            block: |
-              default live-install
-              label live-install
-                menu label ^Install Ubuntu
-                kernel /casper/vmlinuz
-                append  file=/cdrom/preseed/ubuntu.seed boot=casper debug-ubiquity automatic-ubiquity initrd=/casper/initrd quiet splash noprompt --- console=ttyS0,115200n8
-
-        - name: "Print the content of modified file isolinux.cfg"
-          ansible.builtin.debug:
-            msg: "{{ lookup('file', src_iso_file_dir + '/isolinux.cfg') }}"
-
-        - name: "Customize the ISO with isolinux/isolinux.cfg"
-          community.general.iso_customize:
-            src_iso: "{{ src_iso_file_path }}"
-            dest_iso: "{{ rebuilt_unattend_iso_path }}"
-            add_files:
-              - src_file: "{{ src_iso_file_dir }}/grub.cfg"
-                dest_file: "/boot/grub/grub.cfg"
-              - src_file: "{{ new_unattend_install_conf }}"
-                dest_file: "/preseed/ubuntu.seed"
-              - src_file: "{{ src_iso_file_dir }}/isolinux.cfg"
-                dest_file: "/isolinux/isolinux.cfg"
-      when: 
-        - result_extract_file is defined
-        - result_extract_file.failed is defined
-        - not result_extract_file.failed
-
-    - name: "Customize the ISO without isolinux/isolinux.cfg"
-      community.general.iso_customize:
-        src_iso: "{{ src_iso_file_path }}"
-        dest_iso: "{{ rebuilt_unattend_iso_path }}"
-        add_files:
+    - name: "Set facts of files to be updated or added into Ubuntu ISO"
+      ansible.builtin.set_fact:
+        update_iso_files:
           - src_file: "{{ src_iso_file_dir }}/grub.cfg"
             dest_file: "/boot/grub/grub.cfg"
+          - src_file: "{{ src_iso_file_dir }}/md5sum.txt"
+            dest_file: "/md5sum.txt"
           - src_file: "{{ new_unattend_install_conf }}"
             dest_file: "/preseed/ubuntu.seed"
-      when: 
-        - result_extract_file is defined
-        - result_extract_file.failed is defined
-        - result_extract_file.failed
-  when: unattend_install_conf is match('Ubuntu/Desktop/Ubiquity')
+          - src_file: "{{ src_iso_file_dir }}/{{ pre_install_script_file }}"
+            dest_file: "/preseed/{{ pre_install_script_file }}"
+          - src_file: "{{ src_iso_file_dir }}/{{ post_install_script_file }}"
+            dest_file: "/preseed/{{ post_install_script_file }}"
 
-- name: "Rebuild ISO for Ubuntu live server / Ubuntu 23.04 or later Desktop"
+- name: "Rebuild ISO for Ubuntu desktop or live server using Subiquity installer"
+  when: unattend_installer == "Ubuntu-Subiquity"
   block:
-    - name: Extract specific files inside ISO
-      community.general.iso_extract:
-        image: "{{ src_iso_file_path }}"
-        dest: "{{ src_iso_file_dir }}"
-        files:
-          - 'boot/grub/grub.cfg'
-          - 'md5sum.txt'
-
-    - name: "Add autoinstall to UEFI boot kernel command for Ubuntu live server"
+    - name: "Update boot command options in boot/grub/grub.cfg"
       ansible.builtin.replace:
         path: "{{ unattend_iso_cache }}/grub.cfg"
-        regexp: '(.*vmlinuz)(.*)'
-        replace: "\\1 autoinstall console=ttyS0,115200n8 \\2"
+        regexp: '(.*vmlinuz )(.*)'
+        replace: "\\1autoinstall \\2 console=ttyS0,115200n8 "
 
-    - name: "Set timeout to 5 seconds at boot menu"
+    - name: "Update boot command options in isolinux/txt.cfg"
       ansible.builtin.replace:
-        path: "{{ unattend_iso_cache }}/grub.cfg"
-        regexp: 'set timeout=.*'
-        replace: "set timeout=5"
+        path: "{{ unattend_iso_cache }}/txt.cfg"
+        regexp: '(.*initrd )(.*)'
+        replace: "\\1autoinstall \\2 console=ttyS0,115200n8"
+      when: ubuntu_bios_cfg_exist | bool
 
-    - name: "Update md5sum for UEFI boot config file"
-      ansible.builtin.shell: |
-        md5=`md5sum grub.cfg | awk '{print $1}'`
-        sed -i "/.\/boot\/grub\/grub.cfg/ s/^[^ ]*/$md5/" md5sum.txt
-      args:
-        chdir: "{{ unattend_iso_cache }}"
-
-    - name: "set var ubuntu_bios_cfg_exist to default false"
+    - name: "Set facts of files to be updated or added into Ubuntu ISO"
       ansible.builtin.set_fact:
-        ubuntu_bios_cfg_exist: false
-
-    - name: "Extract isolinux/txt.cfg inside ISO if exists"
-      community.general.iso_extract:
-        image: "{{ src_iso_file_path }}"
-        dest: "{{ src_iso_file_dir }}"
-        files:
-          - 'isolinux/txt.cfg'
-      register: check_file_result
-      ignore_errors: true
-
-    - debug: var=check_file_result
-
-    - name: "set var ubuntu_bios_cfg_exist to true or not"
-      ansible.builtin.set_fact:
-        ubuntu_bios_cfg_exist: true
-      when: not check_file_result.failed
-
-    - name: "Update BIOS boot config file if it exists and Customize ISO"
-      block:
-        - name: "Add autoinstall to BIOS boot kernel command for Ubuntu live server"
-          ansible.builtin.replace:
-            path: "{{ unattend_iso_cache }}/txt.cfg"
-            regexp: '(.*initrd)(.*)'
-            replace: "\\1 autoinstall console=ttyS0,115200n8 \\2"
-
-        - name: "Update md5sum for BIOS boot config file"
-          ansible.builtin.shell: |
-            md5=`md5sum txt.cfg | awk '{print $1}'`
-            sed -i "/.\/isolinux\/txt.cfg/ s/^[^ ]*/$md5/" md5sum.txt
-          args:
-            chdir: "{{ unattend_iso_cache }}"
-
-        - name: "Customize the ISO"
-          community.general.iso_customize:
-            src_iso: "{{ src_iso_file_path }}"
-            dest_iso: "{{ rebuilt_unattend_iso_path }}"
-            add_files:
-              - src_file: "{{ src_iso_file_dir }}/grub.cfg"
-                dest_file: "boot/grub/grub.cfg"
-              - src_file: "{{ src_iso_file_dir }}/md5sum.txt"
-                dest_file: "md5sum.txt"
-              - src_file: "{{ src_iso_file_dir }}/txt.cfg"
-                dest_file: "isolinux/txt.cfg"
-      when: ubuntu_bios_cfg_exist
-
-    - name: "Customize the ISO without txt.cfg"
-      community.general.iso_customize:
-        src_iso: "{{ src_iso_file_path }}"
-        dest_iso: "{{ rebuilt_unattend_iso_path }}"
-        add_files:
+        update_iso_files:
           - src_file: "{{ src_iso_file_dir }}/grub.cfg"
-            dest_file: "boot/grub/grub.cfg"
+            dest_file: "/boot/grub/grub.cfg"
           - src_file: "{{ src_iso_file_dir }}/md5sum.txt"
-            dest_file: "md5sum.txt"
-      when: not ubuntu_bios_cfg_exist
-  when: >-
-    (unattend_install_conf is match('Ubuntu/Server') or
-     unattend_install_conf is match('Ubuntu/Desktop/Subiquity'))
+            dest_file: "/md5sum.txt"
+
+- name: "Update md5sum checksum for boot/grub/grub.cfg"
+  ansible.builtin.shell: |
+    md5=`md5sum grub.cfg | awk '{print $1}'`
+    sed -i "/.\/boot\/grub\/grub.cfg/ s/^[^ ]*/$md5/" md5sum.txt
+  args:
+    chdir: "{{ src_iso_file_dir }}"
+
+- name: "Add isolinux/txt.cfg to update ISO file list and updates its md5sum"
+  when: ubuntu_bios_cfg_exist | bool
+  block:
+    - name: "Set facts of boot config files to be updated in ISO"
+      ansible.builtin.set_fact:
+        update_iso_files: >-
+          {{ update_iso_files +
+            [{'src_file': src_iso_file_dir ~ '/txt.cfg',
+              'dest_file': '/isolinux/txt.cfg'}]
+          }}
+
+    - name: "Update md5sum checksum for isolinux/txt.cfg"
+      ansible.builtin.shell: |
+        md5=`md5sum txt.cfg | awk '{print $1}'`
+        sed -i "/.\/isolinux\/txt.cfg/ s/^[^ ]*/$md5/" md5sum.txt
+      args:
+        chdir: "{{ src_iso_file_dir }}"
+
+- name: "Rebuild ISO for Ubuntu Desktop with Ubiquity installer"
+  community.general.iso_customize:
+    src_iso: "{{ src_iso_file_path }}"
+    dest_iso: "{{ rebuilt_unattend_iso_path }}"
+    add_files: "{{ update_iso_files }}"

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -41,9 +41,3 @@
       - src_file: "{{ new_unattend_install_conf }}"
         dest_file: "/etc/installerconfig"
   when: unattend_installer == "FreeBSD"
-
-# Remove original OS ISO image downloaded from ESXi datastore
-- name: "Remove source ISO image from local cache"
-  ansible.builtin.file:
-    path: "{{ src_iso_file_path }}"
-    state: absent

--- a/linux/deploy_vm/rebuild_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_unattend_install_iso.yml
@@ -10,8 +10,9 @@
     iso_file_datastore: "{{ os_installation_iso_list[0].split()[0] | regex_replace('\\[|\\]', '') }}"
     iso_file_path_in_datastore: "{{ os_installation_iso_list[0].split()[1] }}"
 
-# Fetch ISO file from ESXi datastore
-- include_tasks: ../../common/esxi_download_datastore_file.yml
+# Fetch original ISO file from ESXi datastore
+- name: "Download source ISO image file from ESXi datastore"
+  include_tasks: ../../common/esxi_download_datastore_file.yml
   vars:
     src_datastore: "{{ iso_file_datastore }}"
     src_file_path: "{{ iso_file_path_in_datastore }}"
@@ -28,19 +29,21 @@
   ansible.builtin.set_fact:
     unattend_install_file_name: "{{ new_unattend_install_conf | basename }}"
 
-- name: "Set fact of unattend install config file name"
-  ansible.builtin.set_fact:
-    unattend_install_os_type: "{{ unattend_install_conf.split('/')[0]  | lower }}"
+- name: "Rebuild ISO image file for {{ unattend_installer }}"
+  include_tasks: "rebuild_{{ unattend_installer.split('-')[0] | lower }}_unattend_install_iso.yml"
+  when: unattend_installer in ["Ubuntu-Ubiquity", "Ubuntu-Subiquity", "Photon", "Debian", "Pardus"]
 
-- name: "rebuild ISO for {{ unattend_install_os_type }}"
-  include_tasks: "rebuild_{{ unattend_install_os_type }}_unattend_install_iso.yml"
-  when: unattend_install_os_type in ["photon", "debian", "ubuntu", "pardus"]
-
-- name: "Rebuild ISO for FreeBSD"
+- name: "Rebuild ISO image file for FreeBSD"
   community.general.iso_customize:
     src_iso: "{{ src_iso_file_path }}"
     dest_iso: "{{ rebuilt_unattend_iso_path }}"
     add_files:
       - src_file: "{{ new_unattend_install_conf }}"
         dest_file: "/etc/installerconfig"
-  when: unattend_install_os_type == "freebsd"
+  when: unattend_installer == "FreeBSD"
+
+# Remove original OS ISO image downloaded from ESXi datastore
+- name: "Remove source ISO image from local cache"
+  ansible.builtin.file:
+    path: "{{ src_iso_file_path }}"
+    state: absent

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -27,43 +27,26 @@
       }}
   when: ova_guest_os_type in ['amazon', 'ubuntu']
 
-- name: "Create a temporary folder for caching cloud-init seed data and ISO files"
-  include_tasks: ../../common/create_temp_file_dir.yml
-  vars:
-    tmp_dir: "{{ local_cache }}"
-    tmp_state: "directory"
-    tmp_prefix: "seed_iso_"
-
-- name: "Set fact of cloud-init seed ISO directory path"
-  ansible.builtin.set_fact:
-    seed_iso_dir_path: "{{ tmp_path }}"
-
 - name: "Create cloud-init seed ISO to configure guest OS"
   include_tasks: ../utils/create_seed_iso.yml
   vars:
+    seed_iso_dir_path: "{{ unattend_iso_cache }}"
     user_data_template: "{{ ova_guest_os_type }}-ova-user-data.j2"
     local_hostname: "{{ ova_guest_os_type }}-ova-{{ hostname_timestamp }}"
+
+- name: "Set fact of cloud-init seed ISO to be uploaded to ESXi datastore"
+  ansible.builtin.set_fact:
+    transferred_unattend_iso_list: ["{{ seed_iso_path | basename }}"]
+
+- name: "Display cloud-init seed ISO to be uploaded to ESXi datastore"
+  ansible.builtin.debug:
+    msg: "The cloud-init seed ISO to be uploaded to ESXi datastore {{ datastore }}: {{ transferred_unattend_iso_list }}"
 
 - name: "Upload cloud-init seed ISO to ESXi server datastore"
   include_tasks: ../../common/esxi_upload_datastore_file.yml
   vars:
     src_file_path: "{{  seed_iso_path }}"
     dest_file_path: "{{ vm_dir_name }}/{{ seed_iso_path | basename }}"
-
-- name: "Remove cloud-init seed ISO from local cache folder {{ seed_iso_dir_path }}"
-  include_tasks: ../../common/delete_local_file.yml
-  vars:
-    local_path: "{{ seed_iso_path }}"
-
-- name: "Copy cloud-init seed data files to test log folder"
-  ansible.builtin.copy:
-    src: "{{ seed_iso_dir_path }}/"
-    dest: "{{ current_test_log_folder }}/"
-
-- name: "Remove local cache folder {{ seed_iso_dir_path }}"
-  include_tasks: ../../common/delete_local_file.yml
-  vars:
-    local_path: "{{ seed_iso_dir_path }}"
 
 - name: "Initialize CDROM device for attaching cloud-init seed ISO"
   ansible.builtin.set_fact:

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -27,6 +27,17 @@
       }}
   when: ova_guest_os_type in ['amazon', 'ubuntu']
 
+- name: "Create a temporary folder for caching cloud-init seed data and ISO files"
+  include_tasks: ../../common/create_temp_file_dir.yml
+  vars:
+    tmp_dir: "{{ local_cache }}"
+    tmp_state: "directory"
+    tmp_prefix: "seed_iso_"
+
+- name: "Set fact of cloud-init seed ISO directory path"
+  ansible.builtin.set_fact:
+    seed_iso_dir_path: "{{ tmp_path }}"
+
 - name: "Create cloud-init seed ISO to configure guest OS"
   include_tasks: ../utils/create_seed_iso.yml
   vars:
@@ -38,6 +49,21 @@
   vars:
     src_file_path: "{{  seed_iso_path }}"
     dest_file_path: "{{ vm_dir_name }}/{{ seed_iso_path | basename }}"
+
+- name: "Remove cloud-init seed ISO from local cache folder {{ seed_iso_dir_path }}"
+  include_tasks: ../../common/delete_local_file.yml
+  vars:
+    local_path: "{{ seed_iso_path }}"
+
+- name: "Copy cloud-init seed data files to test log folder"
+  ansible.builtin.copy:
+    src: "{{ seed_iso_dir_path }}/"
+    dest: "{{ current_test_log_folder }}/"
+
+- name: "Remove local cache folder {{ seed_iso_dir_path }}"
+  include_tasks: ../../common/delete_local_file.yml
+  vars:
+    local_path: "{{ seed_iso_dir_path }}"
 
 - name: "Initialize CDROM device for attaching cloud-init seed ISO"
   ansible.builtin.set_fact:
@@ -115,10 +141,13 @@
 - name: "Eject CDROM devices from guest OS"
   include_tasks: ../utils/eject_cdrom_in_guest.yml
 
-- name: "Remove local temporary directory {{ tmp_seed_dir }}"
-  include_tasks: ../../common/delete_local_file.yml
+- name: "Delete uploaded cloud-init seed ISO from ESXi datastore"
+  include_tasks: ../../common/esxi_check_delete_datastore_file.yml
   vars:
-    local_path: "{{ tmp_seed_dir }}"
+    file_in_datastore: "{{ datastore }}"
+    file_in_datastore_path: "{{ vm_dir_name }}/{{ seed_iso_path | basename }}"
+    file_in_datastore_ops: "absent"
+    file_in_datastore_ignore_failed: true
 
 - name: "Get all CDROM devices on VM"
   include_tasks: ../../common/vm_get_cdrom_devices.yml

--- a/linux/deploy_vm/templates/post_install_scripts/add_pardus_repo.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/add_pardus_repo.sh
@@ -1,0 +1,9 @@
+MAJOR_VERSION=$(echo $VERSION_ID | cut -d '.' -f 1)
+if [ $MAJOR_VERSION -ge 23 ]; then
+    echo "deb http://depo.pardus.org.tr/pardus $VERSION_CODENAME main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+    echo "deb http://depo.pardus.org.tr/pardus ${VERSION_CODENAME}-deb main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+    echo "deb http://depo.pardus.org.tr/guvenlik ${VERSION_CODENAME}-deb main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+else
+    echo "deb http://depo.pardus.org.tr/pardus $VERSION_CODENAME main contrib non-free" >> /etc/apt/sources.list
+    echo "deb http://depo.pardus.org.tr/guvenlik $VERSION_CODENAME main contrib non-free" >> /etc/apt/sources.list
+fi;

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -1,0 +1,47 @@
+#Install open-vm-toools from CDROM if it exists
+cdrom_missing_pkgs=""
+for pkg in $required_pkgs; do
+    echo "Searching package $pkg in CDROM"
+    apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
+    pkg_in_cdrom=$?
+    if [ $pkg_in_cdrom -eq 0 ]; then
+        echo "Installing pacakge $pkg from CDROM"
+        apt install -y $pkg 2>&1
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Failed to install package $pkg from CDROM"
+        fi
+    else
+        echo "Package $pkg doesn't exist in CDROM"
+        cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
+    fi
+done
+
+if [ "X$cdrom_missing_pkgs" != "X" ]; then
+    echo "Adding $OS_NAME $VERSION_ID ($VERSION_CODENAME) offical online repo"
+{% if unattend_installer == 'Debian' %}
+    echo "deb http://deb.debian.org/debian/ $VERSION_CODENAME main contrib" >> /etc/apt/sources.list
+{% elif unattend_installer == 'Pardus' %}
+    {% include 'add_pardus_repo.sh' %}
+{% endif %}
+
+    echo "APT source list with online repos:"
+    cat /etc/apt/sources.list
+
+    echo "Updating list of available packages"
+    apt update -y 2>&1
+
+    for pkg in $cdrom_missing_pkgs; do
+        echo "Searching package $pkg in online repo"
+        apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
+        pkg_in_online_repo=$?
+        if [ $pkg_in_online_repo -eq 0 ]; then
+            echo "Installing package $pkg from online repo"
+            apt install -y $pkg 2>&1
+            if [ $? -ne 0 ]; then
+                echo "ERROR: Failed to install package $pkg from online repo"
+            fi
+        else
+            echo "ERROR: Failed to find package $pkg from CDROM and online repo"
+        fi
+    done
+fi

--- a/linux/deploy_vm/templates/post_install_scripts/config_ssh.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/config_ssh.sh
@@ -1,0 +1,27 @@
+if [ -f /etc/ssh/sshd_config ]; then
+    echo "Config SSHd server to permit root login and password authentication"
+    sed -ri 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+    sed -ri 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+else
+    echo "ERROR: openssh-server is not installed in system"
+fi
+
+{% if new_user is defined and new_user != 'root' %}
+echo "Add new user {{ new_user }} to sudoers"
+echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/{{ new_user }}
+{% endif %}
+
+# Add ssh keys
+echo "Add SSH authorized keys for root"
+mkdir -p -m 700 /root/.ssh
+echo "{{ ssh_public_key }}" > /root/.ssh/authorized_keys
+chown --recursive root:root /root/.ssh
+chmod 0644 /root/.ssh/authorized_keys
+
+{% if new_user is defined and new_user != 'root' %}
+echo "Add SSH authorized keys for new user {{ new_user }}"
+mkdir -p -m 700 /home/{{ new_user }}/.ssh
+echo "{{ ssh_public_key }}" > /home/{{ new_user }}/.ssh/authorized_keys
+chown --recursive {{ new_user }}:{{ new_user }} /home/{{ new_user }}/.ssh
+chmod 0644 /home/{{ new_user }}/.ssh/authorized_keys
+{% endif %}

--- a/linux/deploy_vm/templates/post_install_scripts/disable_greeter.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/disable_greeter.sh
@@ -1,0 +1,13 @@
+if [[ "X$OS_DM" =~ Xgdm ]]; then
+    echo "Disable GNOME initial setup at first login"
+    mkdir -p -m 755 /root/.config
+    echo "yes" > /root/.config/gnome-initial-setup-done
+    chown --recursive root:root /root/.config
+{% if new_user is defined and new_user != 'root' %}
+    mkdir -p -m 755 /home/{{ new_user }}/.config
+    echo "yes" > /home/{{ new_user }}/.config/gnome-initial-setup-done
+    chown --recursive {{ new_user }}:{{ new_user }} /home/{{ new_user }}/.config
+{% endif %}
+elif [[ "X$OS_DM" =~ Xlightdm ]]; then
+    echo "TBD: Disable XFCE greeter at first login"
+fi

--- a/linux/deploy_vm/templates/post_install_scripts/disable_screen_saver.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/disable_screen_saver.sh
@@ -1,0 +1,27 @@
+if [[ "X$OS_DM" =~ Xgdm ]]; then
+    echo "Disable GNOME blank screen, screen saver and automatic suspend"
+    cat >/etc/dconf/profile/user <<EOF
+user-db:user
+system-db:local
+EOF
+
+    mkdir -p /etc/dconf/db/local.d
+    chmod a+rx /etc/dconf/db/local.d
+    cat >/etc/dconf/db/local.d/00-gdm <<EOF
+[org/gnome/desktop/screensaver]
+lock-enabled=false
+
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout=0
+sleep-inactive-ac-type='nothing'
+EOF
+    chmod a+rx /etc/dconf/db/local.d/00-gdm
+    echo "Update the system dconf databases"
+    dconf update
+elif [[ "X$OS_DM" =~ Xlightdm ]] && [ -f /etc/xdg/autostart/light-locker.desktop ]; then
+    echo "TBD: Disable XFCE screen saver and blank screen"
+    echo "Hidden=true" >> /etc/xdg/autostart/light-locker.desktop
+fi

--- a/linux/deploy_vm/templates/post_install_scripts/enable_auto_login.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/enable_auto_login.sh
@@ -1,0 +1,20 @@
+# Enable user auto login
+if [[ "X$OS_DM" =~ Xgdm ]] && [[ "X$OS_DM_CONF" != "X" ]]; then
+{% if new_user is defined and new_user != 'root' %}
+    echo "Enable auto login for new user {{ new_user }}"
+    sed -ri 's/#? *AutomaticLogin *=.*$/AutomaticLogin={{ new_user }}/' $OS_DM_CONF
+{% else %}
+    echo "Enable auto login for root"
+    sed -ri 's/#? *AutomaticLogin *=.*$/AutomaticLogin=root/' $OS_DM_CONF
+{% endif %}
+    sed -ri 's/#? *AutomaticLoginEnable *=.*$/AutomaticLoginEnable=true/' $OS_DM_CONF
+elif [[ "X$OS_DM" =~ Xlightdm ]] && [[ "X$OS_DM_CONF" != "X" ]]; then
+{% if new_user is defined and new_user != 'root' %}
+    echo "Enable auto login for new user {{ new_user }}"
+    sed -ri 's/#autologin-user=/autologin-user={{ new_user }}/' $OS_DM_CONF
+{% else %}
+    echo "Enable auto login for root"
+    sed -ri 's/#autologin-user=/autologin-user=root/' $OS_DM_CONF
+{% endif %}
+    sed -ri 's/#autologin-user-timeout=.*$/autologin-user-timeout=0/' $OS_DM_CONF
+fi

--- a/linux/deploy_vm/templates/post_install_scripts/get_os_info.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/get_os_info.sh
@@ -1,0 +1,47 @@
+echo "OS release information:"
+. /etc/os-release
+OS_NAME=$NAME
+OS_ID=$ID
+echo "OS name is $OS_NAME, release version is $VERSION_ID, codename is $VERSION_CODENAME"
+
+echo "System environment variables:"
+env | sort
+
+# Get IPv4 address
+ip_addr=$(ip -o -f inet addr show | grep -v 127.0.0.1 | awk '{print $4}')
+if [ "X$ip_addr" == "X" ]; then
+    ip_link_name=$(ip -o -f inet addr show | grep -v 127.0.0.1 | awk '{print $2}')
+    echo "Network interface $ip_link_name has no DHCP IPv4 address. Try to bring it up now ..."
+    ip link set $ip_link_name up
+    sleep 5
+    ip_addr=$(ip -o -f inet addr show | grep -v 127.0.0.1 | awk '{print $4}')
+fi
+
+if [ "X$ip_addr" != "X" ]; then
+    echo "DHCP IPv4 address at post-install: $ip_addr"
+else
+    echo "ERROR: Failed to obtain DHCP IPv4 address"
+fi
+
+# Get display manager and config file
+if [ -f /etc/systemd/system/display-manager.service ]; then
+    OS_DM=$(readlink /etc/systemd/system/display-manager.service | awk -F '/' '{print $NF}' | awk -F '.' '{print $0}')
+    if [[ "X$OS_DM" =~ Xgdm ]]; then
+        echo "$OS_NAME $VERSION_ID display manager is GNOME"
+        # Display manager config file
+        if [ "X$OS_ID" == "Xdebian" ]; then
+            OS_DM_CONF=/etc/gdm3/daemon.conf
+        elif [ "X$OS_ID" == "Xubuntu" ]; then
+            OS_DM_CONF=/etc/gdm3/custom.conf
+        else
+            OS_DM_CONF=/etc/gdm/custom.conf
+        fi
+    elif [[ "$OS_DM" =~ lightdm ]]; then
+        OS_DM_CONF=/etc/lightdm/lightdm.conf
+    fi
+
+    if [ "X$OS_DM_CONF" != "X" ] && [ ! -e "$OS_DM_CONF" ]; then
+      echo "ERROR: $OS_DM_CONF doesn't exist. Please check the config file for $OS_DM"
+      OS_DM_CONF=""
+    fi
+fi

--- a/linux/deploy_vm/templates/post_install_scripts/preseed_late_command.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/preseed_late_command.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Get OS information
+{% include 'get_os_info.sh' %}
+
+# Install required packages
+required_pkgs="open-vm-tools"
+{% if unattend_installer == 'Ubuntu-Ubiquity' %}
+# Ubuntu Desktop required packages
+required_pkgs="$required_pkgs open-vm-tools-desktop build-essential openssh-server vim locales cloud-init rdma-core rdmacm-utils ibverbs-utils"
+{% elif unattend_installer == 'Debian' %}
+# Debian required packages
+required_pkgs="$required_pkgs open-vm-tools-desktop cloud-init debconf-utils rdma-core rdmacm-utils ibverbs-utils"
+{% elif unattend_installer == 'Pardus' %}
+# Pardus required packages
+required_pkgs="$required_pkgs openssh-server build-essential open-vm-tools sg3-utils vim python3-apt dbus"
+if [ "X$OS_DM" != "X" ]; then
+  required_pkgs="$required_pkgs open-vm-tools-desktop"
+fi
+{% endif %}
+
+{% include 'apt_install_pkgs.sh' %}
+
+# Set default locale
+{% include 'set_locale.sh' %}
+
+{% include 'config_ssh.sh' %}
+
+{% include 'enable_auto_login.sh' %}
+
+{% include 'disable_greeter.sh' %}
+
+{% include 'disable_screen_saver.sh' %}

--- a/linux/deploy_vm/templates/post_install_scripts/set_locale.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/set_locale.sh
@@ -1,0 +1,4 @@
+if [ -e /etc/default/locale ]; then
+    echo "Set default locale to en_US.UTF-8"
+    echo 'LC_ALL="en_US.UTF-8"' >> /etc/default/locale
+fi

--- a/linux/deploy_vm/templates/pre_install_scripts/preseed_early_command.sh
+++ b/linux/deploy_vm/templates/pre_install_scripts/preseed_early_command.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+echo "{{ autoinstall_start_msg }}"
+echo "Installer environment variables: "
+env | sort
+
+ip_addr=$(ip -o -f inet addr show | grep -v 127.0.0.1 | awk '{print $4}')
+echo "DHCP IPv4 address at pre-install: $ip_addr"
+
+echo "Boot command"
+cat /proc/cmdline

--- a/linux/utils/create_seed_iso.yml
+++ b/linux/utils/create_seed_iso.yml
@@ -3,36 +3,21 @@
 ---
 # Create seed ISO file for cloud-init config
 # Parameters:
-# user_data_template: the path to cloud-init user-data template
-# local_hostname: the VM hostname to be set via cloud-init
-
-- name: "Create a temporary directory for creating cloud-init seed.iso"
-  include_tasks: ../../common/create_temp_file_dir.yml
-  vars:
-    tmp_dir: "{{ local_cache }}"
-    tmp_state: "directory"
-    tmp_prefix: "seed_"
-
-- name: "Set fact of temp path of the seed file"
-  ansible.builtin.set_fact:
-    tmp_seed_dir: "{{ tmp_path }}"
-
+#   seed_iso_dir_path: The directory path to save cloud-init seed ISO file
+#   user_data_template: The path to cloud-init user-data template
+#   local_hostname: the VM hostname to be set via cloud-init
+#
 - name: "Set the path to seed.iso"
   ansible.builtin.set_fact:
-    user_data_path: "{{ tmp_seed_dir }}/user-data"
-    meta_data_path: "{{ tmp_seed_dir }}/meta-data"
-    seed_iso_path: "{{ tmp_seed_dir }}/seed.iso"
-
-- include_tasks: get_local_ssh_public_key.yml
-  when: ssh_public_key is undefined or not ssh_public_key
+    user_data_path: "{{ seed_iso_dir_path }}/user-data"
+    meta_data_path: "{{ seed_iso_dir_path }}/meta-data"
+    seed_iso_path: "{{ seed_iso_dir_path }}/seed-{{ lookup('pipe','date +%s') }}.iso"
 
 - name: "Create user-data file for cloud-init local datasource"
   ansible.builtin.template:
     src: "{{ user_data_template }}"
     dest: "{{ user_data_path }}"
     mode: "0666"
-  vars:
-    vm_password_hash: "{{ vm_password | password_hash('sha512') }}"
 
 - name: "Create meta-data file for cloud-init local datasource"
   ansible.builtin.file:
@@ -44,16 +29,6 @@
   ansible.builtin.lineinfile:
     path: "{{ meta_data_path }}"
     line: "local-hostname: {{ local_hostname }}"
-
-- name: "Collect cloud-init meta data and user data to log folder"
-  ansible.builtin.copy:
-    src: "{{ cloud_init_data }}"
-    dest: "{{ current_test_log_folder }}/{{ cloud_init_data | basename }}"
-  with_items:
-    - "{{ meta_data_path }}"
-    - "{{ user_data_path }}"
-  loop_control:
-    loop_var: cloud_init_data
 
 - name: "Create seed.iso as cloud-init local datasource"
   include_tasks: ../../common/create_iso.yml


### PR DESCRIPTION
We need more information to identify OS deployment failure when not detecting "Autoinstall is completed" message. This fix made some changes to OS using Debian installer like Debian, Pardus, Ubuntu desktop 22.10 or earlier (which uses Ubiquity).
1. Added separate shell scripts to be executed at early_command and late_command/success_command, which are more easier to maintain and identify script errors.
2. Added early command to print some basic information, like environment variables, IP address (might be empty, which is as expected for most of Debian family OS), boot command (we can see whether boot command options are correct at debug)
3. Dump /var/log/syslog to serial console after installation, which is the full installer log.
4. Optimized `linux/deploy_vm/create_unattend_install_iso.yml` and `linux/deploy_vm/rebuild_ubuntu_unattend_install_iso.yml`