### PR TITLE
[Linux] Increase video memory to 8MB for Ubuntu desktop VM

### DIFF
--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -87,8 +87,8 @@
   ansible.builtin.set_fact:
     vm_video_memory_mb: 8
   when:
-    - unattend_installer in ['RHEL', 'SLE']
-    - unattend_install_conf | lower is not match('.*(minimal|server_without_gui).*')
+    - unattend_installer in ['RHEL', 'SLE', 'Ubuntu-Ubiquity', 'Ubuntu-Subiquity']
+    - unattend_install_conf | lower is not search('minimal|server_without_gui|ubuntu/server')
 
 - name: "Set video memory size"
   when: vm_video_memory_mb


### PR DESCRIPTION
Default video memory is only 4 MB, which could cause Ubuntu failed to launch the display manager. Increase it to 8MB.

```
+-------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                          |
|                           | bitness='64'                                |
|                           | distroAddlVersion='23.10 (Mantic Minotaur)' |
|                           | distroName='Ubuntu'                         |
|                           | distroVersion='23.10'                       |
|                           | familyName='Linux'                          |
|                           | kernelVersion='6.5.0-26-generic'            |
|                           | prettyName='Ubuntu 23.10'                   |
+-------------------------------------------------------------------------+


Test Results (Total: 3, Passed: 3, Elapsed Time: 00:35:12)
+-------------------------------------------------------------+
| ID | Name                              | Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:24:14  |
|  2 | ovt_verify_install                | Passed | 00:07:33  |
|  3 | ovt_verify_status                 | Passed | 00:03:05  |
+-------------------------------------------------------------+
```