### PR TITLE
[Linux] Skip disabling firewalld.service for Amazon Linux

### DIFF
--- a/linux/utils/disable_firewall.yml
+++ b/linux/utils/disable_firewall.yml
@@ -8,7 +8,7 @@
     firewall_service_name: "firewalld.service"
   when:
     - guest_os_family in ["RedHat", "Suse"]
-    - guest_os_ansible_distribution != 'RHCOS'
+    - guest_os_ansible_distribution not in ['RHCOS', 'Amazon']
 
 - name: "Set fact of firewall service for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:


### PR DESCRIPTION
Amazon Linux doesn't have firewalld.service either. So no need to disable firewalld.service on Amazon Linux.
```
+---------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                            |
|                           | bitness='64'                                  |
|                           | cpeString='cpe:2.3:o:amazon:amazon_linux:2'   |
|                           | distroAddlVersion='2'                         |
|                           | distroName='Amazon Linux'                     |
|                           | distroVersion='2'                             |
|                           | familyName='Linux'                            |
|                           | kernelVersion='4.14.322-246.539.amzn2.x86_64' |
|                           | prettyName='Amazon Linux 2'                   |
+---------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 2, Elapsed Time: 01:39:01)
+------------------------------------------------------+
| ID | Name                       | Status | Exec Time |
+------------------------------------------------------+
|  1 | e1000e_network_device_ops  | Passed | 00:54:05  |
|  2 | vmxnet3_network_device_ops | Passed | 00:44:04  |
+------------------------------------------------------+
```