### PR TITLE
Get VM primary mac address after VM power on

### DIFF
--- a/common/vm_get_vm_info.yml
+++ b/common/vm_get_vm_info.yml
@@ -40,3 +40,4 @@
       - "VM hardware version: {{ vm_hardware_version }}"
       - "VM hardware version number: {{ vm_hardware_version_num }}"
       - "VM firmware: {{ vm_firmware }}"
+      - "VM primary network adapter MAC address: {{ vm_primary_nic_mac }}"

--- a/common/vm_get_vm_info.yml
+++ b/common/vm_get_vm_info.yml
@@ -25,9 +25,6 @@
     vm_hardware_version_num: "{{ vm_config.config.version.split('-')[-1] }}"
     vm_firmware: "{{ vm_config.config.firmware }}"
 
-- name: "Wait for mac address is available"
-  include_tasks: vm_wait_primary_nic_mac.yml
-
 - name: "Display VM's basic information"
   ansible.builtin.debug:
     msg:
@@ -40,4 +37,3 @@
       - "VM hardware version: {{ vm_hardware_version }}"
       - "VM hardware version number: {{ vm_hardware_version_num }}"
       - "VM firmware: {{ vm_firmware }}"
-      - "VM primary network adapter MAC address: {{ vm_primary_nic_mac }}"

--- a/common/vm_wait_primary_nic_mac.yml
+++ b/common/vm_wait_primary_nic_mac.yml
@@ -40,8 +40,3 @@
     - gather_network_facts.network_data['0'] is defined
     - gather_network_facts.network_data['0'].mac_addr is defined
     - gather_network_facts.network_data['0'].mac_addr
-
-- name: "Display VM's primary network adapter MAC address"
-  ansible.builtin.debug:
-    msg:
-      - "VM primary network adapter MAC address: {{ vm_primary_nic_mac }}"

--- a/common/vm_wait_primary_nic_mac.yml
+++ b/common/vm_wait_primary_nic_mac.yml
@@ -40,3 +40,10 @@
     - gather_network_facts.network_data['0'] is defined
     - gather_network_facts.network_data['0'].mac_addr is defined
     - gather_network_facts.network_data['0'].mac_addr
+
+- name: "Assert VM primary network adapter has MAC address"
+  ansible.builtin.assert:
+    that:
+      - vm_primary_nic_mac
+    fail_msg: "VM primary network adapter has No MAC address"
+    success_msg: "VM primary network adapter MAC address is {{ vm_primary_nic_mac }}"

--- a/common/vm_wait_primary_nic_mac.yml
+++ b/common/vm_wait_primary_nic_mac.yml
@@ -45,5 +45,6 @@
   ansible.builtin.assert:
     that:
       - vm_primary_nic_mac
+      - vm_primary_nic_mac | ansible.utils.hwaddr
     fail_msg: "VM primary network adapter has No MAC address"
     success_msg: "VM primary network adapter MAC address is {{ vm_primary_nic_mac }}"

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -77,6 +77,18 @@
 
         - name: "Get existing VM info"
           include_tasks: ../common/vm_get_vm_info.yml
+
+        - name: "Get VM's power state"
+          include_tasks: vm_get_power_state.yml
+
+        - name: "Power on VM"
+          include_tasks: vm_set_power_state.yml
+          vars:
+            vm_power_state_set: "powered-on"
+          when: vm_power_state_get == "poweredOff"
+
+        - name: "Wait for VM primary network adapter has MAC address"
+          include_tasks: ../../common/vm_wait_primary_nic_mac.yml
       when: vm_exists is defined and vm_exists
 
     - name: Set fact of the VM datastore path

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -79,16 +79,16 @@
           include_tasks: ../common/vm_get_vm_info.yml
 
         - name: "Get VM's power state"
-          include_tasks: vm_get_power_state.yml
+          include_tasks: ../common/vm_get_power_state.yml
 
         - name: "Power on VM"
-          include_tasks: vm_set_power_state.yml
+          include_tasks: ../common/vm_set_power_state.yml
           vars:
             vm_power_state_set: "powered-on"
           when: vm_power_state_get == "poweredOff"
 
         - name: "Wait for VM primary network adapter has MAC address"
-          include_tasks: ../../common/vm_wait_primary_nic_mac.yml
+          include_tasks: ../common/vm_wait_primary_nic_mac.yml
       when: vm_exists is defined and vm_exists
 
     - name: Set fact of the VM datastore path

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -201,6 +201,19 @@
   vars:
     vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
 
+# VM might not have MAC address after creation without power-on
+# So here try to get it again for below update_inventory.yml
+- name: "Retry to get VM primary network adapter MAC address"
+  include_tasks: ../../common/vm_wait_primary_nic_mac.yml
+  when: not vm_primary_nic_mac
+
+- name: "Assert VM primary network adapter has MAC address"
+  ansible.builtin.assert:
+    that:
+      - vm_primary_nic_mac
+    fail_msg: "No MAC address is assigned to the VM primary network adapter"
+    success_msg: "VM primary network adapter MAC address is {{ vm_primary_nic_mac }}"
+
 # VMware Photon OS kickstart file can't add shutdown action,
 # so here needs to shutdown it separately
 - name: "Shutdown VMware Photon OS VM after auto install completes"

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -201,18 +201,10 @@
   vars:
     vm_take_screenshot_local_path: "{{ current_test_log_folder }}"
 
-# VM might not have MAC address after creation without power-on
-# So here try to get it again for below update_inventory.yml
-- name: "Retry to get VM primary network adapter MAC address"
+# For only ESXi managed VM, its MAC address is generated after power on
+# not at VM creation
+- name: "Get VM's primary network adapter MAC address"
   include_tasks: ../../common/vm_wait_primary_nic_mac.yml
-  when: not vm_primary_nic_mac
-
-- name: "Assert VM primary network adapter has MAC address"
-  ansible.builtin.assert:
-    that:
-      - vm_primary_nic_mac
-    fail_msg: "No MAC address is assigned to the VM primary network adapter"
-    success_msg: "VM primary network adapter MAC address is {{ vm_primary_nic_mac }}"
 
 # VMware Photon OS kickstart file can't add shutdown action,
 # so here needs to shutdown it separately

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -90,6 +90,9 @@
 - name: "Add a serial port for VM"
   include_tasks: ../../common/vm_add_serial_port.yml
 
+- name: "Get VM's primary network adapter MAC address"
+  include_tasks: ../../common/vm_wait_primary_nic_mac.yml
+
 - name: "Reconfigure VM with cloud-init"
   include_tasks: reconfigure_vm_with_cloudinit.yml
   when: ova_guest_os_type in ['photon', 'ubuntu', 'amazon']

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -108,7 +108,6 @@
 
 - name: "Get VM's primary network adapter MAC address after poweron VM"
   include_tasks: ../../common/vm_wait_primary_nic_mac.yml
-  when: vm_primary_nic_mac is undefined or not vm_primary_nic_mac  
 
 - name: "Get VM IP address"
   include_tasks: ../../common/vm_get_ip.yml

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -49,6 +49,9 @@
 
 - name: "Get VM info"
   include_tasks: ../../common/vm_get_vm_info.yml
+
+#- name: "Get VM's primary network adapter MAC address"
+#  include_tasks: ../../common/vm_wait_primary_nic_mac.yml
 # - include_tasks: ../../common/vm_get_ip_from_vmtools.yml
 
 # Copy script ConfigureRemotingForAnsible.ps1 to guest OS


### PR DESCRIPTION
The VM might not have MAC address after vm_create.yml, which led to vm_primary_nic_mac not set and failing to get VM IP. Changes in this PR fixes this issue.
