### PR TITLE
[Linux] Update packagelist_file in VMware Photon OS kickstart

### DIFF
--- a/autoinstall/Photon/ks.cfg
+++ b/autoinstall/Photon/ks.cfg
@@ -5,7 +5,7 @@
         "text": "{{ vm_password_hash }}"
         },
     "disk": "/dev/{{ boot_disk_name }}",
-    "packagelist_file": "packages_ova.json",
+    "packagelist_file": "packages_minimal.json",
     "arch": "x86_64",
     "additional_packages": ["vim","gawk","sudo","tar", "ndctl", "python3-rpm"],
     "linux_flavor": "linux-esx",


### PR DESCRIPTION
The package list file "packages_ova.json" was removed from VMware Photon OS 5.0 daily build. This fix replaced it with "packages_minimal.json".