### PR TITLE
[Windows] Fix incorrect user and sysprep error in GOSC test cases

### DIFF
--- a/windows/guest_customization/check_autologon_count.yml
+++ b/windows/guest_customization/check_autologon_count.yml
@@ -1,46 +1,50 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get auto Admin logon value after gosc
-- include_tasks: ../utils/win_execute_cmd.yml
+# Check logon as Administrator automatically is set in guest OS
+- name: "Initialize the registry value of logon as Administrator automatically"
+  ansible.builtin.set_fact:
+    auto_admin_logon: 0
+
+- name: "Get logon as Administrator automatically registry value"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "(get-itemproperty -path 'HKLM:\\software\\microsoft\\Windows NT\\CurrentVersion\\Winlogon').AutoAdminLogon"
-- name: Set fact of the Admin auto logon
+    win_powershell_cmd: >-
+      (Get-ItemProperty -path 'HKLM:\\software\\microsoft\\Windows NT\\CurrentVersion\\Winlogon').AutoAdminLogon
+
+- name: "Set fact of logon as Administrator automatically registry value"
   ansible.builtin.set_fact:
     auto_admin_logon: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
-- ansible.builtin.debug:
-    msg: "Get auto Admin logon enabled value: {{ auto_admin_logon }}"
-  when: enable_debug
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length != 0
 
-- name: Get auto admin logon count value after GOSC
-  ansible.windows.win_shell: "(get-itemproperty -path 'HKLM:\\software\\microsoft\\Windows NT\\CurrentVersion\\Winlogon').AutoLogonCount"
+- name: "Check logon as Administrator automatically is enabled"
+  ansible.builtin.assert:
+    that:
+      - "{{ auto_admin_logon | int == 1 }}"
+    success_msg: "Logon as Administrator automatically is enabled in guest OS."
+    fail_msg: "Logon as Administrator automatically registry value '{{ auto_admin_logon }}' is not equal to 1."
+
+- name: "Get number of times to logon as Administrator automatically"
+  ansible.windows.win_shell: >-
+    (Get-ItemProperty -path 'HKLM:\\software\\microsoft\\Windows NT\\CurrentVersion\\Winlogon').AutoLogonCount
   register: get_auto_logon_count
   delegate_to: "{{ vm_guest_ip }}"
   until:
+    - get_auto_logon_count.stdout_lines is defined
     - get_auto_logon_count.stdout_lines | length != 0
-    - get_auto_logon_count.stdout_lines[0] | int == customize_autologon_count | int - 1
+    - get_auto_logon_count.stdout_lines[0] | int == win_gosc_spec.gosc_autologon_count | int - 1
   retries: 100
   delay: 3
   ignore_errors: true
 
-- name: "Check auto admin logon count value after GOSC"
+- name: "Check number of times to logon as Administrator automatically"
   ansible.builtin.assert:
     that:
-      - get_auto_logon_count is defined
-      - get_auto_logon_count.stdout_lines | length != 0
-      - get_auto_logon_count.stdout_lines[0] | int == customize_autologon_count | int - 1
+      - not get_auto_logon_count.failed
+    success_msg: "Number of times to logon as Administrator automatically is set correctly: {{ get_auto_logon_count.stdout_lines[0] }}."
     fail_msg: >-
-      Auto admin logon count value after GOSC is still incorrect after 300 seconds.
-      Current auto admin logon count value is '{{ get_auto_logon_count.stdout_lines[0] | int | default("") }}',
-      not expected '{{ customize_autologon_count | int - 1 }}'.
-
-- ansible.builtin.debug:
-    msg: "Get remain auto logon count: {{ get_auto_logon_count.stdout_lines[0] }}"
-  when: enable_debug
-
-- name: Check auto admin logon enabled and count is accurate
-  ansible.builtin.assert:
-    that:
-      - "{{ auto_admin_logon | int == 1 }}"
-    success_msg: "Auto Admin logon is enabled and customized auto logon count is accurate."
-    fail_msg: "Auto Admin logon is not enabled."
+      The number of times to logon as Administrator automatically is incorrect after 300 seconds.
+      Got value '{{ get_auto_logon_count.stdout_lines[0] | default('') }}' in guest OS after GOSC,
+      expected value is '{{ win_gosc_spec.gosc_autologon_count | int - 1 }}'.

--- a/windows/guest_customization/check_autologon_count.yml
+++ b/windows/guest_customization/check_autologon_count.yml
@@ -22,9 +22,11 @@
 - name: "Check logon as Administrator automatically is enabled"
   ansible.builtin.assert:
     that:
-      - "{{ auto_admin_logon | int == 1 }}"
+      - auto_admin_logon | int == 1
     success_msg: "Logon as Administrator automatically is enabled in guest OS."
-    fail_msg: "Logon as Administrator automatically registry value '{{ auto_admin_logon }}' is not equal to 1."
+    fail_msg: >-
+      Logon as Administrator automatically is not enabled in guest OS,
+      got registry value '{{ auto_admin_logon }}', not expected value 1.
 
 - name: "Get number of times to logon as Administrator automatically"
   ansible.windows.win_shell: >-

--- a/windows/guest_customization/check_ip_hostname.yml
+++ b/windows/guest_customization/check_ip_hostname.yml
@@ -1,0 +1,16 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Wait for VM IP address after GOSC"
+  include_tasks: ../../common/vm_wait_guest_ip.yml
+  vars:
+    wait_ipv4: "{{ win_gosc_spec.gosc_ip | default('') }}"
+
+- name: "Update in-memory inventory after GOSC"
+  include_tasks: ../utils/win_update_inventory.yml
+  when: gosc_network_type == "dhcp"
+
+- name: "Wait for guest OS hostname after GOSC"
+  include_tasks: ../../common/vm_wait_guest_hostname.yml
+  vars:
+    wait_guest_hostname: "{{ win_gosc_spec.gosc_hostname }}"

--- a/windows/guest_customization/check_runonce_command.yml
+++ b/windows/guest_customization/check_runonce_command.yml
@@ -2,16 +2,19 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Check runonce command executed in guest OS
-- name: Display the run once command
-  ansible.builtin.debug: var=customize_runonce
+- name: "Display the GOSC run once command"
+  ansible.builtin.debug: var=win_gosc_spec.gosc_runonce
 
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Get GOSC run once command output file"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "get-content -Path C:\\gosc_runonce.txt"
+    win_powershell_cmd: "Get-Content -Path {{ win_gosc_spec.gosc_echo_file }}"
 
-- name: Check run once command executed
+- name: "Check GOSC run once command executed in guest OS"
   ansible.builtin.assert:
     that:
-      - "{{ win_powershell_cmd_output.stdout_lines[0].strip() == customize_runonce_echo_string.strip() }}"
-    success_msg: "Run once command executed and test file created"
-    fail_msg: "Run once command not executed or test file not created"
+      - win_powershell_cmd_output.stdout_lines is defined
+      - win_powershell_cmd_output.stdout_lines | length != 0
+      - "{{ win_powershell_cmd_output.stdout_lines[0].strip() == win_gosc_spec.gosc_echo_string.strip() }}"
+    success_msg: "Run once command is executed in guest OS."
+    fail_msg: "Run once command is not executed successfully in guest OS."

--- a/windows/guest_customization/check_runonce_command.yml
+++ b/windows/guest_customization/check_runonce_command.yml
@@ -15,6 +15,6 @@
     that:
       - win_powershell_cmd_output.stdout_lines is defined
       - win_powershell_cmd_output.stdout_lines | length != 0
-      - "{{ win_powershell_cmd_output.stdout_lines[0].strip() == win_gosc_spec.gosc_echo_string.strip() }}"
+      - win_powershell_cmd_output.stdout_lines[0].strip() == win_gosc_spec.gosc_echo_string.strip()
     success_msg: "Run once command is executed in guest OS."
     fail_msg: "Run once command is not executed successfully in guest OS."

--- a/windows/guest_customization/check_timezone.yml
+++ b/windows/guest_customization/check_timezone.yml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Check timezone name after GOS customization
+- name: "Initialize the timezone name in guest OS"
+  ansible.builtin.set_fact:
+    timezone_after_gosc: ""
+
 - name: "Print timezone name in Windows GOSC spec"
   ansible.builtin.debug:
     msg: "Configured timezone in GOSC spec: {{ win_gosc_spec.gosc_timezone_name }}"
@@ -21,7 +25,7 @@
 - name: "Check customized timezone in guest OS"
   ansible.builtin.assert:
     that:
-      - "{{ timezone_after_gosc == win_gosc_spec.gosc_timezone_name }}"
+      - timezone_after_gosc == win_gosc_spec.gosc_timezone_name
     success_msg: "Timezone '{{ timezone_after_gosc }}' is set by GOSC successfully in guest OS."
     fail_msg: >-
       Got timezone in guest OS '{{ timezone_after_gosc }}',

--- a/windows/guest_customization/check_timezone.yml
+++ b/windows/guest_customization/check_timezone.yml
@@ -1,23 +1,28 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check timezone name after gos customization
-- ansible.builtin.debug:
-    msg: "Configured timezone: {{ customize_timezone_name }}"
-  when: enable_debug is defined and enable_debug
-- name: Check timezone in guest OS
+# Check timezone name after GOS customization
+- name: "Print timezone name in Windows GOSC spec"
+  ansible.builtin.debug:
+    msg: "Configured timezone in GOSC spec: {{ win_gosc_spec.gosc_timezone_name }}"
+
+- name: "Get timezone info in guest OS"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "tzutil /g"
-- name: Set fact of the timezone in guest OS
+
+- name: "Set fact of the timezone in guest OS"
   ansible.builtin.set_fact:
-    timezone_after_customize: "{{ win_powershell_cmd_output.stdout_lines[0] if not win_powershell_cmd_output.failed else 'NA'}}"
-- ansible.builtin.debug:
-    msg: "Get timezone after customize: {{ timezone_after_customize }}"
-- name: Check returned timezone name is the specified one
+    timezone_after_gosc: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length != 0
+
+- name: "Check customized timezone in guest OS"
   ansible.builtin.assert:
     that:
-      - "{{ not win_powershell_cmd_output.failed }}"
-      - "{{ win_powershell_cmd_output.stdout_lines[0] == customize_timezone_name }}"
-    success_msg: "Check customized timezone in guest OS succeed."
-    fail_msg: "Check customized timezone in guest OS failed."
+      - "{{ timezone_after_gosc == win_gosc_spec.gosc_timezone_name }}"
+    success_msg: "Timezone '{{ timezone_after_gosc }}' is set by GOSC successfully in guest OS."
+    fail_msg: >-
+      Got timezone in guest OS '{{ timezone_after_gosc }}',
+      which is not the one set in GOSC sepc '{{ win_gosc_spec.gosc_timezone_name }}'.

--- a/windows/guest_customization/get_gosc_logs_network.yml
+++ b/windows/guest_customization/get_gosc_logs_network.yml
@@ -16,9 +16,7 @@
 
 - name: "Set fact of the absolute directory path list of GOSC log"
   ansible.builtin.set_fact:
-    win_gosc_log_dir: "{{ win_gosc_log_dir + [win_windows_dir ~ win_dir_separator ~ item] }}"
-  with_items: "{{ win_gosc_log_dir_rel }}"
-  no_log: true
+    win_gosc_log_dir: "{{ [win_windows_dir] | ansible.builtin.product(win_gosc_log_dir_rel) | map('join', win_dir_separator) }}"
 
 - name: "Display the directory path list of GOSC log"
   ansible.builtin.debug: var=win_gosc_log_dir

--- a/windows/guest_customization/get_gosc_logs_network.yml
+++ b/windows/guest_customization/get_gosc_logs_network.yml
@@ -2,28 +2,31 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Fetch log files from Windows guest OS to local
-- name: Initialize the absolute path of GOSC log folders
+- name: "Initialize the absolute directory path list of GOSC log"
   ansible.builtin.set_fact:
-    gosc_win_log_folders_src: []
-    separator: '\'
+    win_gosc_log_dir: []
 
-- name: Set fact of the GOSC log paths
+- name: "Set fact of the relative directory path list of GOSC log"
   ansible.builtin.set_fact:
-    gosc_win_log_folders:
+    win_gosc_log_dir_rel:
       - 'Temp\vmware-imc\'
       - 'System32\Sysprep\Panther\'
       - 'Panther\'
       - 'Debug\'
-- name: Set fact of the absolute path of GOSC log folders
-  ansible.builtin.set_fact:
-    gosc_win_log_folders_src: "{{ gosc_win_log_folders_src + [win_dir ~ separator ~ item] }}"
-  with_items: "{{ gosc_win_log_folders }}"
-- name: Display the GOSC log paths
-  ansible.builtin.debug: var=gosc_win_log_folders_src
 
-- include_tasks: ../utils/win_get_folder.yml
+- name: "Set fact of the absolute directory path list of GOSC log"
+  ansible.builtin.set_fact:
+    win_gosc_log_dir: "{{ win_gosc_log_dir + [win_windows_dir ~ win_dir_separator ~ item] }}"
+  with_items: "{{ win_gosc_log_dir_rel }}"
+  no_log: true
+
+- name: "Display the directory path list of GOSC log"
+  ansible.builtin.debug: var=win_gosc_log_dir
+
+- name: "Get GOSC log files from guest OS"
+  include_tasks: ../utils/win_get_folder.yml
   vars:
     win_get_folder_dst_path: "{{ current_test_log_folder }}"
-  with_items: "{{ gosc_win_log_folders_src }}"
+  with_items: "{{ win_gosc_log_dir }}"
   loop_control:
     loop_var: win_get_folder_src_path

--- a/windows/guest_customization/get_gosc_logs_no_network.yml
+++ b/windows/guest_customization/get_gosc_logs_no_network.yml
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Fetch log files from Windows guest OS to local
-- name: "Initialize the dict of source log files and dest path"
+- name: "Initialize the GOSC log files source and dest paths"
   ansible.builtin.set_fact:
-    separator: '\'
-    source_log_list: []
-    dest_log_list: []
-    gosc_win_log_src_dest: {}
+    win_gosc_log_files: []
+    win_gosc_log_files_dst: []
+    win_gosc_log_src_dest: {}
 
-- name: "Set fact of the GOSC log files' paths"
+- name: "Set fact of the relative file path list of GOSC log"
   ansible.builtin.set_fact:
-    gosc_win_log_files:
+    win_gosc_log_files_rel:
       - 'Temp\vmware-imc\guestcust.log'
       - 'Temp\vmware-imc\toolsDeployPkg.log'
       - 'System32\Sysprep\Panther\setupact.log'
@@ -24,19 +23,18 @@
       - 'Debug\PASSWD.LOG'
       - 'Debug\sammui.log'
 
-- name: "Set fact of the absolute log files path list"
+- name: "Set fact of the absolute file path list of GOSC log"
   ansible.builtin.set_fact:
-    source_log_list: "{{ source_log_list + [win_dir ~ separator ~ item] }}"
-    dest_log_list: "{{ dest_log_list + [current_test_log_folder ~ '/' ~ item.split(separator) | join('/')] }}"
-  with_items: "{{ gosc_win_log_files }}"
-  no_log: true
+    win_gosc_log_files: "{{ win_gosc_log_files + [win_windows_dir ~ win_dir_separator ~ item] }}"
+    win_gosc_log_files_dst: "{{ win_gosc_log_files_dst + [current_test_log_folder ~ '/' ~ item.split(win_dir_separator) | join('/')] }}"
+  with_items: "{{ win_gosc_log_files_rel }}"
 
 - name: "Set fact of the source and dest log files path dict"
   ansible.builtin.set_fact:
-    gosc_win_log_src_dest: "{{ dict(source_log_list | zip(dest_log_list)) }}"
+    win_gosc_log_src_dest: "{{ dict(win_gosc_log_files | zip(win_gosc_log_files_dst)) }}"
 
 - name: "Display the GOSC log files to be fetched"
-  ansible.builtin.debug: var=gosc_win_log_src_dest
+  ansible.builtin.debug: var=win_gosc_log_src_dest
 
 - name: "Fetch GOSC log files from guest OS"
   include_tasks: ../../common/vm_guest_file_operation.yml
@@ -44,4 +42,4 @@
     operation: "fetch_file"
     src_path: "{{ item.key }}"
     dest_path: "{{ item.value }}"
-  loop: "{{ gosc_win_log_src_dest | dict2items }}"
+  loop: "{{ win_gosc_log_src_dest | dict2items }}"

--- a/windows/guest_customization/get_gosc_logs_no_network.yml
+++ b/windows/guest_customization/get_gosc_logs_no_network.yml
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Fetch log files from Windows guest OS to local
-- name: Initialize the dict of source log files and dest path
+- name: "Initialize the dict of source log files and dest path"
   ansible.builtin.set_fact:
     separator: '\'
     source_log_list: []
     dest_log_list: []
     gosc_win_log_src_dest: {}
 
-- name: Set fact of the GOSC log files' paths
+- name: "Set fact of the GOSC log files' paths"
   ansible.builtin.set_fact:
     gosc_win_log_files:
       - 'Temp\vmware-imc\guestcust.log'
@@ -23,23 +23,25 @@
       - 'Debug\NetSetup.LOG'
       - 'Debug\PASSWD.LOG'
       - 'Debug\sammui.log'
-- name: Set fact of the absolute file path list
+
+- name: "Set fact of the absolute log files path list"
   ansible.builtin.set_fact:
     source_log_list: "{{ source_log_list + [win_dir ~ separator ~ item] }}"
     dest_log_list: "{{ dest_log_list + [current_test_log_folder ~ '/' ~ item.split(separator) | join('/')] }}"
   with_items: "{{ gosc_win_log_files }}"
+  no_log: true
 
-- name: Set fact of the source file path and dest file path dict
+- name: "Set fact of the source and dest log files path dict"
   ansible.builtin.set_fact:
     gosc_win_log_src_dest: "{{ dict(source_log_list | zip(dest_log_list)) }}"
-- name: Display the GOSC log files to be fetched
+
+- name: "Display the GOSC log files to be fetched"
   ansible.builtin.debug: var=gosc_win_log_src_dest
 
-- include_tasks: ../../common/vm_guest_file_operation.yml
+- name: "Fetch GOSC log files from guest OS"
+  include_tasks: ../../common/vm_guest_file_operation.yml
   vars:
     operation: "fetch_file"
     src_path: "{{ item.key }}"
     dest_path: "{{ item.value }}"
-    vm_username: 'Administrator'
-    vm_password: "{{ customize_logon_password }}"
   loop: "{{ gosc_win_log_src_dest | dict2items }}"

--- a/windows/guest_customization/get_gosc_logs_no_network.yml
+++ b/windows/guest_customization/get_gosc_logs_no_network.yml
@@ -25,9 +25,12 @@
 
 - name: "Set fact of the absolute file path list of GOSC log"
   ansible.builtin.set_fact:
-    win_gosc_log_files: "{{ win_gosc_log_files + [win_windows_dir ~ win_dir_separator ~ item] }}"
-    win_gosc_log_files_dst: "{{ win_gosc_log_files_dst + [current_test_log_folder ~ '/' ~ item.split(win_dir_separator) | join('/')] }}"
-  with_items: "{{ win_gosc_log_files_rel }}"
+    win_gosc_log_files: >-
+      {{ [win_windows_dir] | ansible.builtin.product(win_gosc_log_files_rel) |
+      map('join', win_dir_separator) }}
+    win_gosc_log_files_dst: >-
+      {{ [current_test_log_folder] | ansible.builtin.product(win_gosc_log_files_rel) |
+      map('join', win_dir_separator) | map('replace', win_dir_separator, '/') }}
 
 - name: "Set fact of the source and dest log files path dict"
   ansible.builtin.set_fact:

--- a/windows/guest_customization/gosc_sanity_dhcp.yml
+++ b/windows/guest_customization/gosc_sanity_dhcp.yml
@@ -4,14 +4,14 @@
 # Description:
 #   This test case is used for check guest OS customization (GOSC)
 # with DHCP network configuration. If VMware Tools is not installed,
-# the test result is 'No Run'.
+# the test result is 'Blocked'.
 # Note: VM guest OS customization requires vCenter server.
 #
 - name: gosc_sanity_dhcp
   hosts: localhost
   gather_facts: false
   vars:
-    customize_network_type: "dhcp"
+    gosc_network_type: "dhcp"
   tasks:
     - name: "GOSC test with DHCP network configure"
       include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/gosc_sanity_dhcp.yml
+++ b/windows/guest_customization/gosc_sanity_dhcp.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for check guest OS customization (GOSC)
+#   This test case is used for checking guest OS customization (GOSC)
 # with DHCP network configuration. If VMware Tools is not installed,
 # the test result is 'Blocked'.
 # Note: VM guest OS customization requires vCenter server.
@@ -13,5 +13,5 @@
   vars:
     gosc_network_type: "dhcp"
   tasks:
-    - name: "GOSC test with DHCP network configure"
+    - name: "GOSC test with DHCP network configuration"
       include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/gosc_sanity_dhcp.yml
+++ b/windows/guest_customization/gosc_sanity_dhcp.yml
@@ -2,108 +2,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for check guest customization with DHCP
-# network configuration. If VMware tools is not installed, the test
-# result is 'No Run'.
-# Note: VM guest customization requires vCenter server.
+#   This test case is used for check guest OS customization (GOSC)
+# with DHCP network configuration. If VMware Tools is not installed,
+# the test result is 'No Run'.
+# Note: VM guest OS customization requires vCenter server.
 #
 - name: gosc_sanity_dhcp
   hosts: localhost
   gather_facts: false
+  vars:
+    customize_network_type: "dhcp"
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
-          vars:
-            skip_test_no_vmtools: true
-
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCenter server is not configured"
-            skip_reason: "Blocked"
-          when: vcenter_is_defined is undefined or not vcenter_is_defined | bool
-
-        - include_tasks: win_gosc_prepare.yml
-        - name: Set fact of the network customize type to dhcp
-          ansible.builtin.set_fact:
-            customize_network_type: 'dhcp'
-            vm_dhcp_gosc_start: true
-        - include_tasks: win_gosc_execution.yml
-          vars:
-            customize_network: "{{ gosc_dhcp_network | default('VM Network') }}"
-            timeout: 2400
-
-        # Check guest customization state is completed
-        - include_tasks: ../../common/vm_wait_log_msg.yml
-          vars:
-            vm_wait_log_name: "vmware.log"
-            vm_wait_log_msg: "Chipset: The guest has requested that the virtual machine be hard reset.*|GuestRpc: Reinitializing Channel 0.*"
-            vm_wait_log_retries: 60
-            vm_wait_log_delay: 30
-            vm_wait_log_msg_times: 2
-          when:
-            - esxi_version is defined and esxi_version
-            - esxi_version is version('6.5.0', '=')
-        - include_tasks: ../../common/vm_wait_gosc_completed.yml
-          when: >
-            (esxi_version is undefined) or
-            (not esxi_version) or
-            (esxi_version is version('6.5.0', '>'))
-
-        # Wait guest get IP address
-        - include_tasks: ../../common/vm_wait_guest_ip.yml
-
-        # Get guest IP after customization from guestinfo
-        - include_tasks: ../../common/vm_get_ip_from_vmtools.yml
-        - name: Set fact of the guest IP after GOSC
-          ansible.builtin.set_fact:
-            guest_ip_after_gosc: "{{ vm_guest_ip }}"
-        - include_tasks: ../utils/win_check_winrm.yml
-
-        # Get guest hostname after customization from guestinfo
-        - include_tasks: ../../common/vm_wait_guest_hostname.yml
-          vars:
-            wait_guest_hostname: "{{ customize_gos_hostname }}"
-
-        - include_tasks: ../../common/vm_get_config.yml
-          vars:
-            property_list: ['guest.hostName']
-        - name: Set fact of the hostname after GOSC
-          ansible.builtin.set_fact:
-            hostname_after_gosc: "{{ vm_config.guest.hostName }}"
-        - ansible.builtin.debug:
-            msg: "Get guest OS hostname/IP after customization: {{ hostname_after_gosc }}/{{ guest_ip_after_gosc }}"
-
-        - name: Check if IP address and hostname changed after customization
-          ansible.builtin.assert:
-            that:
-              - "{{ hostname_before_gosc != hostname_after_gosc }}"
-              - "{{ hostname_after_gosc == customize_gos_hostname }}"
-            success_msg: "Check hostname after GOSC succeed."
-            fail_msg: "Check hostname after GOSC failed."
-
-        # After customize Administrator user password changed
-        # Add customizated IP address to Ansible hosts
-        - include_tasks: ../utils/add_windows_host.yml
-          vars:
-            vm_password: "{{ customize_logon_password }}"
-          when: vm_username | lower == "administrator"
-
-        - name: "Add customizated IP address to Ansible hosts using user '{{ vm_username }}'"
-          include_tasks: ../utils/add_windows_host.yml
-          when: vm_username | lower != "administrator"
-
-        # Check auto admin logon and count
-        - include_tasks: check_autologon_count.yml
-        # Check run once command executed
-        - include_tasks: check_runonce_command.yml
-        # Check timezone configured
-        - include_tasks: check_timezone.yml
-      rescue:
-        - include_tasks: ../../common/test_rescue.yml
-      always:
-        - block:
-            - include_tasks: ../../common/vm_get_power_state.yml
-            # Get all gosc logs from guest to local
-            - include_tasks: get_gosc_logs_network.yml
-              when: vm_power_state_get == "poweredOn"
-          when: vm_dhcp_gosc_start is defined and vm_dhcp_gosc_start
+    - name: "GOSC test with DHCP network configure"
+      include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/gosc_sanity_staticip.yml
+++ b/windows/guest_customization/gosc_sanity_staticip.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for check guest OS customization (GOSC)
+#   This test case is used for checking guest OS customization (GOSC)
 # with static network configuration. If VMware Tools is not installed,
 # the test result is 'Blocked'.
 # Note: VM guest OS customization requires vCenter server.
@@ -13,5 +13,5 @@
   vars:
     gosc_network_type: "static"
   tasks:
-    - name: "GOSC test with static network configure"
+    - name: "GOSC test with static network configuration"
       include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/gosc_sanity_staticip.yml
+++ b/windows/guest_customization/gosc_sanity_staticip.yml
@@ -2,105 +2,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for check guest customization with static
-# network configuration. If VMware tools is not installed, the test
-# result is 'No Run'.
-# Note: VM guest customization requires vCenter server.
+#   This test case is used for check guest OS customization (GOSC)
+# with static network configuration. If VMware Tools is not installed,
+# the test result is 'No Run'.
+# Note: VM guest OS customization requires vCenter server.
 #
 - name: gosc_sanity_staticip
   hosts: localhost
   gather_facts: false
+  vars:
+    customize_network_type: "static"
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
-          vars:
-            skip_test_no_vmtools: true
-
-        - include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCenter server is not configured"
-            skip_reason: "Blocked"
-          when: vcenter_is_defined is undefined or not vcenter_is_defined | bool
-
-        # Prepare router VM, vSwitch and portgroup
-        - include_tasks: ../../common/network_testbed_setup.yml
-          when: router_vm_deployed is undefined or not router_vm_deployed | bool
-
-        - include_tasks: win_gosc_prepare.yml
-
-        # Use router VM as the default gateway hardcoded to 192.168.192.1,
-        # use configured static IP address in this subnet
-        - name: Set fact of customize static network and gosc start
-          ansible.builtin.set_fact:
-            customize_network_type: 'static'
-            vm_static_gosc_start: true
-
-        - include_tasks: win_gosc_execution.yml
-          vars:
-            customize_ip: '192.168.192.10'
-            customize_gateway: "{{ vlan_gateway }}"
-            customize_netmask: '255.255.255.0'
-            customize_network: "{{ portgroup_name }}"
-            timeout: 2400
-
-        # Wait guest customization state is completed
-        - include_tasks: ../../common/vm_wait_log_msg.yml
-          vars:
-            vm_wait_log_name: "vmware.log"
-            vm_wait_log_msg: "Chipset: The guest has requested that the virtual machine be hard reset.*|GuestRpc: Reinitializing Channel 0.*"
-            vm_wait_log_retries: 60
-            vm_wait_log_delay: 30
-            vm_wait_log_msg_times: 2
-          when:
-            - esxi_version is defined and esxi_version
-            - esxi_version is version('6.5.0', '=')
-        - include_tasks: ../../common/vm_wait_gosc_completed.yml
-          when: >
-            (esxi_version is undefined) or
-            (not esxi_version) or
-            (esxi_version is version('6.5.0', '>'))
-
-        # Wait guest get the customized static IP
-        - include_tasks: ../../common/vm_wait_guest_ip.yml
-          vars:
-            wait_ipv4: "192.168.192.10"
-
-        # Get guest IP after customization from guestinfo
-        - include_tasks: ../../common/vm_get_ip_from_vmtools.yml
-        - name: Set fact of the VM guest IP after GOSC
-          ansible.builtin.set_fact:
-            guest_ip_after_gosc: "{{ vm_guest_ip }}"
-
-        # Get guest hostname after customization from guestinfo
-        - include_tasks: ../../common/vm_wait_guest_hostname.yml
-          vars:
-            wait_guest_hostname: "{{ customize_gos_hostname }}"
-
-        - include_tasks: ../../common/vm_get_config.yml
-          vars:
-            property_list: ['guest.hostName']
-        - name: Set fact of the hostname after GOSC
-          ansible.builtin.set_fact:
-            hostname_after_gosc: "{{ vm_config.guest.hostName }}"
-        - ansible.builtin.debug:
-            msg: "Get guest OS hostname/IP after customization: {{ hostname_after_gosc }}/{{ guest_ip_after_gosc }}"
-
-        - name: Check IP and hostname changed after customization
-          ansible.builtin.assert:
-            that:
-              - "{{ guest_ip_before_gosc != guest_ip_after_gosc }}"
-              - "{{ hostname_before_gosc != hostname_after_gosc }}"
-              - "{{ hostname_after_gosc == customize_gos_hostname }}"
-              - "{{ guest_ip_after_gosc == '192.168.192.10' }}"
-            success_msg: "Check guest IP address, hostname after GOSC succeed."
-            fail_msg: "Check guest IP address, hostname after GOSC failed."
-
-      rescue:
-        - include_tasks: ../../common/test_rescue.yml
-      always:
-        - block:
-            - include_tasks: ../../common/vm_get_power_state.yml
-            # Get GOSC log files
-            - include_tasks: get_gosc_logs_no_network.yml
-              when: vm_power_state_get == "poweredOn"
-          when: vm_static_gosc_start is defined and vm_static_gosc_start
+    - name: "GOSC test with static network configure"
+      include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/gosc_sanity_staticip.yml
+++ b/windows/guest_customization/gosc_sanity_staticip.yml
@@ -4,14 +4,14 @@
 # Description:
 #   This test case is used for check guest OS customization (GOSC)
 # with static network configuration. If VMware Tools is not installed,
-# the test result is 'No Run'.
+# the test result is 'Blocked'.
 # Note: VM guest OS customization requires vCenter server.
 #
 - name: gosc_sanity_staticip
   hosts: localhost
   gather_facts: false
   vars:
-    customize_network_type: "static"
+    gosc_network_type: "static"
   tasks:
     - name: "GOSC test with static network configure"
       include_tasks: win_gosc_workflow.yml

--- a/windows/guest_customization/uninstall_onedrive.yml
+++ b/windows/guest_customization/uninstall_onedrive.yml
@@ -1,46 +1,30 @@
 # Copyright 2022-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of OneDrive setup exe file path for Windows 11 GA"
+- name: "Set fact of OneDrive setup file path for Windows 11 GA"
   ansible.builtin.set_fact:
     one_drive_setup_exe: "C:\\Windows\\SysWOW64\\OneDriveSetup.exe"
-  when:
-    - guest_os_ansible_distribution_ver == '10.0.22000.0'
-- name: Set fact of OneDrive setup exe file path
+  when: guest_os_ansible_distribution_ver == '10.0.22000.0'
+
+- name: "Set fact of OneDrive setup file path"
   ansible.builtin.set_fact:
     one_drive_setup_exe: "C:\\Windows\\System32\\OneDriveSetup.exe"
   when: one_drive_setup_exe is undefined
 
-# Check OneDrive setup exe file exists
-- include_tasks: ../utils/win_check_file_exist.yml
+- name: "Check if OneDrive setup file exists"
+  include_tasks: ../utils/win_check_file_exist.yml
   vars:
     win_check_file_exist_file: "{{ one_drive_setup_exe }}"
 
-# Uninstall OneDrive when predefined setup exe file exists
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Uninstall OneDrive"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "Start-Process -NoNewWindow -Wait -FilePath {{ one_drive_setup_exe }} -ArgumentList '/uninstall'"
   when:
     - win_check_file_exist_result is defined
     - win_check_file_exist_result
 
-# Get installed OneDrive appx package name
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Remove OneDriveSync Appx package"
+  include_tasks: ../utils/win_remove_appx_package.yml
   vars:
-    win_powershell_cmd: "(Get-AppxPackage -AllUsers | Where PackageFullName -Like '*OneDriveSync*').PackageFullName"
-
-- name: Set fact of OneDrive Sync appx package name
-  ansible.builtin.set_fact:
-    one_drive_appx_package_name: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
-  when:
-    - win_powershell_cmd_output is defined
-    - "'stdout_lines' in win_powershell_cmd_output"
-    - win_powershell_cmd_output.stdout_lines | length != 0
-    - win_powershell_cmd_output.stdout_lines[0]
-
-- include_tasks: ../utils/win_execute_cmd.yml
-  vars:
-    win_powershell_cmd: "Remove-AppxPackage -Package {{ one_drive_appx_package_name }}"
-  when:
-    - one_drive_appx_package_name is defined
-    - one_drive_appx_package_name
+    win_appx_package: "OneDriveSync"

--- a/windows/guest_customization/win_gosc_execution.yml
+++ b/windows/guest_customization/win_gosc_execution.yml
@@ -1,9 +1,9 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of GOSC starts"
+- name: "Set fact of Windows GOSC starts"
   ansible.builtin.set_fact:
-    win_customize_start: true
+    win_gosc_start: true
 
 - name: "Customize Windows guest OS"
   community.vmware.vmware_guest:
@@ -16,31 +16,32 @@
     folder: "{{ vm_folder }}"
     name: "{{ vm_name }}"
     networks:
-      - name: "{{ customize_network }}"
-        ip: "{{ customize_ip | default(omit) }}"
-        gateway: "{{ customize_gateway | default(omit) }}"
-        netmask: "{{ customize_netmask | default(omit) }}"
-        type: "{{ customize_network_type }}"
+      - name: "{{ win_gosc_spec.gosc_network }}"
+        ip: "{{ win_gosc_spec.gosc_ip | default(omit) }}"
+        gateway: "{{ win_gosc_spec.gosc_gateway | default(omit) }}"
+        netmask: "{{ win_gosc_spec.gosc_netmask | default(omit) }}"
+        type: "{{ gosc_network_type }}"
     customization:
       existing_vm: true
-      dns_servers: "{{ gosc_dns_servers }}"
-      domain: "{{ customize_domain }}"
-      hostname: "{{ customize_gos_hostname }}"
-      autologon: "{{ customize_autologon }}"
-      autologoncount: "{{ customize_autologon_count }}"
-      password: "{{ customize_logon_password }}"
-      timezone: "{{ customize_timezone_id }}"
+      dns_servers: "{{ win_gosc_spec.gosc_dns_servers | default(omit) }}"
+      dns_suffix: "{{ win_gosc_spec.gosc_dns_suffix | default(omit) }}"
+      domain: "{{ win_gosc_spec.gosc_domain | default(omit) }}"
+      hostname: "{{ win_gosc_spec.gosc_hostname }}"
+      autologon: "{{ win_gosc_spec.gosc_autologon }}"
+      autologoncount: "{{ win_gosc_spec.gosc_autologon_count }}"
+      password: "{{ win_gosc_spec.gosc_logon_password }}"
+      timezone: "{{ win_gosc_spec.gosc_timezone_id }}"
       runonce:
-        - "{{ customize_runonce }}"
+        - "{{ win_gosc_spec.gosc_runonce }}"
     wait_for_customization: true
     wait_for_customization_timeout: 2400
-  register: customize_windows_result
+  register: win_gosc_result
 
 - name: "Display the Windows GOSC result"
-  ansible.builtin.debug: var=customize_windows_result
+  ansible.builtin.debug: var=win_gosc_result
   when: enable_debug
 
 - name: "Set fact of the password for user 'Administrator'"
   ansible.builtin.set_fact:
-    vm_password: "{{ customize_logon_password }}"
+    vm_password: "{{ win_gosc_spec.gosc_logon_password }}"
   when: vm_username | lower == "administrator"

--- a/windows/guest_customization/win_gosc_execution.yml
+++ b/windows/guest_customization/win_gosc_execution.yml
@@ -1,6 +1,10 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+- name: "Set fact of GOSC starts"
+  ansible.builtin.set_fact:
+    win_customize_start: true
+
 - name: "Customize Windows guest OS"
   community.vmware.vmware_guest:
     validate_certs: "{{ validate_certs | default(false) }}"
@@ -29,9 +33,14 @@
       runonce:
         - "{{ customize_runonce }}"
     wait_for_customization: true
-    wait_for_customization_timeout: "{{ timeout | default(omit) }}"
+    wait_for_customization_timeout: 2400
   register: customize_windows_result
 
-- name: Display the Windows customization result
+- name: "Display the Windows GOSC result"
   ansible.builtin.debug: var=customize_windows_result
   when: enable_debug
+
+- name: "Set fact of the password for user 'Administrator'"
+  ansible.builtin.set_fact:
+    vm_password: "{{ customize_logon_password }}"
+  when: vm_username | lower == "administrator"

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -104,7 +104,7 @@
     - name: "Decrypt Bitlocker volumes"
       include_tasks: ../utils/win_decrypt_bitlocker_volume.yml
 
-- name: "Shutdown guest OS before execute GOSC"
+- name: "Shutdown guest OS before executing GOSC"
   include_tasks: ../utils/win_shutdown_restart.yml
   vars:
     set_win_power_state: "shutdown"

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -9,60 +9,81 @@
   include_tasks: ../../common/network_testbed_setup.yml
   when:
     - (router_vm_deployed is undefined) or (not router_vm_deployed | bool)
-    - customize_network_type == "static"
+    - gosc_network_type == "static"
 
-- name: "Set fact of the common parameters in static and DHCP GOSC spec"
+- name: "Set fact of Windows GOSC spec with common items"
   ansible.builtin.set_fact:
-    customize_gos_hostname: 'gosc-test-win'
-    customize_domain: "autotest.com"
-    customize_autologon: true
-    customize_autologon_count: 10
-    customize_logon_password: 'B1gd3m0z!'
-    customize_timezone_id: '2'
-    customize_timezone_name: "Hawaiian Standard Time"
-    gosc_dns_servers: ['192.168.0.1', '192.168.0.2']
-    customize_runonce_echo_string: 'Windows gosc automation test'
+    win_gosc_spec: {
+      'gosc_hostname': "win-gosc-{{ gosc_network_type }}",
+      'gosc_timezone_id': "2",
+      'gosc_timezone_name': "Hawaiian Standard Time",
+      'gosc_autologon': true,
+      'gosc_autologon_count': 10,
+      'gosc_logon_password': "B1gd3m0z!",
+      'gosc_echo_file': "C:\\win_gosc_runonce.txt",
+      'gosc_echo_string': "Windows {{ gosc_network_type }} GOSC automation test"
+    }
 
-- name: "Set fact of the run once command"
+- name: "Add run once command to Windows GOSC spec"
   ansible.builtin.set_fact:
-    customize_runonce: "cmd.exe /c echo {{ customize_runonce_echo_string }} > C:\\gosc_runonce.txt"
+    win_gosc_spec: >-
+      {{ win_gosc_spec | combine({'gosc_runonce': 
+      "cmd.exe /c echo " ~ win_gosc_spec.gosc_echo_string ~ " > " ~ win_gosc_spec.gosc_echo_file}) }}
 
-- name: "Set fact of the static network config parameters"
+- name: "Set fact of Windows GOSC spec with static IP"
   ansible.builtin.set_fact:
-    customize_ip: '192.168.192.10'
-    customize_gateway: "{{ vlan_gateway }}"
-    customize_netmask: '255.255.255.0'
-    customize_network: "{{ portgroup_name }}"
-  when: customize_network_type == "static"
+    win_gosc_spec: "{{ win_gosc_spec | combine(item) }}"
+  loop:
+    - {'gosc_dns_servers': ['192.168.0.1', '192.168.0.2']}
+    - {'gosc_ip': '192.168.192.10'}
+    - {'gosc_domain': "gosc.test.com"}
+    - {'gosc_dns_suffix': ["test.com", "gosc.test.com"]}
+    - {'gosc_gateway': "{{ vlan_gateway }}"}
+    - {'gosc_netmask': '255.255.255.0'}
+    - {'gosc_network': "{{ portgroup_name }}"}
+  when: gosc_network_type == "static"
 
-- name: "Set fact of the DHCP network config parameter"
+- name: "Set fact of Windows GOSC spec with DHCP IP"
   ansible.builtin.set_fact:
-    customize_network: "{{ gosc_dhcp_network | default('VM Network') }}"
-  when: customize_network_type == "dhcp"
+    win_gosc_spec: >-
+      {{ win_gosc_spec | combine({'gosc_network': (gosc_dhcp_network | default('VM Network'))}) }}
+  when: gosc_network_type == "dhcp"
+
+- name: "Print Windows GOSC spec"
+  ansible.builtin.debug: var=win_gosc_spec
 
 - name: "Set fact of default Windows dir"
   ansible.builtin.set_fact:
-    win_dir: '$env:windir'
+    win_windows_dir: '$env:windir'
+    win_dir_separator: '\'
 - name: "Get directory path in Windows guest OS"
   include_tasks: ../utils/win_get_path.yml
   vars:
-    win_get_path_specified: "{{ win_dir }}"
+    win_get_path_specified: "{{ win_windows_dir }}"
 - name: "Set fact of the absolute path of Windows dir"
   ansible.builtin.set_fact:
-    win_dir: "{{ win_get_path_absolute }}"
-- name: "Print Windows dir"
-  ansible.builtin.debug:
-    msg: "Windows GOSC log files in Windows dir: {{ win_dir }}"
+    win_windows_dir: "{{ win_get_path_absolute }}"
 
-# Uninstall OneDrive in Windows 11 for the known 3rd-party issue
-# Parameter 'uninstall_onedrive' is used for internal testing only
-- name: "Uninstall OneDrive"
-  include_tasks: uninstall_onedrive.yml
+# Workaround for this type of SYSPREP known issue:
+# Package <PackageFullName> was installed for a user, but not provisioned for all users.
+# This package will not function properly in the sysprep image.
+# For more information, please refer to this KB article or Microsoft doc linked:
+# https://kb.vmware.com/s/article/87307
+- name: "Workaround for SYSPREP error"
   when:
-    - uninstall_onedrive is defined
-    - uninstall_onedrive | bool
     - guest_os_ansible_distribution_ver is version('10.0.22000.0', '>=')
     - guest_os_product_type | lower == 'client'
+  block:
+    - name: "Remove BingSearch Appx package"
+      include_tasks: ../utils/win_remove_appx_package.yml
+      vars:
+        win_appx_package: "BingSearch"
+    # Parameter 'uninstall_onedrive' is only used for internal testing now
+    - name: "Uninstall OneDrive"
+      include_tasks: uninstall_onedrive.yml
+      when:
+        - uninstall_onedrive is defined
+        - uninstall_onedrive | bool
 
 # Disable BitLocker which will cause sysprep failure
 # BitLocker is not installed by default on Windows Server

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -1,12 +1,17 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Set the common parameters in static and dhcp
-# GOSC specification
+# Set the parameters in static and DHCP GOSC specifications
 # Note: refer to this page to set time zone id and name:
 # https://msdn.microsoft.com/en-us/library/ms912391.aspx
 #
-- name: "Set fact of the common parameters in static and dhcp GOSC spec"
+- name: "Prepare router VM, vSwitch and portgroup"
+  include_tasks: ../../common/network_testbed_setup.yml
+  when:
+    - (router_vm_deployed is undefined) or (not router_vm_deployed | bool)
+    - customize_network_type == "static"
+
+- name: "Set fact of the common parameters in static and DHCP GOSC spec"
   ansible.builtin.set_fact:
     customize_gos_hostname: 'gosc-test-win'
     customize_domain: "autotest.com"
@@ -22,39 +27,35 @@
   ansible.builtin.set_fact:
     customize_runonce: "cmd.exe /c echo {{ customize_runonce_echo_string }} > C:\\gosc_runonce.txt"
 
-- name: "Set fact of the VM guest IP before GOSC"
+- name: "Set fact of the static network config parameters"
   ansible.builtin.set_fact:
-    guest_ip_before_gosc: "{{ vm_guest_ip }}"
+    customize_ip: '192.168.192.10'
+    customize_gateway: "{{ vlan_gateway }}"
+    customize_netmask: '255.255.255.0'
+    customize_network: "{{ portgroup_name }}"
+  when: customize_network_type == "static"
 
-- name: "Get guest OS hostname from VM guestinfo"
-  include_tasks: ../../common/vm_get_config.yml
-  vars:
-    property_list: ['guest.hostName']
-
-- name: "Set fact of the hostname before GOSC"
+- name: "Set fact of the DHCP network config parameter"
   ansible.builtin.set_fact:
-    hostname_before_gosc: "{{ vm_config.guest.hostName }}"
-
-- ansible.builtin.debug:
-    msg: "Get guest OS hostname/IP before customization: {{ hostname_before_gosc }}/{{ guest_ip_before_gosc }}"
+    customize_network: "{{ gosc_dhcp_network | default('VM Network') }}"
+  when: customize_network_type == "dhcp"
 
 - name: "Set fact of default Windows dir"
   ansible.builtin.set_fact:
     win_dir: '$env:windir'
-
-- name: "Get OS directory"
+- name: "Get directory path in Windows guest OS"
   include_tasks: ../utils/win_get_path.yml
   vars:
     win_get_path_specified: "{{ win_dir }}"
-
 - name: "Set fact of the absolute path of Windows dir"
   ansible.builtin.set_fact:
     win_dir: "{{ win_get_path_absolute }}"
-- ansible.builtin.debug:
+- name: "Print Windows dir"
+  ansible.builtin.debug:
     msg: "Windows GOSC log files in Windows dir: {{ win_dir }}"
 
 # Uninstall OneDrive in Windows 11 for the known 3rd-party issue
-# Paramter 'uninstall_onedrive' is used for internal testing only
+# Parameter 'uninstall_onedrive' is used for internal testing only
 - name: "Uninstall OneDrive"
   include_tasks: uninstall_onedrive.yml
   when:
@@ -63,8 +64,8 @@
     - guest_os_ansible_distribution_ver is version('10.0.22000.0', '>=')
     - guest_os_product_type | lower == 'client'
 
-# Disable BitLocker which will cause sysprep failure.
-# BitLocker is not installed by default on Windows Server.
+# Disable BitLocker which will cause sysprep failure
+# BitLocker is not installed by default on Windows Server
 - name: "Disable BitLocker"
   when: guest_os_product_type | lower == 'client'
   block:
@@ -82,8 +83,7 @@
     - name: "Decrypt Bitlocker volumes"
       include_tasks: ../utils/win_decrypt_bitlocker_volume.yml
 
-# Shutdown guest OS before execute guest customization
-- name: "Shutdown OS"
+- name: "Shutdown guest OS before execute GOSC"
   include_tasks: ../utils/win_shutdown_restart.yml
   vars:
     set_win_power_state: "shutdown"

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -27,20 +27,20 @@
 - name: "Add run once command to Windows GOSC spec"
   ansible.builtin.set_fact:
     win_gosc_spec: >-
-      {{ win_gosc_spec | combine({'gosc_runonce': 
+      {{ win_gosc_spec | combine({'gosc_runonce':
       "cmd.exe /c echo " ~ win_gosc_spec.gosc_echo_string ~ " > " ~ win_gosc_spec.gosc_echo_file}) }}
 
 - name: "Set fact of Windows GOSC spec with static IP"
   ansible.builtin.set_fact:
-    win_gosc_spec: "{{ win_gosc_spec | combine(item) }}"
-  loop:
-    - {'gosc_dns_servers': ['192.168.0.1', '192.168.0.2']}
-    - {'gosc_ip': '192.168.192.10'}
-    - {'gosc_domain': "gosc.test.com"}
-    - {'gosc_dns_suffix': ["test.com", "gosc.test.com"]}
-    - {'gosc_gateway': "{{ vlan_gateway }}"}
-    - {'gosc_netmask': '255.255.255.0'}
-    - {'gosc_network': "{{ portgroup_name }}"}
+    win_gosc_spec: >-
+      {{ win_gosc_spec | combine({
+      'gosc_dns_servers': ['192.168.0.1', '192.168.0.2'],
+      'gosc_ip': '192.168.192.10',
+      'gosc_domain': "gosc.test.com",
+      'gosc_dns_suffix': ["test.com", "gosc.test.com"],
+      'gosc_gateway': vlan_gateway,
+      'gosc_netmask': '255.255.255.0',
+      'gosc_network': portgroup_name}) }}
   when: gosc_network_type == "static"
 
 - name: "Set fact of Windows GOSC spec with DHCP IP"

--- a/windows/guest_customization/win_gosc_verify.yml
+++ b/windows/guest_customization/win_gosc_verify.yml
@@ -15,49 +15,12 @@
   include_tasks: ../../common/vm_wait_gosc_completed.yml
   when: esxi_version is version('6.5.0', '>')
 
-- name: "Wait for VM IP address after GOSC"
-  include_tasks: ../../common/vm_wait_guest_ip.yml
-  vars:
-    wait_ipv4: "{{ customize_ip if (customize_network_type == 'static') else '' }}"
-
-- name: "Get VM IP address after GOSC"
-  include_tasks: ../../common/vm_get_ip_from_vmtools.yml
-
-- name: "Wait for guest OS hostname after GOSC"
-  include_tasks: ../../common/vm_wait_guest_hostname.yml
-  vars:
-    wait_guest_hostname: "{{ customize_gos_hostname }}"
-- name: "Set fact of the guest OS hostname"
-  ansible.builtin.set_fact:
-    hostname_after_gosc: "{{ vm_guest_facts.instance.guest.hostName }}"
-
-- name: "Print guest OS info"
-  ansible.builtin.debug:
-    msg: "Guest OS hostname/IP address after GOSC: {{ hostname_after_gosc }}/{{ vm_guest_ip }}"
-
-- name: "Check customized guest OS hostname"
-  ansible.builtin.assert:
-    that:
-      - "{{ hostname_after_gosc == customize_gos_hostname }}"
-    success_msg: "Guest OS hostname is customized successfully: {{ hostname_after_gosc }}."
-    fail_msg: "Guest OS hostname is '{{ hostname_after_gosc }} after GOSC, expected '{{ customize_gos_hostname }}'."
-
-- name: "Check customized IP address"
-  ansible.builtin.assert:
-    that:
-      - "{{ vm_guest_ip == '192.168.192.10' }}"
-    success_msg: "Guest OS IP address is customized successfully: {{ vm_guest_ip }}."
-    fail_msg: "Guest OS IP address is '{{ vm_guest_ip }}' after GOSC, expected '192.168.192.10'."
-  when: customize_network_type == "static"
+- name: "Check guest OS IP address and hostname"
+  include_tasks: check_ip_hostname.yml
 
 - name: "Verify customization results"
-  when: customize_network_type == "dhcp"
+  when: gosc_network_type == "dhcp"
   block:
-    - name: "Check Windows winrm is connectable"
-      include_tasks: ../utils/win_check_winrm.yml
-    - name: "Add VM IP address to Ansible hosts"
-      include_tasks: ../utils/add_windows_host.yml
-
     - name: "Check auto admin logon and count"
       include_tasks: check_autologon_count.yml
     - name: "Check run once command executed"

--- a/windows/guest_customization/win_gosc_verify.yml
+++ b/windows/guest_customization/win_gosc_verify.yml
@@ -1,0 +1,66 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Check GOSC state in vmware.log on ESXi 6.5"
+  include_tasks: ../../common/vm_wait_log_msg.yml
+  vars:
+    vm_wait_log_name: "vmware.log"
+    vm_wait_log_msg: "Chipset: The guest has requested that the virtual machine be hard reset.*|GuestRpc: Reinitializing Channel 0.*"
+    vm_wait_log_retries: 60
+    vm_wait_log_delay: 30
+    vm_wait_log_msg_times: 2
+  when: esxi_version is version('6.5.0', '=')
+
+- name: "Check GOSC state in vmware.log on ESXi {{ esxi_version }}"
+  include_tasks: ../../common/vm_wait_gosc_completed.yml
+  when: esxi_version is version('6.5.0', '>')
+
+- name: "Wait for VM IP address after GOSC"
+  include_tasks: ../../common/vm_wait_guest_ip.yml
+  vars:
+    wait_ipv4: "{{ customize_ip if (customize_network_type == 'static') else '' }}"
+
+- name: "Get VM IP address after GOSC"
+  include_tasks: ../../common/vm_get_ip_from_vmtools.yml
+
+- name: "Wait for guest OS hostname after GOSC"
+  include_tasks: ../../common/vm_wait_guest_hostname.yml
+  vars:
+    wait_guest_hostname: "{{ customize_gos_hostname }}"
+- name: "Set fact of the guest OS hostname"
+  ansible.builtin.set_fact:
+    hostname_after_gosc: "{{ vm_guest_facts.instance.guest.hostName }}"
+
+- name: "Print guest OS info"
+  ansible.builtin.debug:
+    msg: "Guest OS hostname/IP address after GOSC: {{ hostname_after_gosc }}/{{ vm_guest_ip }}"
+
+- name: "Check customized guest OS hostname"
+  ansible.builtin.assert:
+    that:
+      - "{{ hostname_after_gosc == customize_gos_hostname }}"
+    success_msg: "Guest OS hostname is customized successfully: {{ hostname_after_gosc }}."
+    fail_msg: "Guest OS hostname is '{{ hostname_after_gosc }} after GOSC, expected '{{ customize_gos_hostname }}'."
+
+- name: "Check customized IP address"
+  ansible.builtin.assert:
+    that:
+      - "{{ vm_guest_ip == '192.168.192.10' }}"
+    success_msg: "Guest OS IP address is customized successfully: {{ vm_guest_ip }}."
+    fail_msg: "Guest OS IP address is '{{ vm_guest_ip }}' after GOSC, expected '192.168.192.10'."
+  when: customize_network_type == "static"
+
+- name: "Verify customization results"
+  when: customize_network_type == "dhcp"
+  block:
+    - name: "Check Windows winrm is connectable"
+      include_tasks: ../utils/win_check_winrm.yml
+    - name: "Add VM IP address to Ansible hosts"
+      include_tasks: ../utils/add_windows_host.yml
+
+    - name: "Check auto admin logon and count"
+      include_tasks: check_autologon_count.yml
+    - name: "Check run once command executed"
+      include_tasks: check_runonce_command.yml
+    - name: "Check timezone configured"
+      include_tasks: check_timezone.yml

--- a/windows/guest_customization/win_gosc_workflow.yml
+++ b/windows/guest_customization/win_gosc_workflow.yml
@@ -5,7 +5,7 @@
   block:
     - name: "Initialize GOSC state"
       ansible.builtin.set_fact:
-        win_customize_start: false
+        win_gosc_start: false
 
     - name: "Test setup"
       include_tasks: ../setup/test_setup.yml
@@ -34,7 +34,7 @@
       include_tasks: ../../common/test_rescue.yml
   always:
     - name: "Collect GOSC log files"
-      when: win_customize_start
+      when: win_gosc_start
       block:
         - name: "Get VM power state"
           include_tasks: ../../common/vm_get_power_state.yml
@@ -43,7 +43,7 @@
           block:
             - name: "Get GOSC log files in VM with DHCP IP"
               include_tasks: get_gosc_logs_network.yml
-              when: customize_network_type == "dhcp"
+              when: gosc_network_type == "dhcp"
             - name: "Get GOSC log files in VM with static IP"
               include_tasks: get_gosc_logs_no_network.yml
-              when: customize_network_type == "static"
+              when: gosc_network_type == "static"

--- a/windows/guest_customization/win_gosc_workflow.yml
+++ b/windows/guest_customization/win_gosc_workflow.yml
@@ -1,0 +1,49 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Test case block"
+  block:
+    - name: "Initialize GOSC state"
+      ansible.builtin.set_fact:
+        win_customize_start: false
+
+    - name: "Test setup"
+      include_tasks: ../setup/test_setup.yml
+      vars:
+        skip_test_no_vmtools: true
+
+    - name: "Skip test case"
+      include_tasks: ../../common/skip_test_case.yml
+      vars:
+        skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCenter server is not configured"
+        skip_reason: "Blocked"
+      when: >
+        (vcenter_is_defined is undefined) or
+        (not vcenter_is_defined | bool)
+
+    - name: "Prepare Windows GOSC"
+      include_tasks: win_gosc_prepare.yml
+
+    - name: "Execute Windows GOSC"
+      include_tasks: win_gosc_execution.yml
+
+    - name: "Verify Windows GOSC"
+      include_tasks: win_gosc_verify.yml
+  rescue:
+    - name: "Test case failure"
+      include_tasks: ../../common/test_rescue.yml
+  always:
+    - name: "Collect GOSC log files"
+      when: win_customize_start
+      block:
+        - name: "Get VM power state"
+          include_tasks: ../../common/vm_get_power_state.yml
+        - name: "Get GOSC log files when VM is power on"
+          when: vm_power_state_get == "poweredOn"
+          block:
+            - name: "Get GOSC log files in VM with DHCP IP"
+              include_tasks: get_gosc_logs_network.yml
+              when: customize_network_type == "dhcp"
+            - name: "Get GOSC log files in VM with static IP"
+              include_tasks: get_gosc_logs_no_network.yml
+              when: customize_network_type == "static"

--- a/windows/utils/win_get_file_folder.yml
+++ b/windows/utils/win_get_file_folder.yml
@@ -8,23 +8,24 @@
 #
 - name: "Set the fact of file path"
   ansible.builtin.set_fact:
+    win_src_path: "{{ win_get_src_path }}"
     win_dst_path: "{{ win_get_dst_path }}"
 
-- name: "Check if the path {{ win_get_src_path }} is a directory"
+- name: "Check if source path {{ win_src_path }} is a directory"
   include_tasks: win_is_folder.yml
   vars:
-    win_is_folder_path: "{{ win_get_src_path }}"
+    win_is_folder_path: "{{ win_src_path }}"
 
-- name: "Get file from guest OS"
+- name: "Get specified file from guest OS"
   include_tasks: win_get_file.yml
   vars:
-    win_get_file_src_path: "{{ win_get_src_path }}"
+    win_get_file_src_path: "{{ win_src_path }}"
     win_get_file_dst_path: "{{ win_dst_path }}"
   when: not win_is_folder_result
 
-- name: "Get the files in sub folders"
+- name: "Get files or sub folders in specified folder"
   include_tasks: win_get_folder.yml
   vars:
-    win_get_folder_src_path: "{{ win_get_src_path }}"
+    win_get_folder_src_path: "{{ win_src_path }}"
     win_get_folder_dst_path: "{{ win_dst_path }}"
   when: win_is_folder_result

--- a/windows/utils/win_get_folder.yml
+++ b/windows/utils/win_get_folder.yml
@@ -7,42 +7,42 @@
 #   win_get_folder_dst_path: the destination path in local machine
 #
 - name: "Display the source folder path"
-  ansible.builtin.debug:
-    msg: "Specified source folder path is: {{ win_get_folder_src_path }}"
+  ansible.builtin.debug: var=win_get_folder_src_path
 
-
-- name: "Check if the folder {{ win_get_folder_src_path }} exists in guest OS"
+- name: "Check if source folder exists in guest OS"
   include_tasks: win_check_file_exist.yml
   vars:
     win_check_file_exist_file: "{{ win_get_folder_src_path }}"
 
-- name: "Set the result of file existing"
+- name: "Set fact of source folder existence state"
   ansible.builtin.set_fact:
-    win_file_exist: "{{ win_check_file_exist_result }}"
+    win_folder_exist: "{{ win_check_file_exist_result }}"
 
-- name: "Get files from guest OS"
+- name: "Get files in source folder from guest OS"
+  when: win_folder_exist
   block:
-    - name: "Get files and sub folders under directory {{ win_get_folder_src_path }}"
+    - name: "Get files and sub folders list in source folder"
       include_tasks: win_get_sub_files_folders.yml
       vars:
         win_get_files_folders_folder: "{{ win_get_folder_src_path }}"
 
-    - name: "Fetch files from guest OS"
-      include_tasks: win_get_file_folder.yml
-      vars:
-        win_get_dst_path: "{{ win_get_folder_dst_path }}"
-      with_items: "{{ win_get_files_folders_list }}"
-      loop_control:
-        loop_var: win_get_src_path
-      when: win_get_files_folders_list | length | int != 0
+    - name: "Fetch files in source folder from guest OS"
+      when: win_get_files_folders_list | length != 0
+      block:
+        - name: "Fetch files recusively"
+          include_tasks: win_get_file_folder.yml
+          vars:
+            win_get_dst_path: "{{ win_get_folder_dst_path }}"
+          with_items: "{{ win_get_files_folders_list }}"
+          loop_control:
+            loop_var: win_get_src_path
 
-    - name: "Display message for empty file list"
+    - name: "No files or sub folders in source folder"
       ansible.builtin.debug:
-        msg: "Specified folder '{{ win_get_folder_src_path }}' is empty: {{ win_get_files_folders_list }}"
-      when: win_get_files_folders_list | length | int == 0
-  when: win_file_exist
+        msg: "Specified folder is empty in guest OS: {{ win_get_folder_src_path }}, skip getting files."
+      when: win_get_files_folders_list | length == 0
 
-- name: "Display the message for no file existing"
+- name: "Source folder not exist"
   ansible.builtin.debug:
-    msg: "Folder not exist in guest OS: {{ win_get_folder_src_path }}, skip getting files"
-  when: not win_file_exist
+    msg: "Specified folder does not exist in guest OS: {{ win_get_folder_src_path }}, skip getting files."
+  when: not win_folder_exist

--- a/windows/utils/win_remove_appx_package.yml
+++ b/windows/utils/win_remove_appx_package.yml
@@ -1,0 +1,40 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Remove installed Appx package in Windows guest OS
+# Parameters:
+#   win_appx_package: the keyword in Appx package name
+#
+- name: "Check required parameter"
+  ansible.builtin.assert:
+    that:
+      - win_appx_package is defined
+      - win_appx_package
+    fail_msg: "Parameter 'win_appx_package' is required to be set to a keyword of Appx package name."
+
+- name: "Initialize installed Appx package name"
+  ansible.builtin.set_fact:
+    win_appx_package_name: ''
+
+- name: "Get installed Appx package"
+  include_tasks: win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: "(Get-AppxPackage -AllUsers | Where PackageFullName -Like '*{{ win_appx_package }}*').PackageFullName"
+
+- name: "Set fact of installed Appx package name"
+  ansible.builtin.set_fact:
+    win_appx_package_name: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length != 0
+
+- name: "Remove installed Appx package"
+  include_tasks: win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: "Remove-AppxPackage -Package {{ win_appx_package_name }}"
+  when: win_appx_package_name
+
+- name: "No Appx package"
+  ansible.builtin.debug:
+    msg: "Not get installed Appx package with '{{ win_appx_package }}' in the name, skip removing task."
+  when: not win_appx_package_name


### PR DESCRIPTION
1. Change to use the configured `vm_username` to fetch files from guest OS since customized user 'Administrator' maybe not available due to GOSC failure.
2. Change to use a common file `win_gosc_workflow.yml` as Linux test case to avoid duplicated tasks.
3. Fix sysprep failure by removing packages reported.