### PR TITLE
[Linux] update get_system_firmware.yml to get system firmware for FreeBSD

### DIFF
--- a/common/get_guest_system_info.yml
+++ b/common/get_guest_system_info.yml
@@ -1,7 +1,7 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get guest system info when it's not defined before
+# Get guest OS system info when it's not defined before
 # Note:
 #   For Debian 10.x and 11.x, its 'ansible_distribution_version' only shows major version,
 # minor version can be retrieved from 'ansible_distribution_minor_version'.
@@ -10,13 +10,14 @@
 #   For Windows guest, there is no 'ansible_distribution_release' in guest_system_info,
 # will display 'N/A'.
 #
-- name: "Initialize the facts of guest system info"
+- name: "Initialize the facts of guest OS system info"
   ansible.builtin.set_fact:
     guest_os_ansible_distribution_ver: ''
     guest_os_ansible_distribution_major_ver: ''
     guest_os_ansible_distribution_minor_ver: ''
 
-- include_tasks: get_system_info.yml
+- name: "Get guest OS system info"
+  include_tasks: get_system_info.yml
   vars:
     filter:
       - 'ansible_architecture'
@@ -32,7 +33,7 @@
 - name: "Set facts of guest OS system info"
   ansible.builtin.set_fact:
     guest_os_ansible_distribution: "{{ guest_system_info.ansible_distribution | default('') }}"
-    guest_os_ansible_system: "{{ guest_system_info.ansible_system | default('') }}"
+    guest_os_ansible_system: "{{ guest_system_info.ansible_system | default('') | lower }}"
     guest_os_ansible_architecture: "{{ guest_system_info.ansible_architecture | default('') }}"
     guest_os_ansible_distribution_ver: "{{ guest_system_info.ansible_distribution_version if guest_system_info.ansible_distribution != 'FreeBSD' else guest_system_info.ansible_kernel }}"
     guest_os_ansible_distribution_major_ver: "{{ guest_system_info.ansible_distribution_major_version if 'ansible_distribution_major_version' in guest_system_info else guest_system_info.ansible_distribution_release.split('-')[0].split('.')[0] }}"

--- a/linux/check_efi_firmware/check_efi_firmware.yml
+++ b/linux/check_efi_firmware/check_efi_firmware.yml
@@ -38,7 +38,7 @@
           ansible.builtin.assert:
             that:
               - vm_wait_log_msg_success | bool
-              - guest_firmware == "EFI"
+              - guest_firmware_is_efi
             fail_msg: "Failed to find EFI ROM info in vmware.log or guest OS firmware is not EFI."
             success_msg: "Found EFI ROM info in vmware.log, and guest OS firmware is EFI."
       rescue:

--- a/linux/utils/get_system_firmware.yml
+++ b/linux/utils/get_system_firmware.yml
@@ -1,13 +1,13 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Get system firmware
+# Get guest OS system firmware is EFI or not
 # Return:
-#   guest_firmware: EFI or BIOS
+#   guest_firmware_is_efi: return true if the system firmware is EFI, otherwise return false.
 #
-- name: "Initialize the fact of guest OS system firmware"
+- name: "Initialize the fact of guest OS system firmware is EFI or not"
   ansible.builtin.set_fact:
-    guest_firmware: ""
+    guest_firmware_is_efi: false
 
 - name: "Get firmware for Linux system"
   when: guest_os_ansible_system == "linux"
@@ -17,9 +17,10 @@
       vars:
         guest_file_path: "/sys/firmware/efi"
 
-    - name: "Set fact of guest OS system firmware"
+    - name: "Set fact that guest OS system firmware is EFI"
       ansible.builtin.set_fact:
-        guest_firmware: "{{ 'EFI' if guest_file_exists | bool else 'BIOS' }}"
+        guest_firmware_is_efi: true
+      when: guest_file_exists | bool
 
 - name: "Get firmware for FreeBSD system"
   when: guest_os_ansible_system == "freebsd"
@@ -30,6 +31,9 @@
       ignore_errors: true
       register: kldstat_efirt_result
 
-    - name: "Set fact of guest OS system firmware"
+    - name: "Set fact that guest OS system firmware is EFI"
       ansible.builtin.set_fact:
-        guest_firmware: "{{ 'EFI' if kldstat_efirt_result.rc is defined and kldstat_efirt_result.rc == 0 else 'BIOS' }}"
+        guest_firmware_is_efi: true
+      when: 
+        - kldstat_efirt_result.rc is defined
+        - kldstat_efirt_result.rc == 0

--- a/linux/utils/get_system_firmware.yml
+++ b/linux/utils/get_system_firmware.yml
@@ -5,17 +5,31 @@
 # Return:
 #   guest_firmware: EFI or BIOS
 #
-- name: "Check /sys/firmware/efi existence"
-  include_tasks: get_file_stat_info.yml
-  vars:
-    guest_file_path: "/sys/firmware/efi"
-
-- name: "System firmware is EFI"
+- name: "Initialize the fact of guest OS system firmware"
   ansible.builtin.set_fact:
-    guest_firmware: "EFI"
-  when: guest_file_exists | bool
+    guest_firmware: ""
 
-- name: "System firmware is BIOS"
-  ansible.builtin.set_fact:
-    guest_firmware: "BIOS"
-  when: not (guest_file_exists | bool)
+- name: "Get firmware for Linux system"
+  when: guest_os_ansible_system == "linux"
+  block:
+    - name: "Check /sys/firmware/efi existence"
+      include_tasks: get_file_stat_info.yml
+      vars:
+        guest_file_path: "/sys/firmware/efi"
+
+    - name: "Set fact of guest OS system firmware"
+      ansible.builtin.set_fact:
+        guest_firmware: "{{ 'EFI' if guest_file_exists | bool else 'BIOS' }}"
+
+- name: "Get firmware for FreeBSD system"
+  when: guest_os_ansible_system == "freebsd"
+  block:
+    - name: "Check 'efirt' module is loaded or not"
+      ansible.builtin.shell: "kldstat -m efirt"
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: true
+      register: kldstat_efirt_result
+
+    - name: "Set fact of guest OS system firmware"
+      ansible.builtin.set_fact:
+        guest_firmware: "{{ 'EFI' if kldstat_efirt_result.rc is defined and kldstat_efirt_result.rc == 0 else 'BIOS' }}"


### PR DESCRIPTION
FreeBSD doesn't have `/sys/firmware/efi`, but can check `efirt` is loaded if system firmware is EFI. So, this fix is to set `guest_firmware` for FreeBSD.

Test passed:
```
+----------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'           |
|                           | bitness='64'                 |
|                           | distroName='FreeBSD'         |
|                           | familyName='FreeBSD'         |
|                           | kernelVersion='13.3-RELEASE' |
+----------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:01:10)
+----------------------------------------------+
| ID | Name               | Status | Exec Time |
+----------------------------------------------+
|  1 | check_efi_firmware | Passed | 00:00:52  |
+----------------------------------------------+
```