### PR TITLE
[OpenSUSE Leap] ovt_verify_install failed on opensuse-15.6-BETA-64bit

### DIFF
--- a/linux/open_vm_tools/install_ovt.yml
+++ b/linux/open_vm_tools/install_ovt.yml
@@ -13,7 +13,7 @@
   block:
     - name: "Add a local package repository from ISO image for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_local_dvd_repo.yml
-      when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'Rocky', 'AlmaLinux']
+      when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'Rocky', 'AlmaLinux', 'openSUSE Leap']
     - name: "Add online package repositories for {{ guest_os_ansible_distribution }}"
       include_tasks: ../utils/add_official_online_repo.yml
       when: guest_os_ansible_distribution in ['OracleLinux', 'Ubuntu']

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -107,7 +107,7 @@
   ansible.builtin.set_fact:
     dvd_repo_name: "{{ guest_os_ansible_distribution }}-{{ guest_os_ansible_distribution_ver }}-dvd"
 
-# Add repo from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux
+# Add repo from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux/openSUSE Leap
 - block:
     # Find the dir having repodata
     - name: "Find repodata in {{ guest_cdrom_mount_path }}"
@@ -131,4 +131,4 @@
       with_items: "{{ find_repodata_result.stdout_lines }}"
       loop_control:
         loop_var: repodata_path
-  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux']
+  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux', 'openSUSE Leap']

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -108,7 +108,9 @@
     dvd_repo_name: "{{ guest_os_ansible_distribution }}-{{ guest_os_ansible_distribution_ver }}-dvd"
 
 # Add repo from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux/openSUSE Leap
-- block:
+- name: "Add repo from CDROM for {{ guest_os_ansible_distribution }}"
+  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux', 'openSUSE Leap']
+  block:
     # Find the dir having repodata
     - name: "Find repodata in {{ guest_cdrom_mount_path }}"
       ansible.builtin.command: "find {{ guest_cdrom_mount_path }} -name repodata"
@@ -131,4 +133,3 @@
       with_items: "{{ find_repodata_result.stdout_lines }}"
       loop_control:
         loop_var: repodata_path
-  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux', 'openSUSE Leap']


### PR DESCRIPTION
**Issue:**
Raw Log:
2024-03-08 18:20:58,008 | Failed at Play [03_ovt_verify_install] *********************
2024-03-08 18:20:58,008 | TASK [03_ovt_verify_install][Assert command is executed successfully]
task path: /home/worker/workspace/Ansible_openSUSE_80GA_LSILOGICSAS_VMXNET3_BIOS/ansible-vsphere-gos-validation/linux/open_vm_tools/install_ovt.yml:46
fatal: [localhost]: FAILED! => Failed to install open-vm-tools by executing command: zypper install -y open-vm-tools open-vm-tools-desktop libvmtools0.
error message:
Failed to install open-vm-tools by executing command: zypper install -y open-vm-tools open-vm-tools-desktop libvmtools0."


**Resolution:**
Add DVD repo 

**Result**
<img width="578" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/e747a876-4c2d-4b33-a39f-3bcf5ffeb84c">



