### PR TITLE
Add current_test_timestamp at test_setup as a common variable

### DIFF
--- a/common/reset_base_snapshot.yml
+++ b/common/reset_base_snapshot.yml
@@ -7,18 +7,18 @@
 #   base snapshot with a timestamp sufix, if set to true, will
 #   remove old base snapshot.
 #
-# Check old base snapshot exists or not
-- include_tasks: vm_check_snapshot_exist.yml
+- name: "Check current base snapshot exists or not"
+  include_tasks: vm_check_snapshot_exist.yml
   vars:
     snapshot_name: "{{ base_snapshot_name }}"
 
 - name: "Set fact of snapshot '{{ base_snapshot_name }}' existence"
   ansible.builtin.set_fact:
     old_base_snapshot_exist: "{{ snapshot_exist }}"
-    old_snapshot_new_name: "{{ base_snapshot_name }}-{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
+    old_snapshot_new_name: "{{ base_snapshot_name }}-{{ current_test_timestamp }}"
 
-# Rename old snapshot with a timestamp
-- include_tasks: vm_rename_snapshot.yml
+- name: "Rename current base snapshot to {{ old_snapshot_new_name }}"
+  include_tasks: vm_rename_snapshot.yml
   vars:
     current_snapshot_name: "{{ base_snapshot_name }}"
     new_snapshot_name: "{{ old_snapshot_new_name }}"
@@ -26,16 +26,16 @@
     - old_base_snapshot_exist
     - not remove_old_base_snapshot | default(false)
 
-# Remove old base snapshot
-- include_tasks: vm_remove_snapshot.yml
+- name: "Remove current base snapshot"
+  include_tasks: vm_remove_snapshot.yml
   vars:
     snapshot_name: "{{ base_snapshot_name }}"
   when:
     - old_base_snapshot_exist
     - remove_old_base_snapshot | default(false)
 
-# Take a new snapshot as base snapshot
-- include_tasks: vm_take_snapshot.yml
+- name: "Take a new snapshot as base snapshot"
+  include_tasks: vm_take_snapshot.yml
   vars:
     snapshot_name: "{{ base_snapshot_name }}"
 

--- a/common/set_current_testcase_facts.yml
+++ b/common/set_current_testcase_facts.yml
@@ -16,8 +16,9 @@
                                                string).rjust(gosv_testcases_count | string | length, '0')) }}"
     current_testcase_name: "{{ ansible_play_name }}"
 
-- name: "Set the log folder path for current test case on local machine"
+- name: "Set the timestamp and log folder path for current test case on local machine"
   ansible.builtin.set_fact:
+    current_test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
     current_test_log_folder: "{{ testrun_log_path }}/{{ current_testcase_index }}_{{ ansible_play_name }}"
 
 - name: "Create log folder for current test case"

--- a/common/test_rescue.yml
+++ b/common/test_rescue.yml
@@ -7,10 +7,6 @@
 # 3. take snapshot of the current failure state,
 # 4. or exit testing when parameter 'exit_testing_when_fail' is set to true.
 #
-- name: "Set timestamp of failure state"
-  ansible.builtin.set_fact:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
-
 - name: "Print failed test case"
   ansible.builtin.debug:
     msg: "Testcase: {{ current_testcase_name }} failed"
@@ -92,7 +88,7 @@
     - name: "Take a snapshot at VM current state"
       include_tasks: vm_take_snapshot.yml
       vars:
-        snapshot_name: "{{ current_testcase_name }}_fail_{{ timestamp }}"
+        snapshot_name: "{{ current_testcase_name }}_fail_{{ current_test_timestamp }}"
         dump_memory: true
         vm_take_snapshot_ignore_err: true
       when:

--- a/common/vcenter_add_key_provider.yml
+++ b/common/vcenter_add_key_provider.yml
@@ -31,7 +31,7 @@
 
 - name: "Set fact of new key provider name"
   ansible.builtin.set_fact:
-    new_kp_name: "{{ key_provider_type | lower }}{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
+    new_kp_name: "{{ key_provider_type | lower }}{{ current_test_timestamp }}"
 
 - name: "Add key provider on vCenter server"
   include_tasks: vcenter_add_standard_kp.yml

--- a/common/vm_add_serial_port.yml
+++ b/common/vm_add_serial_port.yml
@@ -9,7 +9,7 @@
 #
 - name: "Set default serial port output file for VM"
   ansible.builtin.set_fact:
-    vm_serial_file_ds_path: "{{ vm_files_path_ds.strip('\\/') }}/serial-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}.log"
+    vm_serial_file_ds_path: "{{ vm_files_path_ds.strip('\\/') }}/serial-{{ current_test_timestamp }}.log"
   when: vm_serial_file_ds_path is undefined or not vm_serial_file_ds_path
 
 - name: "Add a serial port using output file to VM"

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -17,7 +17,6 @@
           vars:
             skip_test_no_vmtools: true
 
-
         # From Flatcar 3760.2.0, /etc/vmware-tools became a read-only file system, which is
         # not writable. So here won't enable VMware Tools logging for Flatcar 3760.2.0 or later
         - name: "Enable VMware Tools logging"

--- a/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
+++ b/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
@@ -29,7 +29,7 @@
         # Take quiesce snapshot
         - name: "Set quiesce snapshot variables"
           ansible.builtin.set_fact:
-            qs_snapshot_name: "quiesce_snapshot_{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
+            qs_snapshot_name: "quiesce_snapshot_{{ current_test_timestamp }}"
             backup_script_dir: "/etc/vmware-tools/backupScripts.d"
             vss_shell_script: "vss_script_sh.sh"
             vss_bin_script: "vss_script_bin_{{ guest_os_bit | replace('-', '') }}"

--- a/linux/deploy_vm/create_unattend_install_iso.yml
+++ b/linux/deploy_vm/create_unattend_install_iso.yml
@@ -53,7 +53,7 @@
       block:
         - name: "Set fact of generated unattend install ISO file name"
           ansible.builtin.set_fact:
-            unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ timestamp }}.iso"
+            unattend_iso_file_name: "{{ guest_id }}{{ '_'.join(''.join(unattend_install_conf.split('.')[:-1]).split('/')) }}-{{ current_test_timestamp }}.iso"
 
         - name: "Set fact of the local path to new generated unattend install ISO"
           ansible.builtin.set_fact:
@@ -71,7 +71,7 @@
       block:
         - name: "Set fact of the rebuilt new OS installation ISO file name"
           ansible.builtin.set_fact:
-            new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ timestamp }}.iso"
+            new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ current_test_timestamp }}.iso"
 
         - name: "Set fact of the local path to the rebuilt OS installation ISO file"
           ansible.builtin.set_fact:
@@ -95,14 +95,14 @@
       vars:
         seed_iso_dir_path: "{{ unattend_iso_cache }}"
         user_data_template: "{{ unattend_install_template }}"
-        local_hostname: "ubuntu-{{ hostname_timestamp }}"
+        local_hostname: "ubuntu-{{ current_test_timestamp }}"
 
     - name: "Set facts for generated unattend install ISO, config file and rebuilt OS installation ISO"
       ansible.builtin.set_fact:
         new_unattend_install_conf: "{{ user_data_path }}"
         unattend_iso_file_path: "{{ seed_iso_path }}"
         unattend_iso_file_name: "{{ seed_iso_path | basename }}"
-        new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ timestamp }}.iso"
+        new_os_installation_iso: "{{ (os_installation_iso_list[0] | basename | splitext)[0] }}-{{ current_test_timestamp }}.iso"
 
     - name: "Set fact of the local path to the rebuilt OS installation ISO file"
       ansible.builtin.set_fact:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -6,8 +6,6 @@
   gather_facts: false
   collections:
     - community.general
-  vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   tasks:
     - name: "Set current test case index, name and log folder"
       include_tasks: ../../common/set_current_testcase_facts.yml
@@ -26,10 +24,6 @@
         # Change vm_username to root if it is not. And add a new user after VM deployment
         - name: "Set user account for new VM"
           include_tasks: set_new_vm_user_account.yml
-
-        - name: "Set fact of timestamp for VM hostname"
-          ansible.builtin.set_fact:
-            hostname_timestamp: "{{ timestamp }}"
 
         - name: "Get SSH public key from localhost"
           include_tasks: ../utils/get_local_ssh_public_key.yml

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -32,7 +32,7 @@
   vars:
     seed_iso_dir_path: "{{ unattend_iso_cache }}"
     user_data_template: "{{ ova_guest_os_type }}-ova-user-data.j2"
-    local_hostname: "{{ ova_guest_os_type }}-ova-{{ hostname_timestamp }}"
+    local_hostname: "{{ ova_guest_os_type }}-ova-{{ current_test_timestamp }}"
 
 - name: "Set fact of cloud-init seed ISO to be uploaded to ESXi datastore"
   ansible.builtin.set_fact:

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -8,7 +8,6 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
     adapter_type: "pvrdma"
   tasks:
     - name: "Test case block"
@@ -50,7 +49,7 @@
             pvrdma_server_vm_ipv4: "{{ vds_vmk_ip_addr | ansible.utils.ipmath(1) }}"
             pvrdma_server_vm_net_prefix: "{{ vds_vmk_net_prefix }}"
             pvrdma_server_vm_gateway: "{{ vds_vmk_ip_addr }}"
-            pvrdma_client_vm_name: "{{ vm_name }}_client_{{ timestamp }}"
+            pvrdma_client_vm_name: "{{ vm_name }}_client_{{ current_test_timestamp }}"
             pvrdma_client_vm_ipv4: "{{ vds_vmk_ip_addr | ansible.utils.ipmath(2) }}"
             pvrdma_client_vm_primary_nic_mac: ""
             pvrdma_client_vm_guest_ip: ""

--- a/linux/utils/collect_cloudinit_logs.yml
+++ b/linux/utils/collect_cloudinit_logs.yml
@@ -5,8 +5,8 @@
 #
 - name: "Initialize cloud-init archives in guest OS"
   ansible.builtin.set_fact:
-    cloudinit_logs_src_path: "/tmp/cloud-init-logs_{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}.tar.gz"
-    cloudinit_cfgs_src_path: "/tmp/cloud-init-configs_{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}.tar.gz"
+    cloudinit_logs_src_path: "/tmp/cloud-init-logs_{{ current_test_timestamp }}.tar.gz"
+    cloudinit_cfgs_src_path: "/tmp/cloud-init-configs_{{ current_test_timestamp }}.tar.gz"
 
 - name: "Set facts of cloud-init archives at local"
   ansible.builtin.set_fact:

--- a/linux/utils/create_seed_iso.yml
+++ b/linux/utils/create_seed_iso.yml
@@ -11,7 +11,7 @@
   ansible.builtin.set_fact:
     user_data_path: "{{ seed_iso_dir_path }}/user-data"
     meta_data_path: "{{ seed_iso_dir_path }}/meta-data"
-    seed_iso_path: "{{ seed_iso_dir_path }}/seed-{{ lookup('pipe','date +%s') }}.iso"
+    seed_iso_path: "{{ seed_iso_dir_path }}/seed-{{ current_test_timestamp }}.iso"
 
 - name: "Create user-data file for cloud-init local datasource"
   ansible.builtin.template:

--- a/linux/utils/enable_vgauth_logging.yml
+++ b/linux/utils/enable_vgauth_logging.yml
@@ -9,7 +9,7 @@
 
 - name: "Set default VGAuthService debug log directory"
   ansible.builtin.set_fact:
-    vgauth_log_dir: "/tmp/vmware-vgauthsvc-{{ lookup('pipe', 'date +%s') }}"
+    vgauth_log_dir: "/tmp/vmware-vgauthsvc-{{ current_test_timestamp }}"
 
 - name: "Set facts of VGAuthService log files"
   ansible.builtin.set_fact:

--- a/linux/vhba_hot_add_remove/lsilogic_vhba_device_ops.yml
+++ b/linux/vhba_hot_add_remove/lsilogic_vhba_device_ops.yml
@@ -15,7 +15,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
     new_disk_ctrl_type: "lsilogic"
   tasks:
-    - include_tasks: vhba_device_hot_add_remove.yml
+    - name: "Test with LSI Logic controller"
+      include_tasks: vhba_device_hot_add_remove.yml

--- a/linux/vhba_hot_add_remove/lsilogicsas_vhba_device_ops.yml
+++ b/linux/vhba_hot_add_remove/lsilogicsas_vhba_device_ops.yml
@@ -14,7 +14,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
     new_disk_ctrl_type: "lsilogicsas"
   tasks:
-    - include_tasks: vhba_device_hot_add_remove.yml
+    - name: "Test with LSI Logic SAS controller"
+      include_tasks: vhba_device_hot_add_remove.yml

--- a/linux/vhba_hot_add_remove/nvme_vhba_device_ops.yml
+++ b/linux/vhba_hot_add_remove/nvme_vhba_device_ops.yml
@@ -15,7 +15,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
     new_disk_ctrl_type: "nvme"
   tasks:
-    - include_tasks: vhba_device_hot_add_remove.yml
+    - name: "Test with NVMe controller"
+      include_tasks: vhba_device_hot_add_remove.yml

--- a/linux/vhba_hot_add_remove/paravirtual_vhba_device_ops.yml
+++ b/linux/vhba_hot_add_remove/paravirtual_vhba_device_ops.yml
@@ -15,7 +15,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
     new_disk_ctrl_type: "paravirtual"
   tasks:
-    - include_tasks: vhba_device_hot_add_remove.yml
+    - name: "Test with PVSCSI controller"
+      include_tasks: vhba_device_hot_add_remove.yml

--- a/linux/vhba_hot_add_remove/sata_vhba_device_ops.yml
+++ b/linux/vhba_hot_add_remove/sata_vhba_device_ops.yml
@@ -15,7 +15,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
     new_disk_ctrl_type: "sata"
   tasks:
-    - include_tasks: vhba_device_hot_add_remove.yml
+    - name: "Test with SATA controller"
+      include_tasks: vhba_device_hot_add_remove.yml

--- a/windows/check_quiesce_snapshot/check_quiesce_snapshot.yml
+++ b/windows/check_quiesce_snapshot/check_quiesce_snapshot.yml
@@ -9,48 +9,64 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
           vars:
             skip_test_no_vmtools: true
 
-        - include_tasks: check_vmx_disk_enable_uuid.yml
+        - name: "Check disk.EnableUUID in VMX file"
+          include_tasks: check_vmx_disk_enable_uuid.yml
           when: guest_os_product_type | lower == "server"
 
-        - include_tasks: ../utils/win_enable_vss_log.yml
+        - name: "Enable vss logging"
+          include_tasks: ../utils/win_enable_vss_log.yml
           when:
             - vmtools_version is defined and vmtools_version
             - vmtools_version is version('11.0.0', '>=')
 
-        - name: Set fact of the remote path in guest OS
+        - name: "Set fact of the remote path in guest OS"
           ansible.builtin.set_fact:
             quiesce_scripts_freeze_thaw_path: "C:\\Windows\\"
             quiesce_scripts_tools_path: "C:\\Program Files\\VMware\\VMware Tools\\backupScripts.d\\"
-        - include_tasks: ../utils/win_get_time.yml
-        - name: Set fact of the time before taking snapshot
+
+        - name: "Get Windows guest OS time"
+          include_tasks: ../utils/win_get_time.yml
+
+        - name: "Set fact of the time before taking snapshot"
           ansible.builtin.set_fact:
             before_snapshot_time: "{{ time_variable }}"
-        - name: Set fact of the snapshot name
+
+        - name: "Set fact of the quiesce snapshot name"
           ansible.builtin.set_fact:
-            qs_snapshot_name: "quiesce_{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
+            qs_snapshot_name: "quiesce_{{ current_test_timestamp }}"
 
-        - include_tasks: copy_custom_scripts_to_guest.yml
+        - name: "Copy custom scripts to guest OS"
+          include_tasks: copy_custom_scripts_to_guest.yml
 
-        - name: Set fact of collecting quiesce log file
+        - name: "Set fact of collecting quiesce log file"
           ansible.builtin.set_fact:
             collect_vss_logs: true
-        # Take quiesce snapshot of VM
-        - include_tasks: ../../common/vm_take_snapshot.yml
+
+        - name: "Take quiesce snapshot of VM"
+          include_tasks: ../../common/vm_take_snapshot.yml
           vars:
             snapshot_name: "{{ qs_snapshot_name }}"
             is_quiesce: true
             dump_memory: false
 
-        - include_tasks: check_custom_scripts_executed.yml
-        - include_tasks: ../../common/vm_remove_snapshot.yml
+        - name: "Check custom scripts executed"
+          include_tasks: check_custom_scripts_executed.yml
+
+        - name: "Remove quiesce snapshot at test success"
+          include_tasks: ../../common/vm_remove_snapshot.yml
           vars:
             snapshot_name: "{{ qs_snapshot_name }}"
       rescue:
-        - include_tasks: collect_vss_logs.yml
+        - name: "Collect vss logs"
+          include_tasks: collect_vss_logs.yml
           when: collect_vss_logs is defined and collect_vss_logs
-        - include_tasks: ../../common/test_rescue.yml
+
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/deploy_vm/create_unattend_install_iso.yml
+++ b/windows/deploy_vm/create_unattend_install_iso.yml
@@ -6,48 +6,54 @@
 # installation package, and script for configuring Windows for Ansible from this path:
 # https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
 #
-- name: Set fact of the timestamp suffix of ISO file name
+- name: "Set fact of unattend install ISO file name"
   ansible.builtin.set_fact:
-    iso_timestamp: "{{ lookup('pipe','date +%s') }}"
-- name: Set fact of unattend install ISO file name
-  ansible.builtin.set_fact:
-    unattend_install_iso: "{{ guest_id }}-{{ firmware }}-{{ boot_disk_controller }}-{{ iso_timestamp }}.iso"
-- name: Set fact of unattend install ISO file path on ESXi host
+    unattend_install_iso: "{{ guest_id }}-{{ firmware }}-{{ boot_disk_controller }}-{{ current_test_timestamp }}.iso"
+
+- name: "Set fact of unattend install ISO file path on ESXi host"
   ansible.builtin.set_fact:
     transferred_unattend_iso: "[{{ datastore }}] {{ unattend_install_iso }}"
 
-- include_tasks: get_ansible_remote_config.yml
+- name: "Get Ansible remote config script for Windows guest OS"
+  include_tasks: get_ansible_remote_config.yml
 
-- include_tasks: gen_unattend_xml_file.yml
+- name: "Get unattend install config file"
+  include_tasks: gen_unattend_xml_file.yml
 
-- name: Set fact of the file list contained in generated ISO file
+- name: "Set fact of the file list contained in generated ISO file"
   ansible.builtin.set_fact:
     unattend_install_file_list:
       - "{{ created_unattend_file }}"
       - "{{ local_cache }}/{{ config_remote_windows.split('/')[-1] }}"
 
-- block:
-    - include_tasks: get_pvscsi_driver.yml
-    - name: Add PVSCSI driver files to unattend install file list
-      ansible.builtin.set_fact:
-        unattend_install_file_list: "{{ unattend_install_file_list + pvscsi_file_path_list }}"
+- name: "Add PVSCSI driver for unattend install"
   when:
     - boot_disk_controller is defined
     - boot_disk_controller == 'paravirtual'
     - windows_has_inbox_driver is undefined or not windows_has_inbox_driver
+  block:
+    - name: "Get PVSCSI driver"
+      include_tasks: get_pvscsi_driver.yml
 
-- include_tasks: ../../common/create_iso.yml
+    - name: "Add PVSCSI driver files to unattend install file list"
+      ansible.builtin.set_fact:
+        unattend_install_file_list: "{{ unattend_install_file_list + pvscsi_file_path_list }}"
+
+- name: "Create unattend install ISO file"
+  include_tasks: ../../common/create_iso.yml
   vars:
     create_iso_src: "{{ unattend_install_file_list }}"
     create_iso_dest: "{{ local_cache }}/{{ unattend_install_iso }}"
 
-# Copy generated unattend install ISO file to ESXi host
-- include_tasks: ../../common/esxi_upload_datastore_file.yml
+- name: "Copy generated unattend install ISO file to ESXi host"
+  include_tasks: ../../common/esxi_upload_datastore_file.yml
   vars:
     src_file_path: "{{ local_cache }}/{{ unattend_install_iso }}"
     dest_file_path: "{{ unattend_install_iso }}"
     upload_file_timeout: 600
-- ansible.builtin.debug:
+
+- name: "Display the unattend install ISO file path on ESXi host"
+  ansible.builtin.debug:
     msg: "Unattend install ISO file is uploaded to ESXi host: {{ transferred_unattend_iso }}"
 
 - name: "Append generated unattend ISO file to the list"

--- a/windows/deploy_vm/gen_unattend_xml_file.yml
+++ b/windows/deploy_vm/gen_unattend_xml_file.yml
@@ -5,7 +5,7 @@
 - name: "Set fact of unattend file template path and dest path"
   ansible.builtin.set_fact:
     unattend_install_conf_path: "{{ main_playbook_path }}/autoinstall/{{ unattend_install_conf }}"
-    unattend_dest_path: "{{ local_cache }}/{{ iso_timestamp }}"
+    unattend_dest_path: "{{ local_cache }}/{{ current_test_timestamp }}"
 - name: "Set fact of target Autounattend.xml file path"
   ansible.builtin.set_fact:
     created_unattend_file: "{{ unattend_dest_path }}/{{ unattend_install_conf | basename }}"

--- a/windows/vtpm_cold_add_remove/vtpm_add_remove_test.yml
+++ b/windows/vtpm_cold_add_remove/vtpm_add_remove_test.yml
@@ -38,7 +38,7 @@
 
 - name: "Set facts of cloned VM name and save current VM info"
   ansible.builtin.set_fact:
-    vm_name_clone_to: "{{ vm_name }}_clone_{{ testrun_timestamp }}"
+    vm_name_clone_to: "{{ vm_name }}_clone_{{ current_test_timestamp }}"
     vm_name_clone_from: "{{ vm_name }}"
     vm_nic_mac_clone_from: "{{ vm_primary_nic_mac }}"
     vm_ip_clone_from: "{{ vm_guest_ip }}"

--- a/windows/wintools_uninstall_verify/add_new_vmxnet3_net_adapter.yml
+++ b/windows/wintools_uninstall_verify/add_new_vmxnet3_net_adapter.yml
@@ -1,35 +1,39 @@
 # Copyright 2022-2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of timestamp"
-  ansible.builtin.set_fact:
-    new_device_timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 - name: "Set fact of new vSwitch and portgroup names"
   ansible.builtin.set_fact:
-    new_device_vswitch: "vSwitch{{ new_device_timestamp }}"
-    new_device_pg: "vSwitch{{ new_device_timestamp }}_PG"
-- include_tasks: ../../common/esxi_add_vswitch.yml
+    new_device_vswitch: "vSwitch{{ current_test_timestamp }}"
+    new_device_pg: "vSwitch{{ current_test_timestamp }}_PG"
+
+- name: "Add a new vSwitch {{ new_device_vswitch }}"
+  include_tasks: ../../common/esxi_add_vswitch.yml
   vars:
     vswitch_name: "{{ new_device_vswitch }}"
-- include_tasks: ../../common/esxi_add_portgroup.yml
+
+- name: "Add a new vSwith port group {{ new_device_pg }}"
+  include_tasks: ../../common/esxi_add_portgroup.yml
   vars:
     vswitch_name: "{{ new_device_vswitch }}"
     portgroup_name: "{{ new_device_pg }}"
+
 - name: "Pause 10 seconds after new portgroup added"
   ansible.builtin.pause:
     seconds: 10
-# Make sure new portgroup added
-- include_tasks: ../../common/esxi_wait_portgroup.yml
+
+- name: "Wait for vSwitch port group being present"
+  include_tasks: ../../common/esxi_wait_portgroup.yml
   vars:
     wait_for_portgroup_name: "{{ new_device_pg }}"
 
-# Add a new vmxnet3 network adapter to VM
-- include_tasks: ../../common/vm_add_network_adapter.yml
+- name: "Add a new vmxnet3 network adapter to VM"
+  include_tasks: ../../common/vm_add_network_adapter.yml
   vars:
     adapter_type: "vmxnet3"
     vm_portgroup_name: "{{ new_device_pg }}"
     network_connected: false
     network_start_connected: false
+
 - name: "Check add new VMXNET3 network adapter config changes"
   ansible.builtin.assert:
     that:
@@ -43,6 +47,7 @@
     new_network_adapter_mac: "{{ (add_adapter.diff.after.keys() | difference(add_adapter.diff.before.keys()))[0] }}"
   when:
     - add_adapter.diff.after.keys() | length == add_adapter.diff.before.keys() | length + 1
+
 - name: "Check getting new VMXNET3 network adapter MAC address"
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
Added a new variable `current_test_timestamp` for each test case, which can be used to replace expressions like `{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}`.