### PR TITLE
[Windows] Fix test case 'gosc_sanity_dhcp' failure

### DIFF
--- a/windows/guest_customization/check_ip_hostname.yml
+++ b/windows/guest_customization/check_ip_hostname.yml
@@ -8,6 +8,8 @@
 
 - name: "Update in-memory inventory after GOSC"
   include_tasks: ../utils/win_update_inventory.yml
+  vars:
+    always_update_inventory: true
   when: gosc_network_type == "dhcp"
 
 - name: "Wait for guest OS hostname after GOSC"

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -11,6 +11,11 @@
     - (router_vm_deployed is undefined) or (not router_vm_deployed | bool)
     - gosc_network_type == "static"
 
+- name: "Save the VM password before GOSC"
+  ansible.builtin.set_fact:
+    vm_passwd_before_gosc: "{{ vm_password }}"
+  when: vm_username | lower == "administrator"
+
 - name: "Set fact of Windows GOSC spec with common items"
   ansible.builtin.set_fact:
     win_gosc_spec: {

--- a/windows/guest_customization/win_gosc_workflow.yml
+++ b/windows/guest_customization/win_gosc_workflow.yml
@@ -47,3 +47,7 @@
             - name: "Get GOSC log files in VM with static IP"
               include_tasks: get_gosc_logs_no_network.yml
               when: gosc_network_type == "static"
+        - name: "Revert back VM password"
+          ansible.builtin.set_fact:
+            vm_password: "{{ vm_passwd_before_gosc }}"
+          when: vm_username | lower == "administrator"

--- a/windows/utils/win_update_inventory.yml
+++ b/windows/utils/win_update_inventory.yml
@@ -5,34 +5,44 @@
 # Parameters:
 #   update_inventory_timeout (optional): the timeout to get VM IP address
 #     and the timeout to wait IP to be connectable
+#   always_update_inventory (optional): if set to False, will not update
+#     host inventory if VM IP is alreay in it. If set to True, will always
+#     update host inventory with VM IP.
 #
-- include_tasks: ../../common/vm_get_ip.yml
+- name: "Get VM IP address"
+  include_tasks: ../../common/vm_get_ip.yml
   vars:
     vm_get_ip_timeout: "{{ update_inventory_timeout | default(900) }}"
-- name: "Display the VM IP address"
+- name: "Display VM IP address"
   ansible.builtin.debug:
     msg: "Get '{{ vm_name }}' IP address: {{ vm_guest_ip }}"
 
-- include_tasks: ../../common/vm_wait_ping.yml
+- name: "Wait VM IP address is connectable"
+  include_tasks: ../../common/vm_wait_ping.yml
   vars:
     vm_wait_ping_ip: "{{ vm_guest_ip }}"
     vm_wait_ping_timeout: "{{ update_inventory_timeout | default(900) }}"
 
-- include_tasks: win_check_winrm.yml
+- name: "Check VM winrm port is started"
+  include_tasks: win_check_winrm.yml
   vars:
     win_check_winrm_timeout: "{{ update_inventory_timeout | default(900) }}"
 
 - name: "Initialize the default update inventory to True"
   ansible.builtin.set_fact:
     update_inventory: true
+
 - name: "Check if VM IP already exist"
+  when:
+    - groups['target_vm'] is defined
+    - always_update_inventory is undefined or not always_update_inventory
   block:
-    - name: Loop groups to update update_inventory
+    - name: "Loop groups to set if update inventory"
       ansible.builtin.set_fact:
         update_inventory: false
       when: vm_guest_ip == item
       loop: "{{ groups['target_vm'] }}"
-  when: groups['target_vm'] is defined
 
-- include_tasks: add_windows_host.yml
+- name: "Update host inventory"
+  include_tasks: add_windows_host.yml
   when: update_inventory


### PR DESCRIPTION
1. always update host inventory after GOSC even DHCP IP is not changed.
2. save back Administrator user password after GOSC test cases.