### PR TITLE
[Linux] Fix test issue for Flatcar 3760.2.0

### DIFF
--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -21,8 +21,13 @@
           ansible.builtin.set_fact:
             vmtools_log_dir: "/tmp/vmware-tools-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
 
+        # From Flatcar 3760.2.0, /etc/vmware-tools became a read-only file system, which
+        # can't be writable.
         - name: "Enable debug logging for VMware Tools"
           include_tasks: ../utils/enable_vmtools_logging.yml
+          when: >-
+            not (guest_os_ansible_distribution == 'Flatcar' and
+                 guest_os_ansible_distribution_ver is version('3760.2.0', '>='))
 
         - name: "Get ESXi version and build"
           include_tasks: ../../common/esxi_get_version_build.yml
@@ -58,33 +63,4 @@
           include_tasks: ../../common/test_rescue.yml
       always:
         - name: "Collect VMware Tools logs"
-          when:
-            - vmtools_log_dir is defined
-            - vmtools_log_dir
-          block:
-            - name: "Get VMware Tools log directory stat info"
-              include_tasks: ../utils/get_file_stat_info.yml
-              vars:
-                guest_file_path: "{{ vmtools_log_dir }}"
-
-            - name: "Collect VMware Tools logs"
-              when: guest_file_exists
-              block:
-                - name: "Archive VMware Tools debug logs"
-                  community.general.archive:
-                    path: "{{ vmtools_log_dir }}"
-                    dest: "{{ vmtools_log_dir }}.tgz"
-                    mode: "0644"
-                  delegate_to: "{{ vm_guest_ip }}"
-                  register: archive_vmtools_logs
-
-                - name: "Fetch VMware Tools debug logs"
-                  include_tasks: ../utils/fetch_file.yml
-                  vars:
-                    fetch_file_src_path: "{{ vmtools_log_dir }}.tgz"
-                    fetch_file_dst_path: "{{ current_test_log_folder }}/"
-                    fetch_file_ignore_errors: true
-                  when:
-                    - archive_vmtools_logs is defined
-                    - archive_vmtools_logs.changed is defined
-                    - archive_vmtools_logs.changed
+          include_tasks: ../utils/collect_vmtools_logs.yml

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -22,7 +22,7 @@
             vmtools_log_dir: "/tmp/vmware-tools-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
 
         # From Flatcar 3760.2.0, /etc/vmware-tools became a read-only file system, which
-        # can't be writable.
+        # is not writable.
         - name: "Enable debug logging for VMware Tools"
           include_tasks: ../utils/enable_vmtools_logging.yml
           when: >-

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -17,17 +17,20 @@
           vars:
             skip_test_no_vmtools: true
 
-        - name: "Set VMware Tools debug logging directory"
-          ansible.builtin.set_fact:
-            vmtools_log_dir: "/tmp/vmware-tools-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
 
-        # From Flatcar 3760.2.0, /etc/vmware-tools became a read-only file system, which
-        # is not writable.
-        - name: "Enable debug logging for VMware Tools"
-          include_tasks: ../utils/enable_vmtools_logging.yml
+        # From Flatcar 3760.2.0, /etc/vmware-tools became a read-only file system, which is
+        # not writable. So here won't enable VMware Tools logging for Flatcar 3760.2.0 or later
+        - name: "Enable VMware Tools logging"
           when: >-
             not (guest_os_ansible_distribution == 'Flatcar' and
                  guest_os_ansible_distribution_ver is version('3760.2.0', '>='))
+          block:
+            - name: "Set VMware Tools debug logging directory"
+              ansible.builtin.set_fact:
+                vmtools_log_dir: "/tmp/vmware-tools-{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
+
+            - name: "Enable debug logging for VMware Tools"
+              include_tasks: ../utils/enable_vmtools_logging.yml
 
         - name: "Get ESXi version and build"
           include_tasks: ../../common/esxi_get_version_build.yml

--- a/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
+++ b/linux/check_quiesce_snapshot_custom_script/check_quiesce_snapshot_custom_script.yml
@@ -21,7 +21,10 @@
           vars:
             skip_msg: "Skip testcase '{{ ansible_play_name }}', it is not supported by {{ guest_os_ansible_distribution }}"
             skip_reason: "Not Supported"
-          when: guest_os_ansible_distribution == 'FreeBSD'
+          when: >-
+            (guest_os_ansible_distribution == 'FreeBSD' or
+             (guest_os_ansible_distribution == 'Flatcar' and
+              guest_os_ansible_distribution_ver is version('3760.2.0', '>=')))
 
         # Take quiesce snapshot
         - name: "Set quiesce snapshot variables"

--- a/linux/utils/collect_vmtools_logs.yml
+++ b/linux/utils/collect_vmtools_logs.yml
@@ -1,0 +1,27 @@
+# Copyright 2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Collect VMware Tools logs to local test case log directory
+# Parameter:
+#   vmtools_vmtoolsd_log_file: the VMware Tools vmtoolsd log path in guest OS
+#   vmtools_vmsvc_log_file: the VMware Tools vmsvc log path in guest OS
+#
+- name: "Initialize fact of default VMware Tools vmtoolsd log path in guest OS"
+  ansible.builtin.set_fact:
+    vmtools_vmtoolsd_log_file: "/var/log/vmware-vmtoolsd-root.log"
+  when: vmtools_vmtoolsd_log_file is undefined or not vmtools_vmtoolsd_log_file
+
+- name: "Initialize fact of default VMware Tools vmsvc log path in guest OS"
+  ansible.builtin.set_fact:
+    vmtools_vmsvc_log_file: "/var/log/vmware-vmsvc-root.log"
+  when: vmtools_vmsvc_log_file is undefined or not vmtools_vmsvc_log_file
+
+- name: "Collect VMware Tools logs to test case log directory"
+  include_tasks: fetch_file.yml
+  vars:
+    fetch_file_src_path: "{{ item }}"
+    fetch_file_dst_path: "{{ current_test_log_folder }}/"
+    fetch_file_ignore_errors: true
+  with_items:
+    - "{{ vmtools_vmtoolsd_log_file }}"
+    - "{{ vmtools_vmsvc_log_file }}"

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -22,9 +22,10 @@
           vars:
             skip_msg: "{{ guest_os_ansible_distribution }} doesn't have VGAuth service"
             skip_reason: "Not Supported"
-          when:
-            - guest_os_ansible_distribution is defined
-            - guest_os_ansible_distribution in ['Flatcar', 'FreeBSD']
+          when: >-
+            (guest_os_ansible_distribution == 'FreeBSD' or
+             (guest_os_ansible_distribution == 'Flatcar' and
+              guest_os_ansible_distribution_ver is version('3760.2.0', '<')))
 
         - name: "Set facts of VGAuthService process and service"
           include_tasks: ../utils/set_vgauth_facts.yml


### PR DESCRIPTION
From Flatcar 3760.2.0, /etc/vmware-tools is not writable any more. So we can't enable VMware Tools debug logs in /etc/vmware-tools/tools.conf, and can't create quiesce snapshot scripts under /etc/vmware-tools/backupScripts.d. Besides, Flatcar 3760.2.0 added vgauth. Therefore, I made below changes for Flatcar:
1. Do not enable VMware Tools debug logging for Flatcar 3760.2.0 or later, and only collect default VMware Tools logs from /var/log.
2. Skip check_quiesce_snapshot_custom_script testing from Flatcar 3760.2.0.
3. Check VGAuth service status from Flatcar 3760.2.0.

In Flatcar 3760.2.0, vmtoolsd and vgauthd services are running but disabled. That need to double check with Flatcar whether it is a 3rd party issue.
```
VM information:
+------------------------------------------------------------------------------------------------------+
| Name                      | test_vm                                                                  |
+------------------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Flatcar 3760.2.0 x86_64                                                  |
+------------------------------------------------------------------------------------------------------+
| GUI Installed             | False                                                                    |
+------------------------------------------------------------------------------------------------------+
| CloudInit Version         |                                                                          |
+------------------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-17                                                                   |
+------------------------------------------------------------------------------------------------------+
| VMTools Version           | 12.3.0 (build-22234872)                                                  |
+------------------------------------------------------------------------------------------------------+
| Config Guest Id           | other3xLinux64Guest                                                      |
+------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | other3xLinux64Guest                                                      |
+------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 3.x Linux (64-bit)                                                 |
+------------------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                               |
+------------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                       |
|                           | bitness='64'                                                             |
|                           | buildNumber='2024-01-16-1847'                                            |
|                           | cpeString='cpe:2.3:o:flatcar-linux:flatcar_linux:3760.2.0:*:*:*:*:*:*:*' |
|                           | distroAddlVersion='3760.2.0'                                             |
|                           | distroName='Flatcar Container Linux by Kinvolk'                          |
|                           | distroVersion='3760.2.0'                                                 |
|                           | familyName='Linux'                                                       |
|                           | kernelVersion='6.1.73-flatcar'                                           |
|                           | prettyName='Flatcar Container Linux by Kinvolk 3760.2.0 (Oklo)'          |
+------------------------------------------------------------------------------------------------------+


Test Results (Total: 3, Passed: 1, Failed: 1, Skipped: 1, Elapsed Time: 00:02:52)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
|  1 | vgauth_check_service                 | * Failed        | 00:00:49  |
|  2 | check_os_fullname                    |   Passed        | 00:00:41  |
|  3 | check_quiesce_snapshot_custom_script | * Not Supported | 00:00:34  |
+-------------------------------------------------------------------------+
```