### PR TITLE
[Linux] Add cdrom repo when testing ovt_verify_install for Rocky Linux and AlmaLinux

### DIFF
--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -13,12 +13,7 @@
   block:
     - name: "Add a local package repository from ISO image for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_local_dvd_repo.yml
-      when: >
-        guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat'] or
-        (guest_os_ansible_distribution in ['Rocky', 'AlmaLinux'] and 
-          ((guest_os_ansible_distribution_major_ver | int == 8 and guest_os_ansible_distribution_minor_ver | int >= 9) or
-           (guest_os_ansible_distribution_major_ver | int == 9 and guest_os_ansible_distribution_minor_ver | int >= 3)))
-
+      when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'Rocky', 'AlmaLinux']
     - name: "Add online package repositories for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_official_online_repo.yml
       when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu']

--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -13,7 +13,11 @@
   block:
     - name: "Add a local package repository from ISO image for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_local_dvd_repo.yml
-      when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat']
+      when: >
+        guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat'] or
+        (guest_os_ansible_distribution in ['Rocky', 'AlmaLinux'] and 
+          ((guest_os_ansible_distribution_major_ver | int == 8 and guest_os_ansible_distribution_minor_ver | int >= 9) or
+           (guest_os_ansible_distribution_major_ver | int == 9 and guest_os_ansible_distribution_minor_ver | int >= 3)))
 
     - name: "Add online package repositories for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_official_online_repo.yml

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -37,6 +37,7 @@
 
 # Disable all existing repos
 - include_tasks: ../utils/disable_repo.yml
+  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED']
 
 # Get the fact of system devices
 - include_tasks: ../../common/get_system_info.yml

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -106,7 +106,7 @@
   ansible.builtin.set_fact:
     dvd_repo_name: "{{ guest_os_ansible_distribution }}-{{ guest_os_ansible_distribution_ver }}-dvd"
 
-# Add repo from CDROM for RHEL/SLES/SLED
+# Add repo from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux
 - block:
     # Find the dir having repodata
     - name: "Find repodata in {{ guest_cdrom_mount_path }}"
@@ -130,4 +130,4 @@
       with_items: "{{ find_repodata_result.stdout_lines }}"
       loop_control:
         loop_var: repodata_path
-  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED']
+  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux']


### PR DESCRIPTION
Problem:
ovt_verify_install downgraded OVT from 12.2.5 to 12.1.5 in RockyLinux 8.9 and 9.3

Test Result:
1) Sanity check in RockyLinux 9.3
<img width="635" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/9ec2d26f-3fee-4396-81f0-008711eeb872">
   
  Check the setting about local DVD repo from output message:
<img width="1344" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/c7f6ebef-4748-4814-95da-3f883ec59c14">
