### PR TITLE
[Linux] Update GOSC testing support status for Miracle Linux

### DIFF
--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -19,6 +19,16 @@
     skip_reason: "Blocked"
   when: enable_cloudinit_gosc and not vmtools_is_ovt
 
+- name: "Skip test case"
+  include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: "Test case '{{ ansible_play_name }}' is skipped because it's not supported"
+    skip_reason: "Not Supported"
+  when:
+    - config_guest_id == 'asianux8_64Guest'
+    - guest_os_ansible_distribution == 'MIRACLE'
+    - vcenter_version is version('8.0.0', '<')
+
 - name: "Check GOSC support status"
   block:
     - name: "Initialize GOSC support status"

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -22,11 +22,10 @@
 - name: "Skip test case"
   include_tasks: ../../common/skip_test_case.yml
   vars:
-    skip_msg: "Test case '{{ ansible_play_name }}' is skipped because it's not supported"
+    skip_msg: "Test case '{{ ansible_play_name }}' is skipped because guest id {{ vm_guest_id }} doesn't support guest OS customization on vCenter Server {{ vcenter_version }}"
     skip_reason: "Not Supported"
   when:
-    - guest_id == 'asianux8_64Guest'
-    - guest_os_ansible_distribution == 'MIRACLE'
+    - vm_guest_id is match('asianux.*')
     - vcenter_version is version('8.0.0', '<')
 
 - name: "Check GOSC support status"

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -85,12 +85,16 @@
         - guest_os_ansible_distribution_major_ver | int == 12
 
     - name: "Check Perl GOSC support status for {{ vm_guest_os_distribution }}"
+      when:
+        - not enable_cloudinit_gosc | bool
+        - guest_os_ansible_distribution not in gos_not_support_gosc
       block:
         - name: "Get GOSC support matrix"
           ansible.builtin.set_fact:
             gosc_support_matrix: "{{ lookup('file', 'gosc_support_matrix.yml') | from_yaml }}"
 
         - name: "Check Perl GOSC support status for {{ vm_guest_os_distribution }} in support matrix"
+          when: gosc_support_matrix[guest_os_ansible_distribution] is defined
           block:
             - name: "Get {{ guest_os_ansible_distribution }} Perl GOSC testing supported OS versions"
               ansible.builtin.set_fact:
@@ -107,6 +111,7 @@
               with_items: "{{ gosc_matrix_os_versions }}"
 
             - name: "Get Perl GOSC supported VC versions and builds"
+              when: gosc_matrix_first_os_version != 'None'
               block:
                 - name: "Get {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} Perl GOSC supported VC versions and builds"
                   ansible.builtin.set_fact:
@@ -122,6 +127,9 @@
                     (vcenter_version is version(gosc_matrix_vc_list[0], '<')))
 
                 - name: "Get Perl GOSC supported open-vm-tools version for {{ vm_guest_os_distribution }}"
+                  when:
+                    - gosc_support_matrix[guest_os_ansible_distribution][gosc_matrix_first_os_version]['vmtools'] is defined
+                    - gosc_support_matrix[guest_os_ansible_distribution][gosc_matrix_first_os_version]['vmtools']
                   block:
                     - name: "Get {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} Perl GOSC supported open-vm-tools version"
                       ansible.builtin.set_fact:
@@ -131,14 +139,6 @@
                       ansible.builtin.set_fact:
                         gosc_is_supported: false
                       when: vmtools_version is version(gosc_support_matrix[guest_os_ansible_distribution][gosc_matrix_first_os_version]['vmtools'], '<')
-                  when:
-                    - gosc_support_matrix[guest_os_ansible_distribution][gosc_matrix_first_os_version]['vmtools'] is defined
-                    - gosc_support_matrix[guest_os_ansible_distribution][gosc_matrix_first_os_version]['vmtools']
-              when: gosc_matrix_first_os_version != 'None'
-          when: gosc_support_matrix[guest_os_ansible_distribution] is defined
-      when:
-        - not enable_cloudinit_gosc | bool
-        - guest_os_ansible_distribution not in gos_not_support_gosc
 
     - name: "Display GOSC support status for {{ vm_guest_os_distribution }}"
       ansible.builtin.debug:

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -25,7 +25,7 @@
     skip_msg: "Test case '{{ ansible_play_name }}' is skipped because it's not supported"
     skip_reason: "Not Supported"
   when:
-    - config_guest_id == 'asianux8_64Guest'
+    - guest_id == 'asianux8_64Guest'
     - guest_os_ansible_distribution == 'MIRACLE'
     - vcenter_version is version('8.0.0', '<')
 

--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -120,6 +120,8 @@ Pardus GNU/Linux:
 # Miracle Linux 8.4 and later, 9.0 support GOSC testing on vCenter Server 8.0U3.
 MIRACLE:
   '8.4':
-    8.0.2: N/A
+    vcenter:
+      8.0.2: N/A
   '9.2':
-    8.0.2: N/A
+    vcenter:
+      8.0.2: N/A

--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -116,3 +116,22 @@ Pardus GNU/Linux:
       8.0.0: N/A
       8.0.1: N/A
       8.0.2: 22385739
+
+# Miracle Linux 8.4 and later, 9.0 support GOSC testing on vCenter Server 8.0U3.
+MIRACLE:
+  '8.4':
+    7.0.0: N/A
+    7.0.1: N/A
+    7.0.2: N/A
+    7.0.3: N/A
+    8.0.0: N/A
+    8.0.1: N/A
+    8.0.2: N/A
+  '9.2':
+    7.0.0: N/A
+    7.0.1: N/A
+    7.0.2: N/A
+    7.0.3: N/A
+    8.0.0: N/A
+    8.0.1: N/A
+    8.0.2: N/A

--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -120,18 +120,6 @@ Pardus GNU/Linux:
 # Miracle Linux 8.4 and later, 9.0 support GOSC testing on vCenter Server 8.0U3.
 MIRACLE:
   '8.4':
-    7.0.0: N/A
-    7.0.1: N/A
-    7.0.2: N/A
-    7.0.3: N/A
-    8.0.0: N/A
-    8.0.1: N/A
     8.0.2: N/A
   '9.2':
-    7.0.0: N/A
-    7.0.1: N/A
-    7.0.2: N/A
-    7.0.3: N/A
-    8.0.0: N/A
-    8.0.1: N/A
     8.0.2: N/A

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -122,12 +122,13 @@
         # Check whether cloud-init version meets cloud-init GOSC requirements
         # Debian 10 and 11 cloud-init GOSC requires cloud-init 22.1 or later installed.
         # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008039
+        # For Miracle Linux 8.x and 9.x, cloud-init GOSC requires cloud-init 22.1 or later installed.
         # For other Linux, cloud-init GOSC requires cloud-init 18.5 or later installed.
         # See https://kb.vmware.com/s/article/90331
         - name: "Set fact of cloud-init version for supporting GOSC"
           ansible.builtin.set_fact:
             gosc_required_cloudinit_version: >-
-              {% if guest_os_ansible_distribution != 'Debian' %}18.5{% else %}22.1{% endif %}
+              {% if guest_os_ansible_distribution in ['Debian', 'MIRACLE'] %}22.1{% else %}18.5{% endif %}
 
         - name: "Get cloud-init version"
           include_tasks: ../utils/get_cloudinit_version.yml

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -16,13 +16,14 @@
     - guest_os_release.ID is defined
     - guest_os_release.ID == 'rhcos'
 
-- name: "Correct OS distribution info for Miracle Linux 8.x"
+- name: "Correct OS distribution version for Miracle Linux 8.x"
   ansible.builtin.set_fact:
-    guest_os_ansible_distribution_ver: "{{ guest_os_release.VERSION | regex_search('\\d\\.\\d') }}"
+    guest_os_ansible_distribution_ver: "{{ guest_os_release.VERSION.split()[0] }}"
     guest_os_ansible_distribution_minor_ver:  "{{ guest_os_release.VERSION.split()[0].split('.')[-1] }}"
   when: 
     - guest_os_ansible_distribution == "MIRACLE"
     - guest_os_ansible_distribution_major_ver | int  == 8
+    - guest_os_release.VERSION is defined and guest_os_release.VERSION | regex_search('\\d\\.\\d')
 
 - name: "Set fact of guest OS ansible distribution is correct or not"
   ansible.builtin.set_fact:

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -23,9 +23,11 @@
         not (guest_os_ansible_distribution == 'RedHat' and
         guest_os_release.NAME is defined and
         guest_os_release.NAME != 'Red Hat Enterprise Linux')
+        and not (guest_os_ansible_distribution == 'MIRACLE' and guest_os_ansible_distribution_major_ver | int == 8)
       }}
 
 - name: "Correct OS distribution info"
+  when: not guest_os_ansible_distrib_is_correct
   block:
     # Overwrite /etc/redhat-release with correct OS release information
     # for RHEL variant OS like ProLinux so that ansible can retrieve
@@ -44,6 +46,7 @@
       ansible.builtin.debug: var=guest_os_redhat_release
 
     - name: "Correct guest OS distribution info"
+      when: guest_os_redhat_release | regex_search("Red *Hat", ignorecase=True)
       block:
         - name: "Get content of guest OS file /etc/system-release"
           ansible.builtin.command: "cat /etc/system-release"
@@ -52,6 +55,9 @@
           register: get_system_release
 
         - name: "Update /etc/redhat-release and refresh OS distribution info"
+          when:
+            - get_system_release.stdout is defined
+            - get_system_release.stdout
           block:
             - name: "Set fact of guest OS system release"
               ansible.builtin.set_fact:
@@ -70,11 +76,6 @@
             - name: "Restore /etc/redhat-release"
               ansible.builtin.shell: "echo '{{ guest_os_redhat_release }}' > /etc/redhat-release"
               delegate_to: "{{ vm_guest_ip }}"
-          when:
-            - get_system_release.stdout is defined
-            - get_system_release.stdout
-      when: guest_os_redhat_release | regex_search("Red *Hat", ignorecase=True)
-  when: not guest_os_ansible_distrib_is_correct
 
 - name: "Set OS family for {{ guest_os_ansible_distribution }} to RedHat"
   ansible.builtin.set_fact:

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -18,8 +18,8 @@
 
 - name: "Correct OS distribution info for Miracle Linux 8.x"
   ansible.builtin.set_fact:
-    guest_os_ansible_distribution_ver: "{{ guest_os_release.VERSION | regex_search('^\\d\\.\\d') }}"
-    guest_os_ansible_distribution_minor_ver:  "{{ guest_os_ansible_distribution_ver.split('.')[1] }}"
+    guest_os_ansible_distribution_ver: "{{ guest_os_release.VERSION | regex_search('\\d\\.\\d') }}"
+    guest_os_ansible_distribution_minor_ver:  "{{ guest_os_release.VERSION.split()[0].split('.')[-1] }}"
   when: 
     - guest_os_ansible_distribution == "MIRACLE"
     - guest_os_ansible_distribution_major_ver | int  == 8

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -23,7 +23,7 @@
   when: 
     - guest_os_ansible_distribution == "MIRACLE"
     - guest_os_ansible_distribution_major_ver | int  == 8
-    - guest_os_release.VERSION is defined and guest_os_release.VERSION | regex_search('\\d\\.\\d')
+    - guest_os_release.VERSION is defined and (guest_os_release.VERSION | regex_search('\\d\\.\\d'))
 
 - name: "Set fact of guest OS ansible distribution is correct or not"
   ansible.builtin.set_fact:

--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -16,6 +16,14 @@
     - guest_os_release.ID is defined
     - guest_os_release.ID == 'rhcos'
 
+- name: "Correct OS distribution info for Miracle Linux 8.x"
+  ansible.builtin.set_fact:
+    guest_os_ansible_distribution_ver: "{{ guest_os_release.VERSION | regex_search('^\\d\\.\\d') }}"
+    guest_os_ansible_distribution_minor_ver:  "{{ guest_os_ansible_distribution_ver.split('.')[1] }}"
+  when: 
+    - guest_os_ansible_distribution == "MIRACLE"
+    - guest_os_ansible_distribution_major_ver | int  == 8
+
 - name: "Set fact of guest OS ansible distribution is correct or not"
   ansible.builtin.set_fact:
     guest_os_ansible_distrib_is_correct: >-
@@ -23,7 +31,6 @@
         not (guest_os_ansible_distribution == 'RedHat' and
         guest_os_release.NAME is defined and
         guest_os_release.NAME != 'Red Hat Enterprise Linux')
-        and not (guest_os_ansible_distribution == 'MIRACLE' and guest_os_ansible_distribution_major_ver | int == 8)
       }}
 
 - name: "Correct OS distribution info"


### PR DESCRIPTION
**Task:**
Add the GOSC support matrix based on the following info:

1) If VM's config_guest_id = 'asianux8_64Guest' on 7.0.x, both perl and cloud-init GOSC should be skipped with reason 'Not Supported'.

2) On 8.0.x, perl GOSC for Miracle Linux 8.4 and later, 9.x are not supported on 8.0.2 or earlier.

3) It needs to update the version of cloud-init to 22.1 to support miraclelinux.

4) KB https://ikb.vmware.com/s/article/88600: Guest OS Customization for Miracle Linux 8 is not fully supported in vSphere 6.7 and 7.0 (88600)


**Test result:**
Testing is on-going.


