### PR TITLE
Fix issue: memory_hot_add_basic: 'current_testcase_name' is undefined at test_rescue

### DIFF
--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -11,13 +11,6 @@
   ansible.builtin.set_fact:
     timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 
-- name: "Set fact of current_testcase_name"
-  ansible.builtin.set_fact:
-    current_testcase_name: "{{ ansible_play_name }}"
-  when: >
-    (current_testcase_name is undefined) or
-    (not current_testcase_name)
-
 - name: "Print failed test case"
   ansible.builtin.debug:
     msg: "Testcase: {{ current_testcase_name }} failed"

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -11,6 +11,11 @@
   ansible.builtin.set_fact:
     timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 
+- name: "Set fact of current_testcase_name if not defined"
+  ansible.builtin.set_fact:
+    current_testcase_name: "{{ ansible_play_name }}"
+  when: current_testcase_name is undefined or not current_testcase_name
+
 - name: "Print failed test case"
   ansible.builtin.debug:
     msg: "Testcase: {{ current_testcase_name }} failed"

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -14,7 +14,9 @@
 - name: "Set fact of current_testcase_name if not defined"
   ansible.builtin.set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
-  when: current_testcase_name is undefined or not current_testcase_name
+  when: >
+    (current_testcase_name is undefined) or 
+    (not current_testcase_name)
 
 - name: "Print failed test case"
   ansible.builtin.debug:

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -15,7 +15,7 @@
   ansible.builtin.set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
   when: >
-    (current_testcase_name is undefined) or 
+    (current_testcase_name is undefined) or
     (not current_testcase_name)
 
 - name: "Print failed test case"

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -11,7 +11,7 @@
   ansible.builtin.set_fact:
     timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 
-- name: "Set fact of current_testcase_name if not defined"
+- name: "Set fact of current_testcase_name"
   ansible.builtin.set_fact:
     current_testcase_name: "{{ ansible_play_name }}"
   when: >

--- a/linux/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,7 +14,8 @@
   tasks:
     - name: "Test case block"
       block:
-        - include_tasks: ../setup/test_setup.yml
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
         - name: Set fact of VM initial memory size to 2048MB before hotadd test
           ansible.builtin.set_fact:

--- a/linux/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,6 +14,8 @@
   tasks:
     - name: "Test case block"
       block:
+        - include_tasks: ../setup/test_setup.yml
+
         - name: Set fact of VM initial memory size to 2048MB before hotadd test
           ansible.builtin.set_fact:
             vm_initial_mem_mb: 2048
@@ -24,8 +26,6 @@
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because memory hotadd test value list is empty"
             skip_reason: "Blocked"
           when: memory_hotadd_size_list | length == 0
-
-        - include_tasks: ../setup/test_setup.yml
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:


### PR DESCRIPTION
Fix issue: memory_hot_add_basic: 'current_testcase_name' is undefined at test_rescue

2023-11-17 01:56:22,017 | Failed at Play [1_memory_hot_add_basic] ********************
2023-11-17 01:56:22,017 | TASK [1_memory_hot_add_basic][Skip testcase: memory_hot_add_basic, reason: Blocked] 
task path: /home/worker/workspace/Ansible_OracleLinux_9.x_70U1_LSILOGICSAS_E1000E_EFI/ansible-vsphere-gos-validation/common/skip_test_case.yml:21
fatal: [localhost]: FAILED! => Test case 'memory_hot_add_basic' is blocked because memory hotadd test value list is empty
error message:
Test case 'memory_hot_add_basic' is blocked because memory hotadd test value list is empty
2023-11-17 01:56:22,017 | TASK [1_memory_hot_add_basic][Print failed test case] ******
task path: /home/worker/workspace/Ansible_OracleLinux_9.x_70U1_LSILOGICSAS_E1000E_EFI/ansible-vsphere-gos-validation/common/test_rescue.yml:14
fatal: [localhost]: FAILED! => The task includes an option with an undefined variable. The error was: 'current_testcase_name' is undefined. 'current_testcase_name' is undefined
The error appears to be in '/home/worker/workspace/Ansible_OracleLinux_9.x_70U1_LSILOGICSAS_E1000E_EFI/ansible-vsphere-gos-validation/common/test_rescue.yml': line 14, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
- name: ""Print failed test case""
  ^ here
error message:
The task includes an option with an undefined variable. The error was: 'current_testcase_name' is undefined. 'current_testcase_name' is undefined
The error appears to be in '/home/worker/workspace/Ansible_OracleLinux_9.x_70U1_LSILOGICSAS_E1000E_EFI/ansible-vsphere-gos-validation/common/test_rescue.yml': line 14, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
- name: ""Print failed test case""
  ^ here"