### PR TITLE
[CentOS Stream] support centOS Stream in ansible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 |:-------------------------------------------------------| :------------------------------: | :----------------------: | :--------------------------------: |
 | Red Hat Enterprise Linux 7.x, 8.x, 9.x                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| CentOS Stream 9.x                                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| CentOS Stream 8, 9                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 |:-------------------------------------------------------| :------------------------------: | :----------------------: | :--------------------------------: |
 | Red Hat Enterprise Linux 7.x, 8.x, 9.x                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| CentOS Stream 9.x                                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -27,7 +27,7 @@
 26. For FusionOS 22 unattend auto-install, please use files under Fusion.
 27. For FusionOS 23 unattend auto-install, please use file Fusion/server_without_GUI/ks.cfg.
 28. For Kylin Linux Advanced Server V10 unattend auto-install, please use file Kylin/Server/10/ks.cfg.
-29. For CentOS Stream 9.x or later unattend auto-install, please use files under RHEL/8.
+29. For CentOS Stream 8 or later unattend auto-install, please use files under RHEL/8.
 
 # Notes
 ## For Windows

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -27,6 +27,7 @@
 26. For FusionOS 22 unattend auto-install, please use files under Fusion.
 27. For FusionOS 23 unattend auto-install, please use file Fusion/server_without_GUI/ks.cfg.
 28. For Kylin Linux Advanced Server V10 unattend auto-install, please use file Kylin/Server/10/ks.cfg.
+29. For CentOS Stream 9.x or later unattend auto-install, please use files under RHEL/8.
 
 # Notes
 ## For Windows

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -26,6 +26,8 @@
     guest_os_ansible_distribution is match('Pardus.*') or
     (guest_os_ansible_distribution == 'MIRACLE' and 
       guest_os_ansible_distribution_major_ver | int == 8) or
+    (guest_os_ansible_distribution == 'CentOS' and 
+      guest_os_ansible_distribution_release is defined and guest_os_ansible_distribution_release == 'Stream') or
     (guest_os_ansible_distribution in ["Astra Linux (Orel)", "ProLinux", "UnionTech", "Uos", "FreeBSD", "BigCloud", "FusionOS", "Kylin Linux Advanced Server"])
 
 - name: "Skip test case for OS version which has vulnerable bootloaders"


### PR DESCRIPTION
Task:
support centOS Stream in ansible.

Result:
1) passed to test CentOS-Stream-9-x86_64-latest-dvd1.iso  with RHEL/8/server_with_GUI/ks.cfg and EFI firmware
<img width="605" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/7e0a8cbb-e082-4f2c-a619-8ec4ad335f8c">

2) passed to test CentOS-Stream-9-x86_64-latest-dvd1.iso  with RHEL/8/server_without_GUI/ks.cfg and EFI firmware
<img width="605" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/7e0a8cbb-e082-4f2c-a619-8ec4ad335f8c">

3) passed to test CentOS-Stream-9-x86_64-latest-dvd1.iso with RHEL/8/server_with_GUI/ks.cfg and bios firmware
<img width="673" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/f42badfb-7e71-44b8-90bb-be54210d4e6b">



4) passed to test CentOS-Stream-8-x86_64-latest-dvd1.iso  with RHEL/8/server_with_GUI/ks.cfg and bios firmware
<img width="644" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/ce7d196c-a38a-4bdb-ae1d-5ccfaa522e44">



5) passed to test CentOS-Stream-8-x86_64-latest-dvd1.iso  with RHEL/8/server_without_GUI/ks.cfg and EFI firmware
<img width="710" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/26d9a0e3-8975-4ec6-ab00-b0e725cfb12a">
