### PR TITLE
Update guestinfo_detailed_data on newer vSphere with latest VMware Tools

### DIFF
--- a/common/vm_get_guest_info.yml
+++ b/common/vm_get_guest_info.yml
@@ -20,7 +20,9 @@
     guestinfo_guest_full_name: "{{ vm_guestinfo.instance.guest.guestFullName }}"
     guestinfo_guest_family: "{{ vm_guestinfo.instance.guest.guestFamily }}"
     guestinfo_detailed_data: |-
-      {%- if vm_extra_config is defined -%}
+      {%- if vm_guestinfo.instance.guest.guestDetailedData is defined and vm_guestinfo.instance.guest.guestDetailedData -%}
+          {{ vm_guestinfo.instance.guest.guestDetailedData | replace('\"', '') }}
+      {%- elif vm_extra_config is defined -%}
           {%- if 'guestOS.detailed.data' in vm_extra_config -%}{{ vm_extra_config['guestOS.detailed.data'] | replace('\"', '') }}
           {%- elif 'guestInfo.detailed.data' in vm_extra_config -%}{{ vm_extra_config['guestInfo.detailed.data'] | replace('\"', '') }}
           {%- endif -%}


### PR DESCRIPTION
VM with latest VMware Tools on newer vSphere (looks like 8.0U2) post the detailed data to guest info instead of VM extra config. This fix is to set `guestinfo_detailed_data` with  `vm_guestinfo.instance.guest.guestDetailedData` if it is not empty.