### PR TITLE
Add support for FusionOS 22 and 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,33 +65,34 @@ This project supports below scenarios for end-to-end guest operating system vali
 
 ### Compatible Guest Operating Systems
 
-| Guest Operating Systems                       | Automatic Install from ISO Image | Deploy from OVA Template | Existing VM with Guest Operating System Installed |
-|:----------------------------------------------| :------------------------------: | :----------------------: | :--------------------------------: |
-| Red Hat Enterprise Linux 7.x, 8.x, 9.x        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| CentOS 7.x, 8.x                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Oracle Linux 7.x, 8.x, 9.x                    | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Rocky Linux 8.x, 9.x                          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| AlmaLinux 8.x, 9.x                            | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| SUSE Linux Enterprise 15 SP3 and later        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| SUSE Linux Enterprise 12 SP5, 15 SP0/SP1/SP2  |                                  |                          | :heavy_check_mark:                 |
-| VMware Photon OS 3.0, 4.0, 5.0                | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
-| Ubuntu 18.04 live-server                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Ubuntu 18.04 desktop                          |                                  |                          | :heavy_check_mark:                 |
-| Ubuntu 20.04 and later                        | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
-| Flatcar 2592.0.0 and later                    |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
-| Debian 10.10 and later, 11.x, 12.x            | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Debian 9.x, 10.9 and earlier                  |                                  |                          | :heavy_check_mark:                 |
-| Windows 10, 11                                | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Windows Server 2019, 2022                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| UnionTech OS Server 20 1050a                  | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Fedora Server 36 and later                    | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| ProLinux Server 7.9, 8.5                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| FreeBSD 13 and later                          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Pardus 21.2 Server,XFCE Desktop and later     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| openSUSE Leap 15.3 and later                  | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| BCLinux 8.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| BCLinux-for-Euler 21.10                       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| Red Hat Enterprise Linux CoreOS (RHCOS) 4.13 and later                    |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
+| Guest Operating Systems                                | Automatic Install from ISO Image | Deploy from OVA Template | Existing VM with Guest Operating System Installed |
+|:-------------------------------------------------------| :------------------------------: | :----------------------: | :--------------------------------: |
+| Red Hat Enterprise Linux 7.x, 8.x, 9.x                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| CentOS 7.x, 8.x                                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise 15 SP3 and later                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise 12 SP5, 15 SP0/SP1/SP2           |                                  |                          | :heavy_check_mark:                 |
+| VMware Photon OS 3.0, 4.0, 5.0                         | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
+| Ubuntu 18.04 live-server                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Ubuntu 18.04 desktop                                   |                                  |                          | :heavy_check_mark:                 |
+| Ubuntu 20.04 and later                                 | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
+| Flatcar 2592.0.0 and later                             |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
+| Debian 10.10 and later, 11.x, 12.x                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Debian 9.x, 10.9 and earlier                           |                                  |                          | :heavy_check_mark:                 |
+| Windows 10, 11                                         | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Windows Server 2019, 2022                              | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| UnionTech OS Server 20 1050a                           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Fedora Server 36 and later                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| ProLinux Server 7.9, 8.5                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| FreeBSD 13 and later                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Pardus 21.2 Server,XFCE Desktop and later              | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| openSUSE Leap 15.3 and later                           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| BCLinux 8.x                                            | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| BCLinux-for-Euler 21.10                                | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Red Hat Enterprise Linux CoreOS (RHCOS) 4.13 and later |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
+| FusionOS 22 and 23                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 
 **Notes**
 This compatible guest operating systems list is used for this project only. For guest operating system support status on ESXi, please refer to [VMware Compatibility Guide](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&testConfig=16).

--- a/autoinstall/FusionOS/server_with_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_with_GUI/ks.cfg
@@ -1,0 +1,96 @@
+#version=DEVEL
+# Use graphical install
+graphical
+
+%packages
+@^graphical-server-environment
+kexec-tools
+cloud-init
+java-1.8.0-openjdk-headless
+java-1.8.0-openjdk
+ndctl
+iproute
+rdma-core
+librdmacm-utils
+libibverbs
+libibverbs-utils
+infiniband-diags
+perftest
+%end
+
+# Keyboard layouts
+keyboard --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+network  --bootproto=dhcp --onboot=yes --ipv6=auto --activate
+network  --hostname=localhost.localdomain
+
+# Use CDROM installation media
+cdrom
+# SELinux configuration
+selinux --disabled
+
+# X Window System configuration information
+xconfig  --startxonboot
+# Do not run the Setup Agent on first boot
+firstboot --disable
+# System services
+services --enabled="chronyd"
+services --disabled="firewalld"
+
+ignoredisk --only-use={{ boot_disk_name }}
+autopart
+# Partition clearing information
+clearpart --none --initlabel
+
+# System timezone
+timezone Asia/Shanghai --utc
+
+# Shutdown when the install is finished.
+shutdown
+
+# Root password
+rootpw --iscrypted {{ vm_password_hash }}
+# Add SSH key
+sshkey --username=root "{{ ssh_public_key }}"
+
+{% if new_user is defined and new_user != 'root' %}
+user --name={{ new_user }} --password={{ vm_password_hash }} --groups=root,wheel --iscrypted --gecos="{{ new_user }}"
+sshkey --username={{ new_user }} "{{ ssh_public_key }}"
+{% endif %}
+
+%addon com_redhat_kdump --disable --reserve-mb='128'
+
+%end
+
+%anaconda
+pwpolicy root --minlen=8 --minquality=1 --strict --nochanges --notempty
+pwpolicy user --minlen=8 --minquality=1 --strict --nochanges --emptyok
+pwpolicy luks --minlen=8 --minquality=1 --strict --nochanges --notempty
+%end
+
+%post --interpreter=/usr/bin/bash --log=/root/ks-post.log
+if [ -f /etc/cloud/cloud.cfg ]; then
+    sed -i 's/^disable_root:.*/disable_root: false/' /etc/cloud/cloud.cfg
+    sed -i 's/^ssh_pwauth:.*/ssh_pwauth: yes/' /etc/cloud/cloud.cfg
+fi
+
+# Permit root login via SSH
+sed -i 's/^PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Workaround for setting guest_os_family as RHEL
+if [ -f /etc/FusionOS-release ] && [ ! -f /etc/redhat-release ]; then
+    ln -s /etc/FusionOS-release /etc/redhat-release
+fi
+
+{% if new_user is defined and new_user != 'root' %}
+# Add new user to sudoer
+echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
+# Enable autologin
+sed -i '/\[daemon\]/a AutomaticLogin={{ new_user }}' /etc/gdm/custom.conf
+sed -i '/\[daemon\]/a AutomaticLoginEnable=True' /etc/gdm/custom.conf
+{% endif %}
+echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
+%end

--- a/autoinstall/FusionOS/server_without_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_without_GUI/ks.cfg
@@ -1,0 +1,91 @@
+#version=DEVEL
+# Use graphical install
+graphical
+
+%packages
+@^server-product-environment
+kexec-tools
+#open-vm-tools-desktop
+cloud-init
+java-1.8.0-openjdk-headless
+java-1.8.0-openjdk
+ndctl
+iproute
+rdma-core
+librdmacm-utils
+libibverbs
+libibverbs-utils
+infiniband-diags
+perftest
+%end
+
+# Keyboard layouts
+keyboard --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+network  --bootproto=dhcp --ipv6=auto --activate
+network  --hostname=localhost.localdomain
+
+# Use CDROM installation media
+cdrom
+# SELinux configuration
+selinux --disabled
+
+# X Window System configuration information
+xconfig  --startxonboot
+# Do not run the Setup Agent on first boot
+firstboot --disable
+# System services
+services --enabled="chronyd"
+services --disabled="firewalld"
+
+ignoredisk --only-use={{ boot_disk_name }}
+autopart
+# Partition clearing information
+clearpart --none --initlabel
+
+# System timezone
+timezone Asia/Shanghai --utc
+
+# Shutdown when the install is finished.
+shutdown
+
+# Root password
+rootpw --iscrypted {{ vm_password_hash }}
+# Add SSH key
+sshkey --username=root "{{ ssh_public_key }}"
+
+{% if new_user is defined and new_user != 'root' %}
+user --name={{ new_user }} --password={{ vm_password_hash }} --groups=root,wheel --iscrypted --gecos="{{ new_user }}"
+sshkey --username={{ new_user }} "{{ ssh_public_key }}"
+{% endif %}
+
+%addon com_redhat_kdump --disable --reserve-mb='128'
+
+%end
+
+%post --interpreter=/usr/bin/bash --log=/root/ks-post.log
+if [ -f /etc/cloud/cloud.cfg ]; then
+    sed -i 's/^disable_root:.*/disable_root: false/' /etc/cloud/cloud.cfg
+    sed -i 's/^ssh_pwauth:.*/ssh_pwauth: yes/' /etc/cloud/cloud.cfg
+fi
+
+# Permit root login via SSH
+sed -i 's/^PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Workaround for setting guest_os_family as RHEL
+if [ -f /etc/FusionOS-release ] && [ ! -f /etc/redhat-release ]; then
+    ln -s /etc/FusionOS-release /etc/redhat-release
+fi
+
+{% if new_user is defined and new_user != 'root' %}
+# Add new user to sudoer
+echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
+# Enable autologin
+sed -i '/\[daemon\]/a AutomaticLogin={{ new_user }}' /etc/gdm/custom.conf
+sed -i '/\[daemon\]/a AutomaticLoginEnable=True' /etc/gdm/custom.conf
+{% endif %}
+echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
+%end

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -23,7 +23,7 @@
 22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
 23. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
 24. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
-25. For FusionOS unattend auto-install, please use files under Fusion.
+25. For FusionOS 22 and 23 unattend auto-install, please use files under Fusion.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -23,6 +23,7 @@
 22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
 23. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
 24. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
+25. For FusionOS unattend auto-install, please use files under Fusion.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -23,7 +23,8 @@
 22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
 23. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
 24. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
-25. For FusionOS 22 and 23 unattend auto-install, please use files under Fusion.
+25. For FusionOS 22 unattend auto-install, please use files under Fusion.
+26. For FusionOS 23 unattend auto-install, please use file Fusion/server_without_GUI/ks.cfg.
 
 # Notes
 ## For Windows

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -171,6 +171,7 @@
         - (('RHEL' in unattend_install_conf) or
            ('CentOS' in unattend_install_conf) or
            ('Fedora' in unattend_install_conf) or
+           ('FusionOS' in unattend_install_conf) or
            ('BCLinux' in unattend_install_conf))
 
     # For UnionTech OS, send key to boot screen
@@ -249,7 +250,7 @@
         vm_get_fullname_timeout: 600
       when:
         - unattend_install_conf is defined
-        - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler).*')
+        - unattend_install_conf | lower is not match('.*(minimal|server_without_gui|bclinux-for-euler|fusionos).*')
 
     - name: "Get VM guest IPv4 address and add to in-memory inventory"
       include_tasks: ../../common/update_inventory.yml

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -24,7 +24,7 @@
     (guest_os_ansible_distribution == "Rocky" and
       guest_os_ansible_distribution_ver is version('8.4', '<=')) or
     guest_os_ansible_distribution is match('Pardus.*') or
-    (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos", "FreeBSD", "BigCloud"])
+    (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos", "FreeBSD", "BigCloud", "FusionOS"])
 
 - name: "Skip test case for OS version which has vulnerable bootloaders"
   block:


### PR DESCRIPTION
## Description
- This change added autoinstall support and necessary test updates for FusionOS 22 and 23. 
- Tested FusionOS 22 and 23 with sata/ide/pvscsi/nvme, vmxnet3/e1000e, efi/bios and all passed except known issues.

## Test Log
```
VM information:
+---------------------------------------------------------------------------------+
| Guest OS Distribution     | FusionOS 23.0.1 x86_64                              |
+---------------------------------------------------------------------------------+
| GUI Installed             | False                                               |
+---------------------------------------------------------------------------------+
| CloudInit Version         | 21.4                                                |
+---------------------------------------------------------------------------------+
| Hardware Version          | vmx-19                                              |
+---------------------------------------------------------------------------------+
| VMTools Version           | 12.0.5 (build-19716617)                             |
+---------------------------------------------------------------------------------+
| Config Guest Id           | other5xLinux64Guest                                 |
+---------------------------------------------------------------------------------+
| GuestInfo Guest Id        | other5xLinux64Guest                                 |
+---------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 5.x or later Linux (64-bit)                   |
+---------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                          |
+---------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                  |
|                           | bitness='64'                                        |
|                           | distroName='FusionOS'                               |
|                           | distroVersion='23.0.1'                              |
|                           | familyName='Linux'                                  |
|                           | kernelVersion='5.10.0-136.23.0.99.u37.fos23.x86_64' |
|                           | prettyName='FusionOS 23'                            |
+---------------------------------------------------------------------------------+

Test Results (Total: 26, Passed: 22, Skipped: 4, Elapsed Time: 01:44:49)
+--------------------------------------------------------------------------+
| ID | Name                                 |   Status         | Exec Time |
+--------------------------------------------------------------------------+
| 01 | deploy_vm_bios_ide_e1000e            |   Passed         | 00:14:02  |
| 02 | check_inbox_driver                   |   Passed         | 00:01:29  |
| 03 | ovt_verify_install                   |   Passed         | 00:05:04  |
| 04 | ovt_verify_status                    |   Passed         | 00:00:46  |
| 05 | vgauth_check_service                 |   Passed         | 00:00:53  |
| 06 | check_ip_address                     |   Passed         | 00:00:38  |
| 07 | check_os_fullname                    |   Passed         | 00:01:13  |
| 08 | stat_balloon                         |   Passed         | 00:00:45  |
| 09 | stat_hosttime                        |   Passed         | 00:00:42  |
| 10 | device_list                          |   Passed         | 00:02:36  |
| 11 | check_quiesce_snapshot_custom_script |   Passed         | 00:01:07  |
| 12 | memory_hot_add_basic                 |   Passed         | 00:05:58  |
| 13 | cpu_hot_add_basic                    |   Passed         | 00:05:24  |
| 14 | cpu_multicores_per_socket            |   Passed         | 00:10:04  |
| 15 | check_efi_firmware                   | * Not Applicable | 00:00:44  |
| 16 | secureboot_enable_disable            | * Not Applicable | 00:00:41  |
| 17 | e1000e_network_device_ops            |   Passed         | 00:03:56  |
| 18 | vmxnet3_network_device_ops           |   Passed         | 00:03:05  |
| 19 | pvrdma_network_device_ops            |   Passed         | 00:08:54  |
| 20 | paravirtual_vhba_device_ops          |   Passed         | 00:07:57  |
| 21 | lsilogic_vhba_device_ops             | * Not Supported  | 00:00:42  |
| 22 | lsilogicsas_vhba_device_ops          | * Not Supported  | 00:00:44  |
| 23 | sata_vhba_device_ops                 |   Passed         | 00:08:08  |
| 24 | nvme_vhba_device_ops                 |   Passed         | 00:07:56  |
| 25 | nvdimm_cold_add_remove               |   Passed         | 00:08:19  |
| 26 | ovt_verify_uninstall                 |   Passed         | 00:01:54  |
+--------------------------------------------------------------------------+
```

```
VM information:
+------------------------------------------------------------------------------------+
| Guest OS Distribution     | FusionOS 22.0.4 x86_64                                 |
+------------------------------------------------------------------------------------+
| GUI Installed             | True                                                   |
+------------------------------------------------------------------------------------+
| CloudInit Version         | 19.4                                                   |
+------------------------------------------------------------------------------------+
| Hardware Version          | vmx-19                                                 |
+------------------------------------------------------------------------------------+
| VMTools Version           | 12.0.5 (build-19716617)                                |
+------------------------------------------------------------------------------------+
| Config Guest Id           | other4xLinux64Guest                                    |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | other4xLinux64Guest                                    |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 4.x Linux (64-bit)                               |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                             |
+------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                     |
|                           | bitness='64'                                           |
|                           | distroName='FusionOS'                                  |
|                           | distroVersion='22.0.4'                                 |
|                           | familyName='Linux'                                     |
|                           | kernelVersion='4.19.90-2212.2.0.0181.u89.fos22.x86_64' |
|                           | prettyName='FusionOS 22'                               |
+------------------------------------------------------------------------------------+

Test Results (Total: 26, Passed: 22, Skipped: 4, Elapsed Time: 02:20:12)
+--------------------------------------------------------------------------+
| ID | Name                                 |   Status         | Exec Time |
+--------------------------------------------------------------------------+
| 01 | deploy_vm_bios_ide_e1000e            |   Passed         | 00:29:52  |
| 02 | check_inbox_driver                   |   Passed         | 00:01:54  |
| 03 | ovt_verify_install                   |   Passed         | 00:04:29  |
| 04 | ovt_verify_status                    |   Passed         | 00:03:17  |
| 05 | vgauth_check_service                 |   Passed         | 00:01:15  |
| 06 | check_ip_address                     |   Passed         | 00:01:00  |
| 07 | check_os_fullname                    |   Passed         | 00:01:33  |
| 08 | stat_balloon                         |   Passed         | 00:00:57  |
| 09 | stat_hosttime                        |   Passed         | 00:00:55  |
| 10 | device_list                          |   Passed         | 00:03:16  |
| 11 | check_quiesce_snapshot_custom_script |   Passed         | 00:01:39  |
| 12 | memory_hot_add_basic                 |   Passed         | 00:07:33  |
| 13 | cpu_hot_add_basic                    |   Passed         | 00:06:51  |
| 14 | cpu_multicores_per_socket            |   Passed         | 00:11:09  |
| 15 | check_efi_firmware                   | * Not Applicable | 00:00:52  |
| 16 | secureboot_enable_disable            | * Not Applicable | 00:00:48  |
| 17 | e1000e_network_device_ops            |   Passed         | 00:04:52  |
| 18 | vmxnet3_network_device_ops           |   Passed         | 00:03:45  |
| 19 | pvrdma_network_device_ops            |   Passed         | 00:11:27  |
| 20 | paravirtual_vhba_device_ops          |   Passed         | 00:09:44  |
| 21 | lsilogic_vhba_device_ops             | * Not Supported  | 00:00:51  |
| 22 | lsilogicsas_vhba_device_ops          | * Not Supported  | 00:01:00  |
| 23 | sata_vhba_device_ops                 |   Passed         | 00:09:20  |
| 24 | nvme_vhba_device_ops                 |   Passed         | 00:08:56  |
| 25 | nvdimm_cold_add_remove               |   Passed         | 00:09:10  |
| 26 | ovt_verify_uninstall                 |   Passed         | 00:02:12  |
+--------------------------------------------------------------------------+
```