### PR TITLE
[Windows] Skip VBS test for guest OS with lower hardware version

### DIFF
--- a/common/esxi_get_model.yml
+++ b/common/esxi_get_model.yml
@@ -21,7 +21,7 @@
   ansible.builtin.set_fact:
     esxi_model_info: "{{ esxi_host_property_results.ansible_facts.summary.hardware.vendor }} {{ esxi_host_property_results.ansible_facts.summary.hardware.model }}"
     esxi_cpu_model_info: "{{ esxi_host_property_results.ansible_facts.summary.hardware.cpuModel }}"
-    esxi_cpu_vendor: "{{ esxi_host_property_results.ansible_facts.hardware.cpuPkg[0].vendor | default('Unknown') }}"
+    esxi_cpu_vendor: "{{ esxi_host_property_results.ansible_facts.hardware.cpuPkg[0].vendor | default('Unknown') | lower }}"
 
 - name: "Get ESXi server CPU code name"
   when: esxi_cpu_vendor == 'intel'

--- a/common/esxi_get_model.yml
+++ b/common/esxi_get_model.yml
@@ -24,7 +24,7 @@
     esxi_cpu_vendor: "{{ esxi_host_property_results.ansible_facts.hardware.cpuPkg[0].vendor | default('Unknown') }}"
 
 - name: "Get ESXi server CPU code name"
-  when: esxi_cpu_vendor | lower == 'intel'
+  when: esxi_cpu_vendor == 'intel'
   block:
     - name: "Get ESXi server CPU code name"
       ansible.builtin.script: "../tools/query_cpu.py -n '{{ cpu_name }}'"

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -40,6 +40,18 @@
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
           vars:
+            skip_msg: >-
+              Skip test case due to using Intel CPUs for VBS requires vSphere 6.7 or later and using AMD CPUs for VBS
+              requires vSphere 7.0 Update 2 or later. 
+              Please refer to https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CE292D3F-D4AC-4607-B262-DE19CE6E9F6B.html
+          skip_reason: "Not Supported"
+          when: >-
+            (vm_hardware_version_num | int < 14 and esxi_cpu_model == "Intel") or
+            (vm_hardware_version_num | int < 19 and esxi_cpu_model == "AMD")
+
+        - name: "Skip test case"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
             skip_msg: >- 
               Skip test case due to the supported minimum OS version build on AMD server is 17763. The current OS version
               build is {{ guest_os_build_num }}. Please refer to https://kb.vmware.com/s/article/2009916.

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -29,14 +29,6 @@
             skip_reason: "Not Applicable"
           when: vm_firmware | lower != 'efi'
 
-        - name: "Set ESXi CPU model"
-          ansible.builtin.set_fact:
-            esxi_cpu_model: |-
-              {%- if 'AMD' in esxi_cpu_model_info -%}AMD
-              {%- elif 'Intel' in esxi_cpu_model_info -%}Intel
-              {%- else -%}Others
-              {%- endif -%}
-
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
           vars:
@@ -44,10 +36,10 @@
               Skip test case due to using Intel CPUs for VBS requires vSphere 6.7 or later and using AMD CPUs for VBS
               requires vSphere 7.0 Update 2 or later. 
               Please refer to https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CE292D3F-D4AC-4607-B262-DE19CE6E9F6B.html
-          skip_reason: "Not Supported"
+            skip_reason: "Not Supported"
           when: >-
-            (vm_hardware_version_num | int < 14 and esxi_cpu_model == "Intel") or
-            (vm_hardware_version_num | int < 19 and esxi_cpu_model == "AMD")
+            (vm_hardware_version_num | int < 14 and esxi_cpu_vendor | lower == "intel") or
+            (vm_hardware_version_num | int < 19 and esxi_cpu_vendor | lower == "amd")
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
@@ -57,7 +49,7 @@
               build is {{ guest_os_build_num }}. Please refer to https://kb.vmware.com/s/article/2009916.
             skip_reason: "Not Applicable"
           when:
-            - esxi_cpu_model == "AMD"
+            - esxi_cpu_vendor | lower == "amd"
             - guest_os_build_num | int < 17763
 
         - name: "VBS enable test"

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -33,13 +33,13 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case due to using Intel CPUs for VBS requires vSphere 6.7 or later and using AMD CPUs for VBS requires 
-              vSphere 7.0 Update 2 or later. Current CPU is {{ esxi_cpu_vendor }} and hardware version is {{ vm_hardware_version_num }}.
+              Skip test case due to using Intel CPUs for VBS requires hardware version 14 or higher and using AMD CPUs for VBS requires 
+              hardware version 19 or higher. Current CPU is {{ esxi_cpu_vendor }} and hardware version is {{ vm_hardware_version_num }}.
               Please refer to https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CE292D3F-D4AC-4607-B262-DE19CE6E9F6B.html
             skip_reason: "Not Supported"
           when: >-
-            (vm_hardware_version_num | int < 14 and esxi_cpu_vendor | lower == "intel") or
-            (vm_hardware_version_num | int < 19 and esxi_cpu_vendor | lower == "amd")
+            (vm_hardware_version_num | int < 14 and esxi_cpu_vendor == "intel") or
+            (vm_hardware_version_num | int < 19 and esxi_cpu_vendor == "amd")
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
@@ -49,7 +49,7 @@
               build is {{ guest_os_build_num }}. Please refer to https://kb.vmware.com/s/article/2009916.
             skip_reason: "Not Applicable"
           when:
-            - esxi_cpu_vendor | lower == "amd"
+            - esxi_cpu_vendor == "amd"
             - guest_os_build_num | int < 17763
 
         - name: "VBS enable test"

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -33,8 +33,8 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case due to using Intel CPUs for VBS requires vSphere 6.7 or later and using AMD CPUs for VBS
-              requires vSphere 7.0 Update 2 or later. 
+              Skip test case due to using Intel CPUs for VBS requires vSphere 6.7 or later and using AMD CPUs for VBS requires 
+              vSphere 7.0 Update 2 or later. Current CPU is {{ esxi_cpu_vendor }} and hardware version is {{ vm_hardware_version_num }}.
               Please refer to https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CE292D3F-D4AC-4607-B262-DE19CE6E9F6B.html
             skip_reason: "Not Supported"
           when: >-

--- a/windows/vbs_enable_disable/vbs_enable_test.yml
+++ b/windows/vbs_enable_disable/vbs_enable_test.yml
@@ -61,10 +61,10 @@
 - name: "Set expected security properties"
   ansible.builtin.set_fact:
     expected_security_properties: >-
-      {%- if esxi_cpu_vendor | lower == "intel" and guest_os_build_num | int == 10240 -%}
+      {%- if esxi_cpu_vendor == "intel" and guest_os_build_num | int == 10240 -%}
         {{ range(1, 4) | list }}
-      {%- elif (esxi_cpu_vendor | lower == "amd" and guest_os_build_num | int == 17763) or 
-        (esxi_cpu_vendor | lower == "intel" and guest_os_build_num | int == 14393) -%}
+      {%- elif (esxi_cpu_vendor == "amd" and guest_os_build_num | int == 17763) or 
+        (esxi_cpu_vendor == "intel" and guest_os_build_num | int == 14393) -%}
         {{ range(1, 7) | list }}
       {%- else -%}
         {{ range(1, 8) | list }}

--- a/windows/vbs_enable_disable/vbs_enable_test.yml
+++ b/windows/vbs_enable_disable/vbs_enable_test.yml
@@ -61,10 +61,10 @@
 - name: "Set expected security properties"
   ansible.builtin.set_fact:
     expected_security_properties: >-
-      {%- if esxi_cpu_model == "Intel" and guest_os_build_num | int == 10240 -%}
+      {%- if esxi_cpu_vendor | lower == "intel" and guest_os_build_num | int == 10240 -%}
         {{ range(1, 4) | list }}
-      {%- elif (esxi_cpu_model == "AMD" and guest_os_build_num | int == 17763) or 
-        (esxi_cpu_model == "Intel" and guest_os_build_num | int == 14393) -%}
+      {%- elif (esxi_cpu_vendor | lower == "amd" and guest_os_build_num | int == 17763) or 
+        (esxi_cpu_vendor | lower == "intel" and guest_os_build_num | int == 14393) -%}
         {{ range(1, 7) | list }}
       {%- else -%}
         {{ range(1, 8) | list }}


### PR DESCRIPTION
Using Intel CPUs for VBS requires vSphere 6.7 or later (HW14)
Using AMD CPUs for VBS equires vSphere 7.0 Update 2 or later (HW19)