### PR TITLE
[Windows] Remove old base snapshot when reset base snapshot

### DIFF
--- a/windows/guest_os_inplace_upgrade/guest_os_inplace_upgrade.yml
+++ b/windows/guest_os_inplace_upgrade/guest_os_inplace_upgrade.yml
@@ -69,6 +69,8 @@
           include_tasks: check_after_gos_upgrade.yml
         - name: "Reset base snapshot"
           include_tasks: ../../common/reset_base_snapshot.yml
+          vars:
+            remove_old_base_snapshot: true
       rescue:
         - name: "Execute tasks when test failed"
           include_tasks: ../../common/test_rescue.yml

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -128,6 +128,8 @@
 
         - name: "Reset base snapshot"
           include_tasks: ../../common/reset_base_snapshot.yml
+          vars:
+            remove_old_base_snapshot: true
       rescue:
         - name: "Test case failure"
           include_tasks: ../../common/test_rescue.yml


### PR DESCRIPTION
Old base snapshot is not used anymore when testing proceeds and new base snapshot is created.