### PR TITLE
[Pardus 23.1 Server] fix autoinstall issue for pardus 23.1 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | ProLinux Server 7.9, 8.5                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | FreeBSD 13 and later                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Pardus 21.2 Server,XFCE Desktop and later              | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| Pardus 23.x Server,XFCE Desktop                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | openSUSE Leap 15.3 and later                           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | BCLinux 8.x                                            | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | BCLinux-for-Euler 21.10                                | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -20,12 +20,13 @@
 19. For FreeBSD 13 unattend auto-install, please use file FreeBSD/13/installerconfig.
 20. For FreeBSD 14 or later unattend auto-install, please use file FreeBSD/14/installerconfig.
 21. For Pardus 21.2 Server and XFCE Desktop or later unattend auto-install, please use file Pardus/preseed.cfg.
-22. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
-23. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
-24. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
-25. For FusionOS 22 unattend auto-install, please use files under Fusion.
-26. For FusionOS 23 unattend auto-install, please use file Fusion/server_without_GUI/ks.cfg.
-27. For Kylin Linux Advanced Server V10 unattend auto-install, please use file Kylin/Server/10/ks.cfg.
+22. For Pardus 23.x Server and XFCE Desktop unattend auto-install, please use file Pardus/preseed.cfg.
+23. For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
+24. For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
+25. For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
+26. For FusionOS 22 unattend auto-install, please use files under Fusion.
+27. For FusionOS 23 unattend auto-install, please use file Fusion/server_without_GUI/ks.cfg.
+28. For Kylin Linux Advanced Server V10 unattend auto-install, please use file Kylin/Server/10/ks.cfg.
 
 # Notes
 ## For Windows

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -40,13 +40,13 @@
     - "install_en.cfg"
     - "install.cfg"
 
-- name: "Add label autoinstall"
+- name: "Add menu entry for autoinstall"
   ansible.builtin.blockinfile:
     path: "{{ src_iso_file_dir }}/{{ item }}"
     insertafter: "^default autoinstall$"
     block: |
       label autoinstall
-          menu label ^Graphical Autoinstall Installer
+          menu label ^Automated Graphical Installer
           linux /install/vmlinuz
           initrd /install/initrd.gz
           append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -30,7 +30,7 @@
 - name: "Set fact of the kernel and initrd file directory"
   ansible.builtin.set_fact:
     kernel_initrd_dir: |-
-      {%- if kernel_initrd_dir_result.failed is defined and not kernel_initrd_dir_result.failed -%}/install/
+      {%- if kernel_initrd_dir_result.failed is defined and kernel_initrd_dir_result.failed -%}/install/
       {%- else -%}/install/gtk/{%- endif -%}
 
 - name: "Update timeout of file isolinux.cfg"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -19,7 +19,7 @@
       - 'md5sum.txt'
 
 - name: "Check file /install/gtk/vmlinuz exists in file boot/grub/grub.cfg"
-  ansible.builtin.command: "grep '\/install\/gtk\/vmlinuz' {{ src_iso_file_dir }}/grub.cfg"
+  ansible.builtin.shell: "grep '\/install\/gtk\/vmlinuz' {{ src_iso_file_dir }}/grub.cfg"
   register: kernel_initrd_dir_result
   ignore_errors: true
 

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -50,9 +50,9 @@
           linux /install/vmlinuz
           initrd /install/initrd.gz
           append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet
-    with_items:
-      - "install_en.cfg"
-      - "install.cfg"
+  with_items:
+    - "install_en.cfg"
+    - "install.cfg"
 
 - name: "Update default memu entry for grub.cfg"
   ansible.builtin.replace:

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -18,6 +18,21 @@
       - 'isolinux/install.cfg'
       - 'md5sum.txt'
 
+- name: "Extract kernel file inside ISO"
+  community.general.iso_extract:
+    image: "{{ src_iso_file_path }}"
+    dest: "{{ src_iso_file_dir }}"
+    files:
+      - '/install/gtk/vmlinuz'
+    register: kernel_initrd_dir_result
+    ignore_errors: true
+
+- name: "Set fact of the kernel and initrd file directory"
+  ansible.builtin.set_fact:
+    kernel_initrd_dir: |-
+      {%- if kernel_initrd_dir_result.failed is defined and not kernel_initrd_dir_result.failed -%}/install/
+      {%- else -%}/install/gtk/{%- endif -%}
+
 - name: "Update timeout of file isolinux.cfg"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/isolinux.cfg"
@@ -70,8 +85,8 @@
       # menuentry for unattended installation
         menuentry "Automated installation" --id autoinstall {
           set background_color=black
-          linux  /install/gtk/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
-          initrd /install/gtk/initrd.gz
+          linux  {{ kernel_initrd_dir }}vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
+          initrd {{ kernel_initrd_dir }}initrd.gz
         }
 
 - name: "Update md5sum for Pardus ISO files"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -18,21 +18,6 @@
       - 'isolinux/install.cfg'
       - 'md5sum.txt'
 
-- name: "Extract kernel file inside ISO"
-  community.general.iso_extract:
-    image: "{{ src_iso_file_path }}"
-    dest: "{{ src_iso_file_dir }}"
-    files:
-      - '/install/gtk/vmlinuz'
-  register: kernel_initrd_dir_result
-  ignore_errors: true
-
-- name: "Set fact of the kernel and initrd file directory"
-  ansible.builtin.set_fact:
-    kernel_initrd_dir: |-
-      {%- if kernel_initrd_dir_result.failed is defined and kernel_initrd_dir_result.failed -%}/install/
-      {%- else -%}/install/gtk/{%- endif -%}
-
 - name: "Update timeout of file isolinux.cfg"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/isolinux.cfg"
@@ -48,11 +33,54 @@
 - name: "Update default boot label"
   ansible.builtin.lineinfile:
     path: "{{ src_iso_file_dir }}/{{ item }}"
-    insertbefore: "^label install$"
+    firstmatch: true
+    insertbefore: "^label install*"
     line: "default installgui"
   with_items:
     - "install_en.cfg"
     - "install.cfg"
+
+- name: "Search and add label installgui for file install.cfg"
+  block:
+    - name: "Search label installgui in file install.cfg"
+      ansible.builtin.shell: "grep '^default installgui$' {{ src_iso_file_dir }}/install.cfg"
+      ignore_errors: true
+      register: result_search_str
+
+    - name: "Add label installgui when the label does not exist in file install.cfg"
+      ansible.builtin.blockinfile:
+        path: "{{ src_iso_file_dir }}/install.cfg"
+        insertafter: "^default installgui$"
+        block: |
+          label installgui
+              menu label ^Graphical Installer
+              linux /install/vmlinuz
+              initrd /install/initrd.gz
+              append vga=791 theme=pardusdark  --- quiet
+      when:
+        - result_search_str.failed is defined
+        - result_search_str.failed
+
+- name: "Search and add label installgui for file install_en.cfg"
+  block:
+    - name: "Search label installgui in file install_en.cfg"
+      ansible.builtin.shell: "grep '^default installgui$' {{ src_iso_file_dir }}/install_en.cfg"
+      ignore_errors: true
+      register: result_search_str
+
+    - name: "Add label installgui when the label does not exist in file install_en.cfg"
+      ansible.builtin.blockinfile:
+        path: "{{ src_iso_file_dir }}/install_en.cfg"
+        insertafter: "^default installgui$"
+        block: |
+          label installgui
+              menu label ^Graphical Installer
+              linux /install/vmlinuz
+              initrd /install/initrd.gz
+              append vga=791 theme=pardusdark  --- quiet
+      when:
+        - result_search_str.failed is defined
+        - result_search_str.failed
 
 # Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
 - name: "Update boot parameters with preseed.cfg"
@@ -85,8 +113,8 @@
       # menuentry for unattended installation
         menuentry "Automated installation" --id autoinstall {
           set background_color=black
-          linux  {{ kernel_initrd_dir }}vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
-          initrd {{ kernel_initrd_dir }}initrd.gz
+          linux  /install/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
+          initrd /install/initrd.gz
         }
 
 - name: "Update md5sum for Pardus ISO files"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -22,12 +22,11 @@
   ansible.builtin.command: "grep '\/install\/gtk\/vmlinuz' {{ src_iso_file_dir }}/grub.cfg"
   register: kernel_initrd_dir_result
   ignore_errors: true
-  delegate_to: "{{ vm_guest_ip }}"
 
 - name: "Set fact of the kernel and initrd file directory"
   ansible.builtin.set_fact:
     kernel_initrd_dir: |-
-      {%- if kernel_initrd_dir_result.failed is defined and not kernel_initrd_dir_result.failed -%}/install/
+      {%- if kernel_initrd_dir_result.failed is defined and kernel_initrd_dir_result.failed -%}/install/
       {%- else -%}/install/gtk/{%- endif -%}
 
 - name: "Update timeout of file isolinux.cfg"
@@ -58,7 +57,7 @@
     insertafter: "^default autoinstall$"
     block: |
       label autoinstall
-          menu label ^Automated Graphical Installer
+          menu label ^Automated Installer
           linux {{ kernel_initrd_dir }}vmlinuz
           initrd {{ kernel_initrd_dir }}initrd.gz
           append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -24,8 +24,8 @@
     dest: "{{ src_iso_file_dir }}"
     files:
       - '/install/gtk/vmlinuz'
-    register: kernel_initrd_dir_result
-    ignore_errors: true
+  register: kernel_initrd_dir_result
+  ignore_errors: true
 
 - name: "Set fact of the kernel and initrd file directory"
   ansible.builtin.set_fact:

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -18,6 +18,18 @@
       - 'isolinux/install.cfg'
       - 'md5sum.txt'
 
+- name: "Check file /install/gtk/vmlinuz exists in file boot/grub/grub.cfg"
+  ansible.builtin.command: "grep '\/install\/gtk\/vmlinuz' {{ src_iso_file_dir }}/grub.cfg"
+  register: kernel_initrd_dir_result
+  ignore_errors: true
+  delegate_to: "{{ vm_guest_ip }}"
+
+- name: "Set fact of the kernel and initrd file directory"
+  ansible.builtin.set_fact:
+    kernel_initrd_dir: |-
+      {%- if kernel_initrd_dir_result.failed is defined and not kernel_initrd_dir_result.failed -%}/install/
+      {%- else -%}/install/gtk/{%- endif -%}
+
 - name: "Update timeout of file isolinux.cfg"
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/isolinux.cfg"
@@ -47,8 +59,8 @@
     block: |
       label autoinstall
           menu label ^Automated Graphical Installer
-          linux /install/vmlinuz
-          initrd /install/initrd.gz
+          linux {{ kernel_initrd_dir }}vmlinuz
+          initrd {{ kernel_initrd_dir }}initrd.gz
           append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet
   with_items:
     - "install_en.cfg"
@@ -75,8 +87,8 @@
       # menuentry for unattended installation
         menuentry "Automated installation" --id autoinstall {
           set background_color=black
-          linux  /install/vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
-          initrd /install/initrd.gz
+          linux  {{ kernel_initrd_dir }}vmlinuz auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
+          initrd {{ kernel_initrd_dir }}initrd.gz
         }
 
 - name: "Update md5sum for Pardus ISO files"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -60,7 +60,7 @@
           menu label ^Automated Installer
           linux {{ kernel_initrd_dir }}vmlinuz
           initrd {{ kernel_initrd_dir }}initrd.gz
-          append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet
+          append auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
   with_items:
     - "install_en.cfg"
     - "install.cfg"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -55,12 +55,13 @@
   ansible.builtin.blockinfile:
     path: "{{ src_iso_file_dir }}/{{ item }}"
     insertafter: "^default autoinstall$"
+    marker: ""
     block: |
       label autoinstall
           menu label ^Automated Installer
           linux {{ kernel_initrd_dir }}vmlinuz
           initrd {{ kernel_initrd_dir }}initrd.gz
-          append auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0" --- quiet
+          append auto=true file=/cdrom/{{ unattend_install_file_name }} video=vesa:ywrap,mtrr vga=788 "DPMS=-s 0"  --- quiet
   with_items:
     - "install_en.cfg"
     - "install.cfg"

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -43,7 +43,7 @@
 - name: "Search and add label installgui for file install.cfg"
   block:
     - name: "Search label installgui in file install.cfg"
-      ansible.builtin.shell: "grep '^default installgui$' {{ src_iso_file_dir }}/install.cfg"
+      ansible.builtin.shell: "grep '^label installgui' {{ src_iso_file_dir }}/install.cfg"
       ignore_errors: true
       register: result_search_str
 
@@ -64,7 +64,7 @@
 - name: "Search and add label installgui for file install_en.cfg"
   block:
     - name: "Search label installgui in file install_en.cfg"
-      ansible.builtin.shell: "grep '^default installgui$' {{ src_iso_file_dir }}/install_en.cfg"
+      ansible.builtin.shell: "grep '^label installgui' {{ src_iso_file_dir }}/install_en.cfg"
       ignore_errors: true
       register: result_search_str
 

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -26,8 +26,8 @@
 - name: "Set fact of the kernel and initrd file directory"
   ansible.builtin.set_fact:
     kernel_initrd_dir: |-
-      {%- if kernel_initrd_dir_result.failed is defined and kernel_initrd_dir_result.failed -%}/install/
-      {%- else -%}/install/gtk/{%- endif -%}
+      {%- if kernel_initrd_dir_result.failed is defined and not kernel_initrd_dir_result.failed -%}/install/gtk/
+      {%- else -%}/install/{%- endif -%}
 
 - name: "Update timeout of file isolinux.cfg"
   ansible.builtin.replace:

--- a/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_pardus_unattend_install_iso.yml
@@ -28,69 +28,31 @@
   ansible.builtin.replace:
     path: "{{ src_iso_file_dir }}/isolinux.cfg"
     regexp: "default .*"
-    replace: "default installgui"
+    replace: "default autoinstall"
 
 - name: "Update default boot label"
   ansible.builtin.lineinfile:
     path: "{{ src_iso_file_dir }}/{{ item }}"
     firstmatch: true
     insertbefore: "^label install*"
-    line: "default installgui"
+    line: "default autoinstall"
   with_items:
     - "install_en.cfg"
     - "install.cfg"
 
-- name: "Search and add label installgui for file install.cfg"
-  block:
-    - name: "Search label installgui in file install.cfg"
-      ansible.builtin.shell: "grep '^label installgui' {{ src_iso_file_dir }}/install.cfg"
-      ignore_errors: true
-      register: result_search_str
-
-    - name: "Add label installgui when the label does not exist in file install.cfg"
-      ansible.builtin.blockinfile:
-        path: "{{ src_iso_file_dir }}/install.cfg"
-        insertafter: "^default installgui$"
-        block: |
-          label installgui
-              menu label ^Graphical Installer
-              linux /install/vmlinuz
-              initrd /install/initrd.gz
-              append vga=791 theme=pardusdark  --- quiet
-      when:
-        - result_search_str.failed is defined
-        - result_search_str.failed
-
-- name: "Search and add label installgui for file install_en.cfg"
-  block:
-    - name: "Search label installgui in file install_en.cfg"
-      ansible.builtin.shell: "grep '^label installgui' {{ src_iso_file_dir }}/install_en.cfg"
-      ignore_errors: true
-      register: result_search_str
-
-    - name: "Add label installgui when the label does not exist in file install_en.cfg"
-      ansible.builtin.blockinfile:
-        path: "{{ src_iso_file_dir }}/install_en.cfg"
-        insertafter: "^default installgui$"
-        block: |
-          label installgui
-              menu label ^Graphical Installer
-              linux /install/vmlinuz
-              initrd /install/initrd.gz
-              append vga=791 theme=pardusdark  --- quiet
-      when:
-        - result_search_str.failed is defined
-        - result_search_str.failed
-
-# Add DPMS=-s\ 0 to boot command line to disable screen saver for debian installer
-- name: "Update boot parameters with preseed.cfg"
-  ansible.builtin.replace:
+- name: "Add label autoinstall"
+  ansible.builtin.blockinfile:
     path: "{{ src_iso_file_dir }}/{{ item }}"
-    regexp: 'append'
-    replace: 'append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0"'
-  with_items:
-    - "install_en.cfg"
-    - "install.cfg"
+    insertafter: "^default autoinstall$"
+    block: |
+      label autoinstall
+          menu label ^Graphical Autoinstall Installer
+          linux /install/vmlinuz
+          initrd /install/initrd.gz
+          append auto=true file=/cdrom/{{ unattend_install_file_name }} "DPMS=-s 0" vga=791 theme=pardusdark  --- quiet
+    with_items:
+      - "install_en.cfg"
+      - "install.cfg"
 
 - name: "Update default memu entry for grub.cfg"
   ansible.builtin.replace:

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -9,6 +9,7 @@ for pkg in $required_pkgs; do
         apt install -y $pkg 2>&1
         if [ $? -ne 0 ]; then
             echo "ERROR: Failed to install package $pkg from CDROM"
+            cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
         fi
     else
         echo "Package $pkg doesn't exist in CDROM"


### PR DESCRIPTION
Problem
the autoinstall for pardus 23.1 server does not work.

Result:
1) for pardus 23.1 server:
<img width="590" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/fe4ac97c-1418-41d4-a7bb-05e33fd805ea">

2) For pardus 23.1 XFCE:
<img width="548" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/66730546-9015-4684-97f2-a9120159a00d">
