### PR TITLE
[Linux] Fix autoinstall issue for SLED 15 SP6 Beta2

### DIFF
--- a/autoinstall/SLE/15/SP4/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP4/SLED/autoinst.xml
@@ -15,23 +15,13 @@
       </listentry>
       <listentry t="map">
         <media_url>cd:/?devices=/dev/sr0</media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-      <listentry t="map">
-        <media_url>cd:/?devices=/dev/sr0</media_url>
-        <product>sle-module-development-tools</product>
-        <product_dir>/Module-Development-Tools</product_dir>
+        <product>sle-sled</product>
+        <product_dir>/Product-SLED</product_dir>
       </listentry>
       <listentry t="map">
         <media_url>cd:/?devices=/dev/sr0</media_url>
         <product>sle-we</product>
         <product_dir>/Product-WE</product_dir>
-      </listentry>
-      <listentry t="map">
-        <media_url>cd:/?devices=/dev/sr0</media_url>
-        <product>sle-module-legacy</product>
-        <product_dir>/Module-Legacy</product_dir>
       </listentry>
     </add_on_products>
   </add-on>
@@ -814,14 +804,8 @@
       <package>NetworkManager</package>
       <package>libxerces-c-devel</package>
       <package>libxml-security-c-devel</package>
-      <package>java-1_8_0-openjdk-headless</package>
-      <package>java-1_8_0-openjdk</package>
-      <package>ndctl</package>
       <package>rdma-core</package>
-      <package>librdmacm-utils</package>
-      <package>libibverbs-utils</package>
       <package>infiniband-diags</package>
-      <package>perftest</package>
     </packages>
     <patterns t="list">
       <pattern>apparmor</pattern>
@@ -832,14 +816,9 @@
       <pattern>fonts</pattern>
       <pattern>gnome</pattern>
       <pattern>gnome_basic</pattern>
-      <pattern>gnome_basis</pattern>
-      <pattern>gnome_imaging</pattern>
-      <pattern>gnome_multimedia</pattern>
       <pattern>gnome_x11</pattern>
-      <pattern>minimal_base</pattern>
       <pattern>office</pattern>
       <pattern>x11</pattern>
-      <pattern>x11_enhanced</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
       <pattern>yast2_desktop</pattern>

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -40,13 +40,6 @@
 - name: "Create unattend install ISO for {{ unattend_installer }}"
   when: unattend_installer != "Ubuntu-Subiquity"
   block:
-    - name: "Set fact about installing desktop"
-      ansible.builtin.set_fact:
-        install_guest_with_desktop: true
-      when:
-        - guest_id in ['rhel8_64Guest', 'rhel9_64Guest']
-        - unattend_install_conf is match('RHEL/8/server_with_GUI/')
-
     # For nvme boot disk, boot device name shoule be nvme0n1 instead of sda
     - name: "Set boot disk name"
       ansible.builtin.set_fact:

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -9,6 +9,7 @@
     boot_disk_controller: "{{ boot_disk_controller if (boot_disk_controller is defined and boot_disk_controller) else 'paravirtual' }}"
     firmware: "{{ firmware if (firmware is defined and firmware) else 'efi' }}"
     network_adapter_type: "{{ network_adapter_type if (network_adapter_type is defined and network_adapter_type) else 'vmxnet3' }}"
+    vm_video_memory_mb: ""
     autoinstall_complete_msg: "Autoinstall is completed."
 
 - name: "Set CPU number to {{ cpu_cores_per_socket }}"
@@ -33,10 +34,6 @@
 - name: "Update test case name for deploying VM from ISO image"
   ansible.builtin.set_fact:
     current_testcase_name: "deploy_vm_{{ firmware }}_{{ boot_disk_controller }}_{{ network_adapter_type }}"
-
-- name: "Initialize the fact whether to install guest OS with desktop"
-  ansible.builtin.set_fact:
-    install_guest_with_desktop: false
 
 - name: "Get OS installation ISO file list"
   include_tasks: ../../common/get_iso_file_list.yml
@@ -85,8 +82,15 @@
 - name: "Add a serial port to monitor autoinstall process"
   include_tasks: ../../common/vm_add_serial_port.yml
 
+- name: "Set fact of VM video memory size in MB for {{ unattend_installer }}"
+  ansible.builtin.set_fact:
+    vm_video_memory_mb: 8
+  when:
+    - unattend_installer in ['RHEL', 'SLE']
+    - unattend_install_conf | lower is not match('.*(minimal|server_without_gui).*')
+
 - name: "Set video memory size"
-  when: install_guest_with_desktop
+  when: vm_video_memory_mb
   block:
     - name: "Get VM's video card info"
       include_tasks: ../../common/vm_get_video_card.yml
@@ -98,8 +102,8 @@
     - name: "Increase VM's video card memory to 8 MB in case desktop can't be loaded"
       include_tasks: ../../common/vm_set_video_card.yml
       vars:
-        video_memory_mb: 8
-      when: vm_default_video_memory_mb | int < 8
+        video_memory_mb: "{{ vm_video_memory_mb }}"
+      when: vm_default_video_memory_mb | int < vm_video_memory_mb | int
 
 - name: "Enable secure boot on VM"
   include_tasks: ../../common/vm_set_boot_options.yml


### PR DESCRIPTION
There is module conflicts when resolving packages dependencies. So this fix removed not necessary modules and packages at deploy_vm.  Besides, the default 4MB video memory is not enough to launch SLED 15 SP6 desktop. So VM's video memory will be increased to 8MB for RHEL/SLE with desktop installed.