### PR TITLE
[RHCOS] Fix systemd could not find the requested service 'firewalld.service'

### DIFF
--- a/linux/utils/disable_firewall.yml
+++ b/linux/utils/disable_firewall.yml
@@ -6,15 +6,17 @@
 - name: "Set fact of firewall service for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
     firewall_service_name: "firewalld.service"
-  when: guest_os_family in ["RedHat", "Suse"]
+  when:
+    - guest_os_family in ["RedHat", "Suse"]
+    - guest_os_ansible_distribution != 'RHCOS'
 
 - name: "Set fact of firewall service for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
     firewall_service_name: "ufw.service"
   when: guest_os_ansible_distribution == "Ubuntu"
 
-# Stop and disable firewall
-- include_tasks: service_operation.yml
+- name: "Stop and disable firewall service"
+  include_tasks: service_operation.yml
   vars:
     service_name: "{{ firewall_service_name }}"
     service_enabled: false


### PR DESCRIPTION
RHCOS's ansible family is `RedHat`, but it doesn't have firewalld service. So here excluded it from firewall service setting. This change is to fix network_device_ops testing failure like below:

```
Raw Log:
2024-03-26 14:40:24,026 | Failed at Play [2_vmxnet3_network_device_ops] **************
2024-03-26 14:40:24,026 | TASK [2_vmxnet3_network_device_ops][Update service firewalld.service, enabled: False, state: stopped] 
task path: /home/worker/workspace/Ansible_Cycle_RHCOS_OVA/ansible-vsphere-gos-validation/linux/utils/service_operation.yml:17
fatal: [localhost -> x.x.x.x]: FAILED! => systemd could not find the requested service ""'firewalld.service'"": 
error message:
systemd could not find the requested service ""'firewalld.service'"":
```

Test passed with this fix
```
+-----------------------------------------------------------------+
| Guest OS Distribution     | RHCOS 4.15 x86_64                   |
+-----------------------------------------------------------------+


Test Results (Total: 4, Passed: 3, Skipped: 1, Elapsed Time: 00:19:59)
+---------------------------------------------------------------+
| ID | Name                       |   Status        | Exec Time |
+---------------------------------------------------------------+
|  1 | deploy_vm_ova              |   Passed        | 00:09:20  |
|  2 | ovt_verify_install         | * Not Supported | 00:01:15  |
|  3 | e1000e_network_device_ops  |   Passed        | 00:04:49  |
|  4 | vmxnet3_network_device_ops |   Passed        | 00:03:22  |
+---------------------------------------------------------------+
```