### PR TITLE
[Windows] Change the default value for ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT to 10 sencods when installing VMware Tools

### DIFF
--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -32,6 +32,8 @@
   register: wintools_install_result
   async: 600
   poll: 0
+  environment:
+    ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT: 10
 - name: "Pause 2 minutes before checking task status"
   ansible.builtin.pause:
     minutes: 2

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -14,8 +14,6 @@
 - name: wintools_complete_install_verify
   hosts: localhost
   gather_facts: false
-  environment:
-    ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT: 10
   tasks:
     - name: "Test case block"
       block:

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -14,6 +14,8 @@
 - name: wintools_complete_install_verify
   hosts: localhost
   gather_facts: false
+  environment:
+    ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT: 10
   tasks:
     - name: "Test case block"
       block:


### PR DESCRIPTION
The default value for ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT is 5s. This can be too low on slower systems, or systems under heavy load. Increase the value to 10 seconds for VMware Tools installation which encountered such issue before. 