### PR TITLE
[Linux] Add variables for installing FusionOS with static IP address

### DIFF
--- a/autoinstall/FusionOS/server_with_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_with_GUI/ks.cfg
@@ -25,11 +25,11 @@ lang en_US.UTF-8
 
 # Network information
 {% if ethernet0_ipv4_addr | default('') and ethernet0_gateway | default('') and ethernet0_netmask | default('') %}
-network  --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
+network --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
 {% else %}
-network  --bootproto=dhcp --onboot=yes --ipv6=auto --activate
+network --bootproto=dhcp --onboot=yes --ipv6=auto --activate
 {% endif %}
-network  --hostname=localhost.localdomain
+network --hostname=localhost.localdomain
 
 # Use CDROM installation media
 cdrom

--- a/autoinstall/FusionOS/server_with_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_with_GUI/ks.cfg
@@ -24,7 +24,11 @@ keyboard --xlayouts='us'
 lang en_US.UTF-8
 
 # Network information
+{% if ethernet0_ipv4_addr | default('') and ethernet0_gateway | default('') and ethernet0_netmask | default('') %}
+network  --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
+{% else %}
 network  --bootproto=dhcp --onboot=yes --ipv6=auto --activate
+{% endif %}
 network  --hostname=localhost.localdomain
 
 # Use CDROM installation media

--- a/autoinstall/FusionOS/server_without_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_without_GUI/ks.cfg
@@ -26,11 +26,11 @@ lang en_US.UTF-8
 
 # Network information
 {% if ethernet0_ipv4_addr | default('') and ethernet0_gateway | default('') and ethernet0_netmask | default('') %}
-network  --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
+network --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
 {% else %}
-network  --bootproto=dhcp --onboot=yes --ipv6=auto --activate
+network --bootproto=dhcp --onboot=yes --ipv6=auto --activate
 {% endif %}
-network  --hostname=localhost.localdomain
+network --hostname=localhost.localdomain
 
 # Use CDROM installation media
 cdrom

--- a/autoinstall/FusionOS/server_without_GUI/ks.cfg
+++ b/autoinstall/FusionOS/server_without_GUI/ks.cfg
@@ -25,7 +25,11 @@ keyboard --xlayouts='us'
 lang en_US.UTF-8
 
 # Network information
-network  --bootproto=dhcp --ipv6=auto --activate
+{% if ethernet0_ipv4_addr | default('') and ethernet0_gateway | default('') and ethernet0_netmask | default('') %}
+network  --bootproto=static --onboot=yes --ip={{ ethernet0_ipv4_addr }} --gateway={{ ethernet0_gateway }} --netmask={{ ethernet0_netmask }} --nameserver={{ ethernet0_nameservers | default('') }} --ipv6=auto --activate
+{% else %}
+network  --bootproto=dhcp --onboot=yes --ipv6=auto --activate
+{% endif %}
 network  --hostname=localhost.localdomain
 
 # Use CDROM installation media

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -368,3 +368,14 @@ flatcar_python3_download_url: "https://downloads.activestate.com/ActivePython/re
 # server in VM to get packages.
 #
 # http_proxy_vm: "http://myproxy.company.com:8080"
+
+# FusionOS:
+# By default, VM's IPv4 address is assigned by DHCP server. To install FusionOS
+# with static IP, set 'ethernet0_ipv4_addr', 'ethernet0_gateway' and 'ethernet0_netmask'
+# with static IPv4 address, gateway, and netmask. 'ethernet0_nameservers' can be set
+# with DNS nameservers separated by comma or leave it empty.
+#
+# ethernet0_ipv4_addr: 192.168.1.10
+# ethernet0_gateway: 192.168.1.1
+# ethernet0_netmask: 255.255.255.0
+# ethernet0_nameservers: 192.168.1.1,192.168.1.2


### PR DESCRIPTION
Added below 4 variables to configure static IP at deploy_vm for FusionOS.
```
# ethernet0_ipv4_addr: 192.168.1.10
# ethernet0_gateway: 192.168.1.1
# ethernet0_netmask: 255.255.255.0
# ethernet0_nameservers: 192.168.1.1,192.168.1.2
```

After autoinstall completes, the network interface is successfully configured with static IP:

Nameservers are set:
```
# cat /etc/sysconfig/network-scripts/ifcfg-ens33 
TYPE=Ethernet
PROXY_METHOD=none
BROWSER_ONLY=no
BOOTPROTO=none
IPADDR=x.x.x.x
PREFIX=20
GATEWAY=x.x.x.x
DNS1=x.x.x.x
DNS2=x.x.x.x
DEFROUTE=yes
IPV4_FAILURE_FATAL=no
IPV6INIT=yes
IPV6_AUTOCONF=yes
IPV6_DEFROUTE=yes
IPV6_FAILURE_FATAL=no
IPV6_ADDR_GEN_MODE=stable-privacy
NAME=ens33
UUID=e3d3aa8b-76ad-4104-b06e-8ed5e1e12245
DEVICE=ens33
ONBOOT=yes
```

Nameservers are not set:
```
# cat /etc/sysconfig/network-scripts/ifcfg-ens33 
TYPE=Ethernet
PROXY_METHOD=none
BROWSER_ONLY=no
BOOTPROTO=none
IPADDR=x.x.x.x
PREFIX=20
GATEWAY=x.x.x.x
DEFROUTE=yes
IPV4_FAILURE_FATAL=no
IPV6INIT=yes
IPV6_AUTOCONF=yes
IPV6_DEFROUTE=yes
IPV6_FAILURE_FATAL=no
IPV6_ADDR_GEN_MODE=stable-privacy
NAME=ens33
UUID=0f031a4f-0f06-4537-bd5a-97d44f7a80f2
DEVICE=ens33
ONBOOT=yes
```