### PR TITLE
Add check VMware services after VMware Tools install

### DIFF
--- a/windows/utils/win_get_device_driver.yml
+++ b/windows/utils/win_get_device_driver.yml
@@ -6,7 +6,7 @@
 #   win_device_desc_keyword: the keyword in device description, e.g.,
 #   vmxnet3, pvscsi.
 #   win_get_device_driver_timeout: the timeout to get device driver
-#   info, the default value is 120 seconds.
+#   info, the default value is 300 seconds.
 #
 - name: "Check required parameter"
   ansible.builtin.assert:
@@ -20,7 +20,7 @@
     win_guest_device_driver: {}
     win_powershell_cmd: "Get-CimInstance Win32_PnpSignedDriver | where-object {$_.Description -like '*{{ win_device_desc_keyword }}*'} | select DeviceName, DriverDate, DriverProviderName, DriverVersion, InfName, IsSigned, Manufacturer, Signer"
 
-- name: "Try to get device driver info in {{ win_get_device_driver_timeout | default(120) }}s"
+- name: "Try to get device driver info in {{ win_get_device_driver_timeout | default(300) }}s"
   ansible.windows.win_shell: "{{ win_powershell_cmd }}"
   register: win_get_device_driver_result
   delegate_to: "{{ vm_guest_ip }}"
@@ -28,7 +28,7 @@
     - win_get_device_driver_result is defined
     - win_get_device_driver_result.stdout_lines is defined
     - win_get_device_driver_result.stdout_lines | length != 0
-  retries: "{{ ((win_get_device_driver_timeout | default(120) | int) / 5) | int }}"
+  retries: "{{ ((win_get_device_driver_timeout | default(300) | int) / 5) | int }}"
   delay: 5
   ignore_errors: true
 - name: "Display getting device driver info result"
@@ -37,7 +37,7 @@
 
 - name: "Getting device driver info failed"
   ansible.builtin.fail:
-    msg: "Failed to get the driver info of device with description keyword '{{ win_device_desc_keyword }}' in {{ win_get_device_driver_timeout | default(120) }} seconds."
+    msg: "Failed to get the driver info of device with description keyword '{{ win_device_desc_keyword }}' in {{ win_get_device_driver_timeout | default(300) }} seconds."
   when:
     - win_get_device_driver_result.failed is defined
     - win_get_device_driver_result.failed

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -58,6 +58,9 @@
     - wintools_install_result is defined
     - wintools_install_result.ansible_job_id is defined
 
+- name: "Pause 1 minute after VMware Tools install"
+  ansible.builtin.pause:
+    minutes: 1
 - name: "Restart guest OS after VMware Tools install"
   include_tasks: ../utils/win_shutdown_restart.yml
   vars:

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -58,9 +58,9 @@
     - wintools_install_result is defined
     - wintools_install_result.ansible_job_id is defined
 
-- name: "Pause 1 minute after VMware Tools install"
+- name: "Pause 30 seconds after VMware Tools install"
   ansible.builtin.pause:
-    minutes: 1
+    seconds: 30
 - name: "Restart guest OS after VMware Tools install"
   include_tasks: ../utils/win_shutdown_restart.yml
   vars:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -48,8 +48,10 @@
 - name: "Check VMware Tools services"
   ansible.builtin.assert:
     that:
-      - win_tools_services | difference(vmtools_service_dict.keys() | default([])) == []
-    fail_msg: "Check VMware Tools services '{{ win_tools_services }}' in guest OS, not find service '{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }} after VMware Tools install."
+      - win_tools_services_missing == []
+    fail_msg: "Check VMware Tools services '{{ win_tools_services }}' in guest OS, not find services '{{ win_tools_services_missing }}' after VMware Tools install."
+  vars:
+    win_tools_services_missing: "{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }}"
   when:
     - vmtools_version is defined
     - vmtools_version is version('10.3.0', '>=')

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -44,11 +44,15 @@
   ansible.builtin.debug:
     msg: "Service '{{ item.key }}' status is: {{ item.value }}"
   with_dict: "{{ vmtools_service_dict }}"
+
 - name: "Check VMware Tools services"
   ansible.builtin.assert:
     that:
       - win_tools_services | difference(vmtools_service_dict.keys() | default([])) == []
     fail_msg: "Check VMware Tools services '{{ win_tools_services }}' in guest OS, not find service '{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }} after VMware Tools install."
+  when:
+    - vmtools_version is defined
+    - vmtools_version is version('10.3.0', '>=')
 
 - name: "Set fact of expected usernames of VMware Tools processes"
   ansible.builtin.set_fact:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -4,6 +4,10 @@
 # Check VMware Tools service is running and display the installed VMware Tools
 # version, get VMware Tools installation log file.
 #
+- name: "Set fact of VMware Tools services list"
+  ansible.builtin.set_fact:
+    win_tools_services: ['VGAuthService', 'VMTools', 'vmvss']
+
 - name: "Get VMware Tools install log file path"
   include_tasks: ../utils/win_get_path.yml
   vars:
@@ -33,19 +37,18 @@
 - name: "Get VMware drivers list"
   include_tasks: ../utils/win_get_vmtools_driver_list.yml
 
-- name: "Get VMware services list"
+- name: "Get VMware Tools services list"
   include_tasks: ../utils/win_get_vmtools_service_list.yml
 # Not all services are running, e.g., vmvss
-- name: "Display services running status in guest OS"
+- name: "Display VMware Tools services status"
   ansible.builtin.debug:
     msg: "Service '{{ item.key }}' status is: {{ item.value }}"
   with_dict: "{{ vmtools_service_dict }}"
-
-- name: "Check 4 services in the list"
+- name: "Check VMware Tools services"
   ansible.builtin.assert:
     that:
-      - vmtools_service_dict | length == 4
-    fail_msg: "Expect 4 VMware services in guest OS after VMware Tools install, while got '{{ vmtools_service_dict | length }}': {{ vmtools_service_dict.keys() | default('') }}"
+      - win_tools_services | difference(vmtools_service_dict.keys() | default([])) == []
+    fail_msg: "Check VMware Tools services '{{ win_tools_services }}' in guest OS, not find service '{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }} after VMware Tools install."
 
 - name: "Set fact of expected usernames of VMware Tools processes"
   ansible.builtin.set_fact:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -41,6 +41,12 @@
     msg: "Service '{{ item.key }}' status is: {{ item.value }}"
   with_dict: "{{ vmtools_service_dict }}"
 
+- name: "Check 4 services in the list"
+  ansible.builtin.assert:
+    that:
+      - vmtools_service_dict | length == 4
+    fail_msg: "Expect 4 VMware services listed after VMware Tools install, while there are '{{ vmtools_service_dict | length }}' got."
+
 - name: "Set fact of expected usernames of VMware Tools processes"
   ansible.builtin.set_fact:
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -45,7 +45,7 @@
   ansible.builtin.assert:
     that:
       - vmtools_service_dict | length == 4
-    fail_msg: "Expect 4 VMware services listed after VMware Tools install, while there are '{{ vmtools_service_dict | length }}' got."
+    fail_msg: "Expect 4 VMware services in guest OS after VMware Tools install, while got '{{ vmtools_service_dict | length }}': {{ vmtools_service_dict.keys() | default('') }}"
 
 - name: "Set fact of expected usernames of VMware Tools processes"
   ansible.builtin.set_fact:

--- a/windows/wintools_uninstall_verify/prepare_pvscsi_vmxnet3_device.yml
+++ b/windows/wintools_uninstall_verify/prepare_pvscsi_vmxnet3_device.yml
@@ -10,34 +10,38 @@
     vm_has_pvscsi_ctl: false
     vm_has_vmxnet3_net: false
 
-# Check if boot disk controller is PVSCSI
-- name: "Set fact of VM with PVSCSI boot disk controller"
+# PVSCSI boot disk controller
+- name: "Set boot disk controller type to PVSCSI for new VM"
   ansible.builtin.set_fact:
     vm_has_pvscsi_boot_disk: true
   when:
     - new_vm is defined and new_vm | bool
     - boot_disk_controller is defined and boot_disk_controller == 'paravirtual'
-- name: "Get boot disk controller type for existing VM"
+
+- name: "Set boot disk controller type for existing VM"
   block:
-    - include_tasks: ../utils/win_get_boot_disk_ctl_type.yml
-    - name: "Set fact of VM with PVSCSI boot disk controller"
+    - name: "Get boot disk controller type in guest OS"
+      include_tasks: ../utils/win_get_boot_disk_ctl_type.yml
+    - name: "Set boot disk controller type to PVSCSI"
       ansible.builtin.set_fact:
         vm_has_pvscsi_boot_disk: true
       when:
         - win_boot_disk_ctl_type == 'paravirtual'
   when: new_vm is undefined or not new_vm | bool
 
-# If not PVSCSI boot disk controller
+# Not PVSCSI boot disk controller
 - name: "Check if VM has non-boot PVSCSI controller"
   block:
-    - include_tasks: ../utils/win_get_pvscsi_ctl_num.yml
+    - name: "Get PVSCSI controller number in guest OS"
+      include_tasks: ../utils/win_get_pvscsi_ctl_num.yml
     - name: "Set fact of VM has non-boot PVSCSI controller"
       ansible.builtin.set_fact:
         vm_has_pvscsi_ctl: true
       when: ctl_num_guest | int > 0
   when: not vm_has_pvscsi_boot_disk
 
-- include_tasks: ../utils/win_get_netadapter_num.yml
+- name: "Get network adatper number in guest OS"
+  include_tasks: ../utils/win_get_netadapter_num.yml
 - name: "Set fact of VM with VMXNET3 network adapter"
   ansible.builtin.set_fact:
     vm_has_vmxnet3_net: true
@@ -45,9 +49,10 @@
 
 # Add a new PVSCSI controller if it's not boot disk controller and
 # VM has no such device
-- name: "Add a new PVSCSI controller to VM"
+- name: "VM without PVSCSI controller"
   block:
-    - include_tasks: ../../common/vm_hot_add_remove_disk_ctrl.yml
+    - name: "Add a PVSCSI controller to VM"
+      include_tasks: ../../common/vm_hot_add_remove_disk_ctrl.yml
       vars:
         disk_controller_ops: "present"
         disk_controller_type: "paravirtual"
@@ -57,13 +62,16 @@
           - disk_controller_facts is defined
           - disk_controller_facts.changed
         fail_msg: "Add new PVSCSI controller task result 'changed' is not true."
+    - name: "Pause 10 seconds after adding PVSCSI controller"
+      ansible.builtin.pause:
+        seconds: 10
   when:
     - not vm_has_pvscsi_boot_disk
     - not vm_has_pvscsi_ctl
 
-# Add a new VMXNET3 network adapter if VM has no such device
-- include_tasks: add_new_vmxnet3_net_adapter.yml
+- name: "Add a VMXNET3 network adapter to VM"
+  include_tasks: add_new_vmxnet3_net_adapter.yml
   when: not vm_has_vmxnet3_net
 
-# Get loaded PVSCSI and VMXNET3 drivers info
-- include_tasks: get_pvscsi_vmxnet3_info.yml
+- name: "Get loaded PVSCSI and VMXNET3 drivers info"
+  include_tasks: get_pvscsi_vmxnet3_info.yml

--- a/windows/wintools_uninstall_verify/prepare_pvscsi_vmxnet3_device.yml
+++ b/windows/wintools_uninstall_verify/prepare_pvscsi_vmxnet3_device.yml
@@ -19,6 +19,7 @@
     - boot_disk_controller is defined and boot_disk_controller == 'paravirtual'
 
 - name: "Set boot disk controller type for existing VM"
+  when: new_vm is undefined or not new_vm | bool
   block:
     - name: "Get boot disk controller type in guest OS"
       include_tasks: ../utils/win_get_boot_disk_ctl_type.yml
@@ -27,10 +28,10 @@
         vm_has_pvscsi_boot_disk: true
       when:
         - win_boot_disk_ctl_type == 'paravirtual'
-  when: new_vm is undefined or not new_vm | bool
 
 # Not PVSCSI boot disk controller
 - name: "Check if VM has non-boot PVSCSI controller"
+  when: not vm_has_pvscsi_boot_disk
   block:
     - name: "Get PVSCSI controller number in guest OS"
       include_tasks: ../utils/win_get_pvscsi_ctl_num.yml
@@ -38,7 +39,6 @@
       ansible.builtin.set_fact:
         vm_has_pvscsi_ctl: true
       when: ctl_num_guest | int > 0
-  when: not vm_has_pvscsi_boot_disk
 
 - name: "Get network adatper number in guest OS"
   include_tasks: ../utils/win_get_netadapter_num.yml
@@ -50,6 +50,9 @@
 # Add a new PVSCSI controller if it's not boot disk controller and
 # VM has no such device
 - name: "VM without PVSCSI controller"
+  when:
+    - not vm_has_pvscsi_boot_disk
+    - not vm_has_pvscsi_ctl
   block:
     - name: "Add a PVSCSI controller to VM"
       include_tasks: ../../common/vm_hot_add_remove_disk_ctrl.yml
@@ -65,9 +68,6 @@
     - name: "Pause 10 seconds after adding PVSCSI controller"
       ansible.builtin.pause:
         seconds: 10
-  when:
-    - not vm_has_pvscsi_boot_disk
-    - not vm_has_pvscsi_ctl
 
 - name: "Add a VMXNET3 network adapter to VM"
   include_tasks: add_new_vmxnet3_net_adapter.yml


### PR DESCRIPTION
In some cases, there are only 2 services listed after VMware Tools install, causing can not get vmvss service status before doing quiesce snapshot. Here add a check for services number.