### PR TITLE
set secureboot_enable_disable as not supported for MiracleLinux-8.x

### DIFF
--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -18,7 +18,7 @@
   vars:
     skip_msg: >-
       Skip test case {{ ansible_play_name }} because secure boot is not supported
-      by {{ vm_guest_os_distribution }} {{ guest_os_ansible_distribution_ver }}.
+      by {{ vm_guest_os_distribution }}.
     skip_reason: "Not Supported"
   when: >
     (guest_os_ansible_distribution == "Rocky" and

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -18,12 +18,14 @@
   vars:
     skip_msg: >-
       Skip test case {{ ansible_play_name }} because secure boot is not supported
-      by {{ vm_guest_os_distribution }}.
+      by {{ vm_guest_os_distribution }} {{ guest_os_ansible_distribution_ver }}.
     skip_reason: "Not Supported"
   when: >
     (guest_os_ansible_distribution == "Rocky" and
       guest_os_ansible_distribution_ver is version('8.4', '<=')) or
     guest_os_ansible_distribution is match('Pardus.*') or
+    (guest_os_ansible_distribution == 'MIRACLE' and 
+      guest_os_ansible_distribution_major_ver | int == 8) or
     (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos", "FreeBSD", "BigCloud", "FusionOS"])
 
 - name: "Skip test case for OS version which has vulnerable bootloaders"

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -19,15 +19,6 @@
       block:
         - include_tasks: ../setup/test_setup.yml
 
-        - name: "Skip testcase '{{ ansible_play_name }}' for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_major_ver }}"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip testcase '{{ ansible_play_name }}', it is not supported by {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_major_ver }}"
-            skip_reason: "Not Supported"
-          when:
-            - guest_os_ansible_distribution == 'MIRACLE'
-            - guest_os_ansible_distribution_major_ver | int == 8
-
         - include_tasks: ../../common/vm_get_boot_info.yml
 
         - include_tasks: ../../common/skip_test_case.yml

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -19,6 +19,15 @@
       block:
         - include_tasks: ../setup/test_setup.yml
 
+        - name: "Skip testcase '{{ ansible_play_name }}' for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_major_ver }}"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip testcase '{{ ansible_play_name }}', it is not supported by {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_major_ver }}"
+            skip_reason: "Not Supported"
+          when:
+            - guest_os_ansible_distribution == 'MIRACLE'
+            - guest_os_ansible_distribution_major_ver | int == 8
+
         - include_tasks: ../../common/vm_get_boot_info.yml
 
         - include_tasks: ../../common/skip_test_case.yml


### PR DESCRIPTION
test result:

For miraclelinux 8.8:
<img width="639" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/5abf601b-e0da-4584-9cc6-4590e8c41441">


For miraclelinux 9:
<img width="562" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/1a4f1f1e-368d-4a82-89ae-3705d72cbe40">
