### PR TITLE
[Linux] Skip vmtoolsd and vgauthd status checking when they are upheld in Flatcar

### DIFF
--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -30,6 +30,7 @@
           include_tasks: ../utils/set_ovt_facts.yml
 
         - name: "Add user 'vmware' to check vmusr process"
+          when: "'open-vm-tools-desktop' in ovt_packages"
           block:
             - name: "Add new user 'vmware' if it doesn't exist"
               include_tasks: ../utils/add_user.yml
@@ -43,7 +44,6 @@
 
             - name: "Reboot guest OS and login as user 'vmware'"
               include_tasks: ../utils/reboot.yml
-          when: "'open-vm-tools-desktop' in ovt_packages"
 
         - name: "Check open-vm-tools packages are installed"
           include_tasks: check_ovt_package.yml

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -68,13 +68,13 @@
           ansible.builtin.set_fact:
             ovt_service_is_upheld: false
 
+        # Since Flatcar Stable 3760.2.0, open-vm-tools service default status is disabled,
+        # but it can be started via a dependency in
+        # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
+        # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
         - name: "Check open-vm-tools service is upheld or not for Flatcar"
           when: guest_os_ansible_distribution == "Flatcar"
           block:
-            # Since Flatcar Stable 3760.2.0, open-vm-tools service default status is disabled,
-            # but it can be started via a dependency in
-            # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
-            # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
             - name: "Get properties of systemd unit 'multi-user.target'"
               include_tasks: ../utils/get_systemd_unit_properties.yml
               vars:

--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -9,39 +9,44 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case when VMware Tools is not installed"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to VMware tools installed: {{ vmtools_is_installed | default(false) }}"
             skip_reason: "Not Applicable"
           when: vmtools_is_installed is undefined or not vmtools_is_installed
 
-        # Check VMware Tools status is running
-        - include_tasks: check_vmtools_status.yml
+        - name: "Check VMware Tools status is running"
+          include_tasks: check_vmtools_status.yml
           vars:
             expected_vmtools_status: "running"
 
-        # Set the fact of open-vm-tools processes and services
-        - include_tasks: ../utils/set_ovt_facts.yml
+        - name: "Set facts of open-vm-tools processes and services"
+          include_tasks: ../utils/set_ovt_facts.yml
 
-        # Add user 'vmware' to check vmusr process
-        - block:
-            - include_tasks: ../utils/add_user.yml
+        - name: "Add user 'vmware' to check vmusr process"
+          block:
+            - name: "Add new user 'vmware' if it doesn't exist"
+              include_tasks: ../utils/add_user.yml
               vars:
                 guest_user_name: "vmware"
 
-            - include_tasks: ../utils/enable_auto_login.yml
+            - name: "Enalbe auto login for user 'vmware'"
+              include_tasks: ../utils/enable_auto_login.yml
               vars:
                 autologin_user: "vmware"
 
-            # Reboot to make changes take effect and wait for tools running
-            - include_tasks: ../utils/reboot.yml
+            - name: "Reboot guest OS and login as user 'vmware'"
+              include_tasks: ../utils/reboot.yml
           when: "'open-vm-tools-desktop' in ovt_packages"
 
-        # Check open-vm-tools packages are installed
-        - include_tasks: check_ovt_package.yml
+        - name: "Check open-vm-tools packages are installed"
+          include_tasks: check_ovt_package.yml
           vars:
             expected_package_state: "present"
           with_items: "{{ ovt_packages }}"
@@ -49,8 +54,8 @@
             loop_var: package_name
           when: guest_os_ansible_distribution != 'Flatcar'
 
-        # Check open-vm-tools processes are running
-        - include_tasks: ../utils/check_process_status.yml
+        - name: "Check open-vm-tools processes are running"
+          include_tasks: ../utils/check_process_status.yml
           vars:
             expected_process_state: "present"
             process_uid: "{{ ovt_process.uid }}"
@@ -59,11 +64,37 @@
           loop_control:
             loop_var: ovt_process
 
-        # Check open-vm-tools services are running
-        - include_tasks: ../utils/check_service_status.yml
+        - name: "Initialize the fact that open-vm-tools service is not upheld"
+          ansible.builtin.set_fact:
+            ovt_service_is_upheld: false
+
+        - name: "Check open-vm-tools service is upheld or not for Flatcar"
+          when: guest_os_ansible_distribution == "Flatcar"
+          block:
+            # Since Flatcar Stable 3760.2.0, open-vm-tools service default status is disabled,
+            # but it can be started via a dependency in
+            # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
+            # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
+            - name: "Get properties of systemd unit 'multi-user.target'"
+              include_tasks: ../utils/get_systemd_unit_properties.yml
+              vars:
+                guest_systemd_unit: "multi-user.target"
+
+            - name: "Update the fact that open-vm-tools service is upheld"
+              ansible.builtin.set_fact:
+                ovt_service_is_upheld: true
+              when:
+                - guest_systemd_unit_properties.DropInPaths is defined
+                - guest_systemd_unit_properties.DropInPaths is search('open-vm-tools-sysext-upholds.conf')
+                - guest_systemd_unit_properties.Upholds is defined
+                - guest_systemd_unit_properties.Upholds is search(ovt_service ~ '.service')
+
+        - name: "Check state and status of open-vm-tools service {{ ovt_service }}"
+          include_tasks: ../utils/check_service_status.yml
           vars:
             service_name: "{{ ovt_service }}"
             expected_service_state: "running"
-            expected_service_status: "enabled"
+            expected_service_status: "{{ 'enabled' if not ovt_service_is_upheld else '' }}"
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/linux/utils/check_process_status.yml
+++ b/linux/utils/check_process_status.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check processe is running or not
+# Check process is running or not
 # Parameters:
 #   process_uid: The user id of the running process. By default it is root
 #   process_name: The process name in the command

--- a/linux/utils/check_service_status.yml
+++ b/linux/utils/check_service_status.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check open-vm-tools services status
+# Check systemd service status
 # Parameter:
 #   service_name: the name of the service
 #   expected_service_state: ['active', 'inactive', 'running', 'stopped', 'absent']
@@ -10,11 +10,11 @@
 #     running: the service is active and running
 #     stopped: the service is active and exited
 #     absent: the service doesn't exist
-#   expected_service_status: ['enabled', 'disabled']
+#   expected_service_status: ['enabled', 'disabled', '']
 #     enabled: the service is enabled to start at boot
 #     disabled: the service is disabled to start at boot
-
-
+#     If it is empty, the service can be enabled or disabled
+#
 - name: "Ignore expected_service_status when service '{{ service_name }}' is expected to be '{{ expected_service_state }}'"
   ansible.builtin.set_fact:
     expected_service_status: ""
@@ -26,11 +26,11 @@
   when: >
     (expected_service_state is undefined) or
     (expected_service_state not in ['active', 'inactive', 'running', 'stopped', 'absent']) or
-    (expected_service_state != 'absent' and
-     (expected_service_status is undefined or
-     expected_service_status not in ['enabled', 'disabled']))
+    (expected_service_status is undefined or
+     expected_service_status not in ['enabled', 'disabled', ''])
 
-- include_tasks: get_service_info.yml
+- name: "Get service information"
+  include_tasks: get_service_info.yml
 
 - name: "Check service '{{ service_name }}' is {{ expected_service_state }}"
   ansible.builtin.assert:

--- a/linux/utils/get_systemd_unit_properties.yml
+++ b/linux/utils/get_systemd_unit_properties.yml
@@ -21,5 +21,7 @@
   ansible.builtin.set_fact:
     guest_systemd_unit_properties: "{{ systemctl_show_result.stdout | replace('=', ': ') | from_yaml }}"
   when:
+    - systemctl_show_result.failed is defined
+    - not systemctl_show_result.failed
     - systemctl_show_result.stdout is defined
     - systemctl_show_result.stdout

--- a/linux/utils/get_systemd_unit_properties.yml
+++ b/linux/utils/get_systemd_unit_properties.yml
@@ -1,0 +1,25 @@
+# Copyright 2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Get systemd unit properties
+# Parameter:
+#   guest_systemd_unit: the systemd unit name
+# Return:
+#   guest_systemd_unit_properties: systemd unit properties
+#
+- name: "Initialize the fact of systemd unit's properties"
+  ansible.builtin.set_fact:
+    guest_systemd_unit_properties: {}
+
+- name: "Get properties of systemd unit '{{ guest_systemd_unit }}'"
+  ansible.builtin.shell: "systemctl show {{ guest_systemd_unit }}"
+  ignore_errors: true
+  delegate_to: "{{ vm_guest_ip }}"
+  register: systemctl_show_result
+
+- name: "Set fact of systemd unit's properties"
+  ansible.builtin.set_fact:
+    guest_systemd_unit_properties: "{{ systemctl_show_result.stdout | replace('=', ': ') | from_yaml }}"
+  when:
+    - systemctl_show_result.stdout is defined
+    - systemctl_show_result.stdout

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -37,12 +37,37 @@
             process_name: "{{ vgauth_process.cmd }}"
             expected_process_state: "present"
 
-        - name: "Check VGAuthService is active and enabled"
+        - name: "Initialize the fact that VGAuthService is not upheld"
+          ansible.builtin.set_fact:
+            vgauth_service_is_upheld: false
+
+        - name: "Check VGAuthService is upheld or not for Flatcar"
+          when: guest_os_ansible_distribution == "Flatcar"
+          block:
+            # Since Flatcar Stable 3760.2.0, VGAuthService default status is disabled,
+            # but it can be started via a dependency in
+            # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
+            # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
+            - name: "Get properties of systemd unit 'multi-user.target'"
+              include_tasks: ../utils/get_systemd_unit_properties.yml
+              vars:
+                guest_systemd_unit: "multi-user.target"
+
+            - name: "Update the fact that VGAuthService is upheld"
+              ansible.builtin.set_fact:
+                vgauth_service_is_upheld: true
+              when:
+                - guest_systemd_unit_properties.DropInPaths is defined
+                - guest_systemd_unit_properties.DropInPaths is search('open-vm-tools-sysext-upholds.conf')
+                - guest_systemd_unit_properties.Upholds is defined
+                - guest_systemd_unit_properties.Upholds is search(vgauth_service_name ~ '.service')
+
+        - name: "Check VGAuthService state and status is as expected"
           include_tasks: ../utils/check_service_status.yml
           vars:
             service_name: "{{ vgauth_service_name }}"
             expected_service_state: "running"
-            expected_service_status: "enabled"
+            expected_service_status: "{{ 'enabled' if not vgauth_service_is_upheld else '' }}"
       rescue:
         - name: "Test case failure"
           include_tasks: ../../common/test_rescue.yml

--- a/linux/vgauth_check_service/vgauth_check_service.yml
+++ b/linux/vgauth_check_service/vgauth_check_service.yml
@@ -30,7 +30,7 @@
         - name: "Set facts of VGAuthService process and service"
           include_tasks: ../utils/set_vgauth_facts.yml
 
-        - name: "Check VGAuthService processe is running"
+        - name: "Check VGAuthService process is running"
           include_tasks: ../utils/check_process_status.yml
           vars:
             process_uid: "{{ vgauth_process.uid }}"
@@ -41,13 +41,13 @@
           ansible.builtin.set_fact:
             vgauth_service_is_upheld: false
 
+        # Since Flatcar Stable 3760.2.0, VGAuthService default status is disabled,
+        # but it can be started via a dependency in
+        # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
+        # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
         - name: "Check VGAuthService is upheld or not for Flatcar"
           when: guest_os_ansible_distribution == "Flatcar"
           block:
-            # Since Flatcar Stable 3760.2.0, VGAuthService default status is disabled,
-            # but it can be started via a dependency in
-            # /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf
-            # See https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304
             - name: "Get properties of systemd unit 'multi-user.target'"
               include_tasks: ../utils/get_systemd_unit_properties.yml
               vars:


### PR DESCRIPTION
While testing Flatcar Stable 3760.2.0, we found that the default status of vmtoolsd.service and vgauthd.service were disabled, but they could start at boot. That is because they are started via a dependency in
 /usr/lib/systemd/system/multi-user.target.d/open-vm-tools-sysext-upholds.conf. https://github.com/flatcar/Flatcar/issues/1330#issuecomment-1905544304 explains this change. 

So in our test cases, we need to checking whether vmtoolsd and vgauthd are in upholds of systemd unit multi-user.target for Flatcar. If they are in upholds, we can ignore their service status, no matter they are enabled or disabled.