### PR TITLE
Increase time out for waiting Linux GOSC finished message

### DIFF
--- a/linux/guest_customization/wait_gosc_complete_msg.yml
+++ b/linux/guest_customization/wait_gosc_complete_msg.yml
@@ -10,7 +10,7 @@
 
 - name: "Set the time out seconds to wait for GOSC completed message"
   ansible.builtin.set_fact:
-    wait_gosc_msg_timeout: "{{ wait_gosc_msg_timeout | default(100) }}"
+    wait_gosc_msg_timeout: "{{ wait_gosc_msg_timeout | default(300) }}"
 
 - name: "Wait for '{{ wait_gosc_msg_regexp }}' present in {{ wait_gosc_log_file }}"
   community.vmware.vmware_vm_shell:


### PR DESCRIPTION
Cloud-init GOSC with static IP address on Ubuntu 23.10 took more than 100s to finish. So this change increased the default timeout to 300s.