### PR TITLE
[FreeBSD 13 32bit] Fix autoinstall failure due to no kde5 package from quarterly repo

### DIFF
--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -81,8 +81,8 @@ rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
 mkdir -p /usr/local/etc/pkg/repos
-cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
-FreeBSD: {
+cat >/usr/local/etc/pkg/repos/FreeBSD_latest.conf <<EOF
+FreeBSD_latest: {
     url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest",
     mirror_type: "srv",
     signature_type: "fingerprints",

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -80,7 +80,6 @@ done
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
-{% if guest_id.find('64Guest') == -1 %}
 mkdir -p /usr/local/etc/pkg/repos
 cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
 FreeBSD: {
@@ -91,7 +90,6 @@ FreeBSD: {
     enabled: yes
 }
 EOF
-{% endif %}
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -78,6 +78,19 @@ done
 
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
+
+# Modify the offical repo to latest
+mkdir -p /usr/local/etc/pkg/repos
+cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
+FreeBSD: {
+    url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
+    mirror_type: "srv",
+    signature_type: "fingerprints",
+    fingerprints: "/usr/share/keys/pkg",
+    enabled: yes
+}
+EOF
+
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 for package_to_install in $packages_to_install

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -80,16 +80,18 @@ done
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
+{% if guest_id.find('64Guest') == -1 %}
 mkdir -p /usr/local/etc/pkg/repos
 cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
 FreeBSD: {
-    url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
+    url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest",
     mirror_type: "srv",
     signature_type: "fingerprints",
     fingerprints: "/usr/share/keys/pkg",
     enabled: yes
 }
 EOF
+{% endif %}
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'


### PR DESCRIPTION
Issue:
[FreeBSD 13 32bit] autoinstall is failed due to not to get kde5 package from repo


Result:
+----------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'           |
|                           | bitness='32'                 |
|                           | distroName='FreeBSD'         |
|                           | familyName='FreeBSD'         |
|                           | kernelVersion='13.3-RELEASE' |
+----------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:45:45)
+-------------------------------------------------------+
| ID | Name                        | Status | Exec Time |
+-------------------------------------------------------+
|  1 | deploy_vm_bios_nvme_vmxnet3 | Passed | 00:45:26  |
+-------------------------------------------------------+

