### PR TITLE
[MiracleLinux] check_os_fullname failed for MiracleLinux-8.x with latest VMware Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | BCLinux-for-Euler 21.10                                | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Red Hat Enterprise Linux CoreOS (RHCOS) 4.13 and later |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | FusionOS 22 and 23                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Miracle Linux 8.x                                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Miracle Linux 8.x, 9.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 
 **Notes**
 This compatible guest operating systems list is used for this project only. For guest operating system support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | BCLinux-for-Euler 21.10                                | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Red Hat Enterprise Linux CoreOS (RHCOS) 4.13 and later |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | FusionOS 22 and 23                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Miracle Linux 8.x                                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 
 **Notes**
 This compatible guest operating systems list is used for this project only. For guest operating system support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).

--- a/linux/check_os_fullname/miracle_fullname_map.yml
+++ b/linux/check_os_fullname/miracle_fullname_map.yml
@@ -3,15 +3,15 @@
 ---
 # Guest id "asianux8_64Guest" and full name "MIRACLE LINUX 8 (64-bit)" is available on ESXi 6.7P06 or later
 
-- name: "Set fact of expected guest id on ESXi {{ esxi_version }}"
-  ansible.builtin.set_fact:
-    expected_guest_major_ver: "{{ [guest_os_ansible_distribution_major_ver | int, 8 ] | min }}"
-
 - name: "Set facts when vmtools_version is larger than 12.3.5"
   when:
     - vmtools_version is defined
     - vmtools_version is version('12.3.5', '>')
   block:
+    - name: "Set fact of expected guest id on ESXi {{ esxi_version }}"
+      ansible.builtin.set_fact:
+        expected_guest_major_ver: "{{ [guest_os_ansible_distribution_major_ver | int, 8 ] | min }}"
+
     - name: "Set fact of expected guest id suffix"
       ansible.builtin.set_fact:
         guest_is_otherlinux: false

--- a/linux/check_os_fullname/miracle_fullname_map.yml
+++ b/linux/check_os_fullname/miracle_fullname_map.yml
@@ -1,19 +1,27 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Guest id "asianux8_64Guest" and full name "MIRACLE LINUX 8 (64-bit)" is available on ESXi 6.7 or later
-# When Miracle Linux 9.x is available, its expected guest id and guest full name is same as Miracle Linux 8.x on ESXi 8.x, 
-# as there is no Miracle Linux 9 (64-bit) selection in vSphere UI
+# Guest id "asianux8_64Guest" and full name "MIRACLE LINUX 8 (64-bit)" is available on ESXi 6.7P06 or later
 
 - name: "Set fact of expected guest id on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
     expected_guest_major_ver: "{{ [guest_os_ansible_distribution_major_ver | int, 8 ] | min }}"
 
-- name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
-  ansible.builtin.set_fact:
-    expected_guest_id: "asianux{{ expected_guest_major_ver }}{{ expected_guest_id_suffix }}"
-    expected_guest_fullname: "MIRACLE LINUX {{ expected_guest_major_ver }} ({{ guest_os_bit }})"
-  when: 
+- name: "Set facts when vmtools_version is larger than 12.3.5"
+  when:
     - vmtools_version is defined
     - vmtools_version is version('12.3.5', '>')
+  block:
+    - name: "Set fact of guest OS is not other Linux"
+      ansible.builtin.set_fact:
+        guest_is_otherlinux: false
+
+    - name: "Set fact of expected guest id suffix"
+      ansible.builtin.set_fact:
+        expected_guest_id_suffix: "{{ expected_guest_id_suffix | replace('64', '_64') }}"
+
+    - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        expected_guest_id: "asianux{{ expected_guest_major_ver }}{{ expected_guest_id_suffix }}"
+        expected_guest_fullname: "MIRACLE LINUX {{ expected_guest_major_ver }} ({{ guest_os_bit }})"
 

--- a/linux/check_os_fullname/miracle_fullname_map.yml
+++ b/linux/check_os_fullname/miracle_fullname_map.yml
@@ -1,0 +1,19 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Guest id "asianux8_64Guest" and full name "MIRACLE LINUX 8 (64-bit)" is available on ESXi 6.7 or later
+# When Miracle Linux 9.x is available, its expected guest id and guest full name is same as Miracle Linux 8.x on ESXi 8.x, 
+# as there is no Miracle Linux 9 (64-bit) selection in vSphere UI
+
+- name: "Set fact of expected guest id on ESXi {{ esxi_version }}"
+  ansible.builtin.set_fact:
+    expected_guest_major_ver: "{{ [guest_os_ansible_distribution_major_ver | int, 8 ] | min }}"
+
+- name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    expected_guest_id: "asianux{{ expected_guest_major_ver }}{{ expected_guest_id_suffix }}"
+    expected_guest_fullname: "MIRACLE LINUX {{ expected_guest_major_ver }} ({{ guest_os_bit }})"
+  when: 
+    - vmtools_version is defined
+    - vmtools_version is version('12.3.5', '>')
+

--- a/linux/check_os_fullname/miracle_fullname_map.yml
+++ b/linux/check_os_fullname/miracle_fullname_map.yml
@@ -8,7 +8,7 @@
     - vmtools_version is defined
     - vmtools_version is version('12.3.5', '>')
   block:
-    - name: "Set fact of expected guest id on ESXi {{ esxi_version }}"
+    - name: "Set fact of expected guest OS major version on ESXi {{ esxi_version }}"
       ansible.builtin.set_fact:
         expected_guest_major_ver: "{{ [guest_os_ansible_distribution_major_ver | int, 8 ] | min }}"
 

--- a/linux/check_os_fullname/miracle_fullname_map.yml
+++ b/linux/check_os_fullname/miracle_fullname_map.yml
@@ -12,12 +12,9 @@
     - vmtools_version is defined
     - vmtools_version is version('12.3.5', '>')
   block:
-    - name: "Set fact of guest OS is not other Linux"
-      ansible.builtin.set_fact:
-        guest_is_otherlinux: false
-
     - name: "Set fact of expected guest id suffix"
       ansible.builtin.set_fact:
+        guest_is_otherlinux: false
         expected_guest_id_suffix: "{{ expected_guest_id_suffix | replace('64', '_64') }}"
 
     - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"

--- a/linux/check_os_fullname/set_guestinfo_without_shortname.yml
+++ b/linux/check_os_fullname/set_guestinfo_without_shortname.yml
@@ -19,14 +19,14 @@
     guest_is_otherlinux: false
   when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux", "AlmaLinux", "Rocky",
                                           "SLES", "SLED", "VMware Photon OS", "Amazon", "Fedora",
-                                          "Ubuntu", "Debian", "openSUSE Leap", "FreeBSD"]
+                                          "Ubuntu", "Debian", "openSUSE Leap", "FreeBSD", "MIRACLE"]
 
 - name: "Set fact of expected guest id suffix"
   ansible.builtin.set_fact:
     expected_guest_id_suffix: "{{ expected_guest_id_suffix | replace('64', '_64') }}"
   when: >-
     guest_os_ansible_distribution in ["RedHat", "SLES", "SLED",
-                                     "CentOS", "OracleLinux", "Debian", "FreeBSD"]
+                                     "CentOS", "OracleLinux", "Debian", "FreeBSD", "MIRACLE"]
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   include_tasks: rhel_fullname_map.yml
@@ -63,6 +63,12 @@
     expected_guest_id: "opensuse{{ expected_guest_id_suffix }}"
     expected_guest_fullname: "SUSE openSUSE ({{ guest_os_bit }})"
   when: guest_os_ansible_distribution == "openSUSE Leap"
+
+- name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    expected_guest_id: "asianux{{ guest_os_ansible_distribution_major_ver }}{{ expected_guest_id_suffix }}"
+    expected_guest_fullname: "MIRACLE LINUX {{ guest_os_ansible_distribution_major_ver }} ({{ guest_os_bit }})"
+  when: guest_os_ansible_distribution == "MIRACLE"
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   include_tasks: otherlinux_fullname_map.yml

--- a/linux/check_os_fullname/set_guestinfo_without_shortname.yml
+++ b/linux/check_os_fullname/set_guestinfo_without_shortname.yml
@@ -19,14 +19,14 @@
     guest_is_otherlinux: false
   when: guest_os_ansible_distribution in ["RedHat", "CentOS", "OracleLinux", "AlmaLinux", "Rocky",
                                           "SLES", "SLED", "VMware Photon OS", "Amazon", "Fedora",
-                                          "Ubuntu", "Debian", "openSUSE Leap", "FreeBSD", "MIRACLE"]
+                                          "Ubuntu", "Debian", "openSUSE Leap", "FreeBSD"]
 
 - name: "Set fact of expected guest id suffix"
   ansible.builtin.set_fact:
     expected_guest_id_suffix: "{{ expected_guest_id_suffix | replace('64', '_64') }}"
   when: >-
     guest_os_ansible_distribution in ["RedHat", "SLES", "SLED",
-                                     "CentOS", "OracleLinux", "Debian", "FreeBSD", "MIRACLE"]
+                                     "CentOS", "OracleLinux", "Debian", "FreeBSD"]
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   include_tasks: rhel_fullname_map.yml

--- a/linux/check_os_fullname/set_guestinfo_without_shortname.yml
+++ b/linux/check_os_fullname/set_guestinfo_without_shortname.yml
@@ -38,7 +38,7 @@
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   include_tasks: "{{ guest_os_ansible_distribution | lower }}_fullname_map.yml"
-  when: guest_os_ansible_distribution in ["Amazon", "CentOS", "OracleLinux", "AlmaLinux", "Rocky", "Debian", "FreeBSD"]
+  when: guest_os_ansible_distribution in ["Amazon", "CentOS", "OracleLinux", "AlmaLinux", "Rocky", "Debian", "FreeBSD", "MIRACLE"]
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   ansible.builtin.set_fact:
@@ -63,12 +63,6 @@
     expected_guest_id: "opensuse{{ expected_guest_id_suffix }}"
     expected_guest_fullname: "SUSE openSUSE ({{ guest_os_bit }})"
   when: guest_os_ansible_distribution == "openSUSE Leap"
-
-- name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
-  ansible.builtin.set_fact:
-    expected_guest_id: "asianux{{ guest_os_ansible_distribution_major_ver }}{{ expected_guest_id_suffix }}"
-    expected_guest_fullname: "MIRACLE LINUX {{ guest_os_ansible_distribution_major_ver }} ({{ guest_os_bit }})"
-  when: guest_os_ansible_distribution == "MIRACLE"
 
 - name: "Set expected guest id and full name for {{ vm_guest_os_distribution }}"
   include_tasks: otherlinux_fullname_map.yml


### PR DESCRIPTION
Issue:
check_os_fullname failed for MiracleLinux-8.x with latest VMware Tools

detail info:
2023-10-11 12:34:17,011 | TASK [1_check_os_fullname][Check guest id in VM's guest info with VMware Tools 12.4.0 on ESXi 8.0.0]
task path: /home/worker/workspace/Ansible_MiracleLinux_8.x_80GA_PARAVIRTUAL_VMXNET3_EFI/ansible-vsphere-gos-validation/linux/check_os_fullname/validate_os_fullname.yml:56
fatal: [localhost]: FAILED! => {
"assertion": "guestinfo_guest_id == expected_guest_id",
"changed": false,
"evaluated_to": false,
"msg": "VM's guest id in guest info is 'asianux8_64Guest', not expected 'other4xLinux64Guest'."
}