### PR TITLE
Display ESXi model, CPU model and code name at deploy_vm failure

### DIFF
--- a/common/esxi_get_model.yml
+++ b/common/esxi_get_model.yml
@@ -1,25 +1,51 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Initialize the facts of ESXi server model info"
+- name: "Initialize facts of ESXi server model info and CPU info"
   ansible.builtin.set_fact:
     esxi_model_info: ''
     esxi_cpu_model_info: ''
+    esxi_cpu_vendor: ''
+    esxi_cpu_code_name: ''
 
-# Get ESXi server model and CPU model
-- include_tasks: esxi_get_property.yml
+- name: "Get ESXi server model and CPU model"
+  include_tasks: esxi_get_property.yml
   vars:
     esxi_host_property_list:
       - summary.hardware.cpuModel
       - summary.hardware.model
       - summary.hardware.vendor
+      - hardware.cpuPkg
 
 - name: "Set fact of ESXi server model and CPU model info"
   ansible.builtin.set_fact:
     esxi_model_info: "{{ esxi_host_property_results.ansible_facts.summary.hardware.vendor }} {{ esxi_host_property_results.ansible_facts.summary.hardware.model }}"
     esxi_cpu_model_info: "{{ esxi_host_property_results.ansible_facts.summary.hardware.cpuModel }}"
+    esxi_cpu_vendor: "{{ esxi_host_property_results.ansible_facts.hardware.cpuPkg[0].vendor | default('Unknown') }}"
 
-- name: "Display ESXi server model info"
-  ansible.builtin.debug: var=esxi_model_info
-- name: "Display ESXi server CPU model info"
-  ansible.builtin.debug: var=esxi_cpu_model_info
+- name: "Get ESXi server CPU code name"
+  when: esxi_cpu_vendor | lower == 'intel'
+  block:
+    - name: "Get ESXi server CPU code name"
+      ansible.builtin.script: "../tools/query_cpu.py -n '{{ cpu_name }}'"
+      vars:
+        cpu_name: "{{ esxi_cpu_model_info | regex_replace(' CPU.*', '') }}"
+      ignore_errors: true
+      register: query_cpu_result
+
+    - name: "Set fact of ESXi server CPU code name"
+      ansible.builtin.set_fact:
+        esxi_cpu_code_name: "{{ query_cpu_result.stdout.strip() }}"
+      when:
+        - query_cpu_result.failed is defined
+        - not query_cpu_result.failed
+        - query_cpu_result.stdout is defined
+        - query_cpu_result.stdout
+
+- name: "Display ESXi server and CPU model info"
+  ansible.builtin.debug:
+    msg:
+      - "ESXi server model info: {{ esxi_model_info }}"
+      - "ESXi server CPU manufacturer: {{ esxi_cpu_vendor }}"
+      - "ESXi server CPU model info: {{ esxi_cpu_model_info }}"
+      - "ESXi server CPU code name: {{ esxi_cpu_code_name }}"

--- a/common/esxi_get_property.yml
+++ b/common/esxi_get_property.yml
@@ -5,17 +5,17 @@
 # Parameters:
 #   esxi_host_property_list
 #
-- name: Get ESXi host specified property
+- name: "Get ESXi host specified property"
   community.vmware.vmware_host_facts:
     hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"
     password: "{{ vsphere_host_user_password }}"
     esxi_hostname: "{{ esxi_hostname }}"
     validate_certs: "{{ validate_certs | default(false) }}"
-    properties: "{{ esxi_host_property_list }}"
+    properties: "{{ esxi_host_property_list | default(omit) }}"
     schema: vsphere
   register: esxi_host_property_results
 
-- name: Display the specified ESXi property result
+- name: "Display the specified ESXi property result"
   ansible.builtin.debug: var=esxi_host_property_results
   when: enable_debug is defined and enable_debug

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -60,6 +60,29 @@
           ansible.builtin.debug: var=vm_guest_ip
           when: vm_guest_ip is defined and vm_guest_ip
       rescue:
+        - name: "Display ESXi and CPU model information at deployment failure"
+          ansible.builtin.debug:
+            msg: >-
+              VM deployment failed on server {{ esxi_model_info }} with
+              ESXi version {{ esxi_version }} build {{ esxi_build }} installed.
+              The server's CPU model is {{ esxi_cpu_model_info }}
+              {% ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name %}
+          tags:
+            - fail_message
+
+        - name: "Known issue - Linux guest OS hung"
+          ansible.builtin.debug:
+            msg: >-
+              Linux guest OS could be hung on ESXi {{ esxi_version }} server
+              based on Intel {{ esxi_cpu_code_name }} CPU. Refer to KB articles
+              https://kb.vmware.com/s/article/92361 and
+              https://kb.vmware.com/s/article/91250.
+          tags:
+            - known_issue
+          when:
+            - esxi_version in ['7.0.0', '7.0.1']
+            - esxi_cpu_code_name in ['Skylake', 'Ice Lake', 'Cascade Lake']
+
         - name: "Collect serial port log at test failure"
           include_tasks: collect_serial_port_log.yml
           vars:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -66,7 +66,7 @@
               VM deployment failed on server {{ esxi_model_info }} with
               ESXi version {{ esxi_version }} build {{ esxi_build }} installed.
               The server's CPU model is {{ esxi_cpu_model_info }}
-              {% ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name %}
+              {{ ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name }}
           tags:
             - fail_message
 

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -82,6 +82,7 @@ class vSphereInfo(object):
         self.build = ''
         self.model = ''
         self.cpu_model = ''
+        self.cpu_codename = ''
 
     def __str__(self):
         info = {'hostname': self.hostname,
@@ -90,6 +91,7 @@ class vSphereInfo(object):
         if self.product.lower() == 'esxi':
             info['model'] = self.model
             info['cpu_model'] = self.cpu_model
+            info['cpu_codename'] = self.cpu_codename
         return json.dumps(info, indent=4)
 
     def update_property(self, p_name, p_value):
@@ -139,6 +141,8 @@ class TestbedInfo(object):
                                            ansible_gosv_facts.get('esxi_model_info', ''))
             self.esxi_info.update_property('cpu_model',
                                            ansible_gosv_facts.get('esxi_cpu_model_info', ''))
+            self.esxi_info.update_property('cpu_codename',
+                                           ansible_gosv_facts.get('esxi_cpu_code_name', ''))
 
     def __str__(self):
         """
@@ -167,8 +171,12 @@ class TestbedInfo(object):
         hostname_col_width = max(
             [len('Hostname or IP'), len(self.vcenter_info.hostname), len(self.esxi_info.hostname)])
         # Get server model column width
+        esxi_cpu_detail = self.esxi_info.cpu_model
+        if self.esxi_info.cpu_codename:
+           esxi_cpu_detail += f" ({self.esxi_info.cpu_codename})"
+
         server_model_col_width = max(
-            [len('Server Model'), len(self.esxi_info.model), len(self.esxi_info.cpu_model)])
+            [len('Server Model'), len(self.esxi_info.model), len(esxi_cpu_detail)])
 
         # Table width
         table_width = sum([9, version_col_width, build_col_width,
@@ -202,12 +210,12 @@ class TestbedInfo(object):
                                      self.esxi_info.build.ljust(build_col_width),
                                      self.esxi_info.hostname.ljust(hostname_col_width),
                                      self.esxi_info.model.ljust(server_model_col_width))
-            if self.esxi_info.cpu_model:
+            if esxi_cpu_detail:
                 msg += row_format.format('',
                                          ''.ljust(version_col_width),
                                          ''.ljust(build_col_width),
                                          ''.ljust(hostname_col_width),
-                                         self.esxi_info.cpu_model.ljust(server_model_col_width))
+                                         esxi_cpu_detail.ljust(server_model_col_width))
             msg += row_border
 
         msg += "\n"

--- a/tools/query_cpu.py
+++ b/tools/query_cpu.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This script can help to query CPU code name from manufacturer website
+#
+import sys
+import requests
+import re
+import traceback
+from lxml import html
+from urllib.parse import quote, urlparse, urlunparse
+from argparse import ArgumentParser, RawTextHelpFormatter
+
+ARK_INTEL_HOME = "https://ark.intel.com"
+
+def url_encode(input_string):
+    encoded_string = quote(input_string)
+    return encoded_string
+
+class Processor(object):
+    def __init__(self):
+        self.cpu_name = None
+        self.code_name = None
+
+    def get_cpu_name(self):
+        return self.cpu_name
+
+    def get_code_name(self):
+        return self.code_name
+
+class IntelProcessor(Processor):
+    def __init__(self, cpu_spec_url):
+        super().__init__()
+        self._parse_cpu_spec(cpu_spec_url)
+
+    def _parse_cpu_spec(self, cpu_spec_url):
+        """
+        Get CPU details from its specification URL
+        For example,
+        https://ark.intel.com/content/www/us/en/ark/products/212458/intel-xeon-gold-6330-processor-42m-cache-2-00-ghz.html
+        """
+        try:
+            response = requests.get(cpu_spec_url)
+            if response.status_code == 200:
+                xml_tree = html.fromstring(response.content)
+                product_title = xml_tree.xpath('//div[contains(@class, "product-family-title-text")]/h1')
+                if product_title:
+                    cpu_name = re.sub(' *Processor *', '', product_title[0].text)
+                    cpu_name = cpu_name.replace('®', '(R)')
+                    self.cpu_name = cpu_name
+                    # Look for code name
+                    codename_a = xml_tree.xpath('//span[@data-key="CodeNameText"]/a')
+                    if codename_a:
+                        self.code_name = codename_a[0].text.replace('Products formerly ', '').strip()
+        except Exception as e:
+            traceback_str = traceback.format_exc()
+            sys.stderr.write(f"Failed to parse CPU specification {cpu_spec_url}\n" + traceback_str)
+            sys.exit(1)
+
+def intel_search_cpu(search_name):
+    """
+    Search for CPU by given CPU name pattern
+    """
+    cpu_spec_url = None
+    # Remove '(R)' from the CPU name
+    cpu_name_pattern = re.sub('\(\w+\)', '', search_name)
+    # Construct the search query URL
+    search_url = f"{ARK_INTEL_HOME}/content/www/us/en/ark/search.html?_charset_=UTF-8&q=" + url_encode(cpu_name_pattern)
+
+    # Send a GET request to the search URL
+    response = requests.get(search_url)
+    if response.status_code == 200:
+        xml_tree = html.fromstring(response.content)
+        # Find the CPU search results
+        cpu_results = xml_tree.xpath('//h4[@class="result-title"]/a')
+        if cpu_results and len(cpu_results) > 0:
+            # It searched more than one CPU results
+            for cpu_result in cpu_results:
+                cpu_name = re.sub(r'(Processor)? *\(.*\)', '', cpu_result.text).strip().replace('®', '(R)')
+                # print(f"Found CPU name: {cpu_name}")
+                if cpu_name == search_name:
+                    cpu_spec_url = ARK_INTEL_HOME + cpu_result.get('href')
+                    break
+        else:
+            # It searched only one CPU result
+            search_result = xml_tree.xpath('//div[contains(@class,"textSearch")]/input[@id="FormRedirectUrl"]')
+            if search_result and len(search_result) > 0:
+                cpu_spec_url = ARK_INTEL_HOME + search_result[0].value
+
+    # print(f"Found CPU spec for {search_name}: {cpu_spec_url}")
+    return cpu_spec_url
+
+def intel_query_cpu_code_name(search_name):
+    """
+    Search CPU and get its code name from CPU specification
+    """
+    cpu_spec_url = intel_search_cpu(search_name)
+    if cpu_spec_url:
+        intel_cpu = IntelProcessor(cpu_spec_url)
+        cpu_name = intel_cpu.get_cpu_name()
+        code_name = intel_cpu.get_code_name()
+        if cpu_name and code_name and cpu_name == search_name:
+            print(code_name)
+
+def parse_arguments():
+    parser = ArgumentParser(description="A tool to query CPU code name by CPU product name",
+                            usage='%(prog)s [OPTIONS]',
+                            formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-n", dest="name", required=True,
+                        help="CPU product name\n" +
+                             "e.g. Intel(R) Xeon(R) Gold 6330")
+
+    args = parser.parse_args()
+    return args
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    try:
+        if 'Intel' in args.name:
+            intel_query_cpu_code_name(args.name)
+        elif 'AMD' in args.name:
+            pass
+    except Exception as e:
+        traceback_str = traceback.format_exc()
+        sys.stderr.write(traceback_str)
+        sys.exit(1)

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -46,12 +46,23 @@
           vars:
             vm_screenshot_local_dir: "{{ current_test_log_folder }}"
       rescue:
+        - name: "Display ESXi and CPU model information at deployment failure"
+          ansible.builtin.debug:
+            msg: >-
+              VM deployment failed on server {{ esxi_model_info }} with
+              ESXi version {{ esxi_version }} build {{ esxi_build }} installed.
+              The server's CPU model is {{ esxi_cpu_model_info }}
+              {% ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name %}
+          tags:
+            - fail_message
+
         - name: "Test case failure"
           include_tasks: ../../common/test_rescue.yml
           vars:
             exit_testing_when_fail: true
       always:
         - name: "Remove NFS mount point"
+          when: nfs_mount_dir is defined and nfs_mount_dir
           block:
             - name: "Umount NFS share point"
               include_tasks: ../../common/local_unmount.yml
@@ -64,4 +75,3 @@
               vars:
                 local_path: "{{ nfs_mount_dir }}"
                 del_local_file_ignore_errors: true
-          when: nfs_mount_dir is defined and nfs_mount_dir

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -52,7 +52,7 @@
               VM deployment failed on server {{ esxi_model_info }} with
               ESXi version {{ esxi_version }} build {{ esxi_build }} installed.
               The server's CPU model is {{ esxi_cpu_model_info }}
-              {% ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name %}
+              {{ ' (code name ' ~ esxi_cpu_code_name ~ ')' if esxi_cpu_code_name }}
           tags:
             - fail_message
 


### PR DESCRIPTION
Added a script to query Intel CPU code name from Intel website, and display the ESXi model, CPU model information at deploy_vm failure. Failures on 70GA, 71U1 with Intel Skylake, Ice Lake, and Cascade Lake CPU, print known issue.

failed_tasks.log
```
2024-03-02 11:00:48,002 | Failed at Play [1_deploy_vm] *******************************

2024-03-02 11:00:48,002 | TASK [1_deploy_vm][Check VMware Tools is running and collects guest OS fullname successfully] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_wait_guest_fullname.yml:46
fatal: [localhost]: FAILED! => {
    "assertion": "vm_guestinfo.instance.guest.toolsRunningStatus == \"guestToolsRunning\"",
    "changed": false,
    "evaluated_to": false,
    "msg": "It's timed out for VMware Tools collecting guest OS fullname in 5 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''."
}
error message:
It's timed out for VMware Tools collecting guest OS fullname in 5 seconds. Current VMware Tools running status is 'guestToolsNotRunning', and guest OS fullname is ''.


2024-03-02 11:00:49,002 | TASK [1_deploy_vm][Display ESXi and CPU model information at deployment failure] 
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/deploy_vm/deploy_vm.yml:63
ok: [localhost] => {
    "msg": "VM deployment failed on server VMware, Inc. VMware7,1 with ESXi version 7.0.1 build 16850804 installed. The server's CPU model is Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz (code name Ice Lake)"
}
error message:
VM deployment failed on server VMware, Inc. VMware7,1 with ESXi version 7.0.1 build 16850804 installed. The server's CPU model is Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz (code name Ice Lake)
```

known_issues.log
```
2024-03-02 11:00:49,002 | Known Issue in Play [1_deploy_vm] **************************

2024-03-02 11:00:49,002 | TASK [1_deploy_vm][Known issue - Linux guest OS hung] ******
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/linux/deploy_vm/deploy_vm.yml:73
ok: [localhost] => {
    "msg": "Linux guest OS could be hung on ESXi 7.0.1 server based on Intel Ice Lake CPU. Refer to KB articles https://kb.vmware.com/s/article/92361 and https://kb.vmware.com/s/article/91250."
}
```