### PR TITLE
[Windows] Fix OS in-place upgrade issues from Windows Server 2012 R2 and Windows Server 2016

### DIFF
--- a/windows/guest_os_inplace_upgrade/check_after_gos_upgrade.yml
+++ b/windows/guest_os_inplace_upgrade/check_after_gos_upgrade.yml
@@ -3,7 +3,7 @@
 ---
 - name: "Set fact of expected guest OS distribution"
   ansible.builtin.set_fact:
-    win_distr_expected: "{{ 'Microsoft ' ~ win_image_name | regex_search('(Windows|Windows Server) ([0-9]+)') ~ ' ' ~ guest_os_edition }}"
+    win_distr_expected: "{{ 'Microsoft ' ~ win_image_name | regex_search('Windows( Server)? ([0-9]+)') ~ ' ' ~ guest_os_edition }}"
 
 - name: "Get VMTools service status in guest OS"
   include_tasks: ../utils/win_get_service_status.yml

--- a/windows/guest_os_inplace_upgrade/check_after_gos_upgrade.yml
+++ b/windows/guest_os_inplace_upgrade/check_after_gos_upgrade.yml
@@ -3,7 +3,7 @@
 ---
 - name: "Set fact of expected guest OS distribution"
   ansible.builtin.set_fact:
-    win_distr_expected: "{{ 'Microsoft ' ~ win_image_name.split('(')[0].strip() }}"
+    win_distr_expected: "{{ 'Microsoft ' ~ win_image_name | regex_search('(Windows|Windows Server) ([0-9]+)') ~ ' ' ~ guest_os_edition }}"
 
 - name: "Get VMTools service status in guest OS"
   include_tasks: ../utils/win_get_service_status.yml

--- a/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
+++ b/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
@@ -67,7 +67,7 @@
 
 - name: "Set fact of Windows Server image keyword"
   ansible.builtin.set_fact:
-    win_upgrade_image_keyword: ".*{{ guest_os_edition }}.*Desktop.*|.*SERVER{{ guest_os_edition | higher }}$"
+    win_upgrade_image_keyword: ".*{{ guest_os_edition }}.*Desktop.*|.*SERVER{{ guest_os_edition | upper }}$"
   when: guest_os_product_type | lower == 'server'
 - name: "Set fact of Windows Client image keyword"
   ansible.builtin.set_fact:

--- a/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
+++ b/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
@@ -67,7 +67,7 @@
 
 - name: "Set fact of Windows Server image keyword"
   ansible.builtin.set_fact:
-    win_upgrade_image_keyword: "*{{ guest_os_edition }} (Desktop Experience)"
+    win_upgrade_image_keyword: ".*{{ guest_os_edition }} \(Desktop Experience\)$|.*SERVER{{ guest_os_edition | higher }}$"
   when: guest_os_product_type | lower == 'server'
 - name: "Set fact of Windows Client image keyword"
   ansible.builtin.set_fact:

--- a/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
+++ b/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
@@ -38,7 +38,7 @@
 - name: "Get CDROM drive mounted with ISO image"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "(Get-Volume | where-object {$_.DriveType -eq 'CD-ROM' -and $_.OperationalStatus -eq 'OK'}).DriveLetter"
+    win_powershell_cmd: "(Get-Volume | where-object {$_.DriveType -eq 'CD-ROM' -and $_.Size -ne 0}).DriveLetter"
 - name: "Set fact of mounted drive in guest OS"
   ansible.builtin.set_fact:
     upgrade_to_iso_drive: "{{ win_powershell_cmd_output.stdout_lines[0] }}"

--- a/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
+++ b/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
@@ -67,7 +67,7 @@
 
 - name: "Set fact of Windows Server image keyword"
   ansible.builtin.set_fact:
-    win_upgrade_image_keyword: ".*{{ guest_os_edition }} \(Desktop Experience\)$|.*SERVER{{ guest_os_edition | higher }}$"
+    win_upgrade_image_keyword: ".*{{ guest_os_edition }}.*Desktop.*|.*SERVER{{ guest_os_edition | higher }}$"
   when: guest_os_product_type | lower == 'server'
 - name: "Set fact of Windows Client image keyword"
   ansible.builtin.set_fact:

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -33,10 +33,11 @@
   block:
     - name: "Set fact of Windows guest OS edition info"
       ansible.builtin.set_fact:
-        guest_os_edition_info: "{{ guest_os_ansible_distribution | regex_search('Microsoft Windows( Server)? ([0-9]+) (.*)', '\\3') }}"
+        guest_os_edition_info: >-
+          {{ guest_os_ansible_distribution | regex_search('Microsoft Windows( Server)? ([0-9]+) (R2 )?(.*)', '\4') }}
     - name: "Set fact of Windows guest OS edition info"
       ansible.builtin.set_fact:
-        guest_os_edition: "{{ guest_os_edition_info[0].split(' ')[-1] }}"
+        guest_os_edition: "{{ guest_os_edition_info[0].strip() }}"
       when: guest_os_edition_info and guest_os_edition_info | length > 0
   when: guest_os_ansible_distribution
 

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -33,10 +33,10 @@
   block:
     - name: "Set fact of Windows guest OS edition info"
       ansible.builtin.set_fact:
-        guest_os_edition_info: "{{ guest_os_ansible_distribution | regex_search('Microsoft (Windows|Windows Server) ([0-9]+) (.*)', '\\3') }}"
+        guest_os_edition_info: "{{ guest_os_ansible_distribution | regex_search('Microsoft Windows( Server)? ([0-9]+) (.*)', '\\3') }}"
     - name: "Set fact of Windows guest OS edition info"
       ansible.builtin.set_fact:
-        guest_os_edition: "{{ guest_os_edition_info[0].split(' ')[0] }}"
+        guest_os_edition: "{{ guest_os_edition_info[0].split(' ')[-1] }}"
       when: guest_os_edition_info and guest_os_edition_info | length > 0
   when: guest_os_ansible_distribution
 

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -30,15 +30,9 @@
     - (guest_os_product_type | lower == 'server' and guest_os_build_num | int >= 20348) or (guest_os_product_type | lower == 'client' and guest_os_build_num | int >= 22449)
 
 - name: "Get Windows guest OS edition from distribution info"
-  block:
-    - name: "Set fact of Windows guest OS edition info"
-      ansible.builtin.set_fact:
-        guest_os_edition_info: >-
-          {{ guest_os_ansible_distribution | regex_search('Microsoft Windows( Server)? ([0-9]+) (R2 )?(.*)', '\4') }}
-    - name: "Set fact of Windows guest OS edition info"
-      ansible.builtin.set_fact:
-        guest_os_edition: "{{ guest_os_edition_info[0].strip() }}"
-      when: guest_os_edition_info and guest_os_edition_info | length > 0
+  ansible.builtin.set_fact:
+    guest_os_edition: >-
+      {{ guest_os_ansible_distribution | regex_search('Microsoft Windows( Server)? ([0-9]+) (R2 )?(.*)', '\4') | first }}
   when: guest_os_ansible_distribution
 
 - name: "Print Windows guest OS information"

--- a/windows/utils/win_get_driver_installer.yml
+++ b/windows/utils/win_get_driver_installer.yml
@@ -24,19 +24,26 @@
       {%- elif win_get_driver_installer_name == 'vmxnet3' -%}vmxnet3ndis6
       {%- else -%}{%- endif -%}
 
+# Get-ItemPropertyValue cmdlet is not contained in Windows Server 2012 R2
 - name: "Get driver installer registry info"
   include_tasks: win_execute_cmd.yml
   vars:
     win_powershell_cmd: |-
       if ($(Test-Path -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}")) {
-          Get-ItemPropertyValue -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}" -Name 'vwdk.installers'
+        reg query "HKLM\System\CurrentControlSet\Services\{{ win_driver_service }}" /v 'vwdk.installers' | findstr 'REG'
       }
+
+#   win_powershell_cmd: |-
+#     if ($(Test-Path -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}")) {
+#         Get-ItemPropertyValue -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}" -Name 'vwdk.installers'
+#     }
+
 - name: "Set fact of the driver installer info list"
   ansible.builtin.set_fact:
-    win_driver_installer_list: "{{ win_powershell_cmd_output.stdout_lines | select }}"
+    win_driver_installer_list: "{{ win_powershell_cmd_output.stdout_lines[0].split(' ')[-1] }}"
   when:
     - win_powershell_cmd_output.stdout_lines is defined
-    - win_powershell_cmd_output.stdout_lines | length != 0
+    - win_powershell_cmd_output.stdout_lines | length == 1
 
 - name: "Display the driver installer info list"
   ansible.builtin.debug:

--- a/windows/utils/win_get_driver_installer.yml
+++ b/windows/utils/win_get_driver_installer.yml
@@ -33,11 +33,6 @@
         reg query "HKLM\System\CurrentControlSet\Services\{{ win_driver_service }}" /v 'vwdk.installers' | findstr 'REG'
       }
 
-#   win_powershell_cmd: |-
-#     if ($(Test-Path -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}")) {
-#         Get-ItemPropertyValue -Path "HKLM:\System\CurrentControlSet\Services\{{ win_driver_service }}" -Name 'vwdk.installers'
-#     }
-
 - name: "Set fact of the driver installer info list"
   ansible.builtin.set_fact:
     win_driver_installer_list: "{{ win_powershell_cmd_output.stdout_lines[0].split(' ')[-1] }}"

--- a/windows/utils/win_get_image_index.yml
+++ b/windows/utils/win_get_image_index.yml
@@ -26,6 +26,11 @@
     win_image_index: ''
     win_image_name: ''
 
+- name: "Get Windows image info"
+  include_tasks: ../utils/win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: "Get-WindowsImage -ImagePath {{ win_image_file_path }}"
+
 - name: "Get matched Windows image info"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:

--- a/windows/utils/win_get_image_index.yml
+++ b/windows/utils/win_get_image_index.yml
@@ -34,7 +34,7 @@
 - name: "Get matched Windows image info"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "(Get-WindowsImage -ImagePath {{ win_image_file_path }} | where-object {$_.ImageName -like '{{ win_image_keyword }}'}) | select ImageIndex, ImageName | ft -hide"
+    win_powershell_cmd: "(Get-WindowsImage -ImagePath {{ win_image_file_path }} | where-object {$_.ImageName -match '{{ win_image_keyword }}'}) | select ImageIndex, ImageName | ft -hide"
 
 - name: "Set fact of Windows image list"
   block:

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -31,7 +31,7 @@
   ansible.windows.win_shell: "{{ vmtools_install_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   ignore_errors: true
-  become: "{{ true if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else false }}"
+  become: "{{ 'Windows Server 2012 R2' in guest_os_ansible_distribution }}"
   become_method: runas
   become_user: "{{ 'Administrator' if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else omit }}"
   register: wintools_install_result

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -29,6 +29,9 @@
   ansible.windows.win_shell: "{{ vmtools_install_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   ignore_errors: true
+  become: true
+  become_method: runas
+  become_user: Administrator
   register: wintools_install_result
   async: 600
   poll: 0

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -25,13 +25,15 @@
     fail_msg: "VMware Tools installation setup files are not in D:\\"
     success_msg: "VMware Tools installation setup files are in D:\\"
 
+# In Windows Server 2012 R2 guest OS, need to set 'become' to run
+# VMware Tools install command
 - name: "Execute VMware Tools silent install command in guest"
   ansible.windows.win_shell: "{{ vmtools_install_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   ignore_errors: true
-  become: true
+  become: "{{ true if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else false }}"
   become_method: runas
-  become_user: Administrator
+  become_user: "{{ 'Administrator' if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else omit }}"
   register: wintools_install_result
   async: 600
   poll: 0

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -77,12 +77,17 @@
       Get usernames of 'vmtoolsd' processes:
       {{ win_powershell_cmd_output.stdout_lines }}.
 
-- name: "Get problem device after VMware Tools install"
-  include_tasks: ../utils/win_get_problem_device.yml
-- name: "Check no problem device listed"
-  ansible.builtin.assert:
-    that:
-      - gos_has_problem_device is defined
-      - not gos_has_problem_device
-    fail_msg: "Problem devices were found in guest OS, please check listed problem devices: {{ gos_problem_device_list }}"
-    success_msg: "No problem device is found in guest OS."
+# In Windows Server 2012 R2 or older OS there is no cmdlet 'Get-PnpDevice',
+# so here only check in newer OS
+- name: "Check if there is problem device in Device Manager"
+  when: guest_os_ansible_distribution_ver is version('6.3.9600.0', '>')
+  block:
+    - name: "Get problem device after VMware Tools install"
+      include_tasks: ../utils/win_get_problem_device.yml
+    - name: "Check no problem device listed"
+      ansible.builtin.assert:
+        that:
+          - gos_has_problem_device is defined
+          - not gos_has_problem_device
+        fail_msg: "Problem devices were found in guest OS, please check listed problem devices: {{ gos_problem_device_list }}"
+        success_msg: "No problem device is found in guest OS."


### PR DESCRIPTION
In Windows Server 2012 R2 or 2016 guest OS, get Windows Server 2025 image info as below:
```
TASK [Execute PowerShell command] **********************************************
task path: /home/worker/workspace/Ansible_Windows_Server_LTSC_Upgrade2016_MAIN_NVME_E1000E_EFI/ansible-vsphere-gos-validation/windows/utils/win_execute_cmd.yml:23
changed: [localhost -> test_vm] => {
    "changed": true,
    "cmd": "Get-WindowsImage -ImagePath D:\\sources\\install.wim",
    "delta": "0:00:21.125000",
    "end": "2024-05-10 09:50:20.468477",
    "rc": 0,
    "start": "2024-05-10 09:49:59.343477",
    "stderr": "",
    "stderr_lines": [],
....
    "stdout_lines": [
        "",
        "",
        "ImageIndex       : 1",
        "ImageName        : Windows Server 2025 SERVERSTANDARDCORE",
        "ImageDescription : Windows Server 2025 SERVERSTANDARDCORE",
        "ImageSize        : 8,953,831,686 bytes",
        "",
        "ImageIndex       : 2",
        "ImageName        : Windows Server 2025 SERVERSTANDARD",
        "ImageDescription : Windows Server 2025 SERVERSTANDARD",
        "ImageSize        : 18,945,747,354 bytes",
        "",
        "ImageIndex       : 3",
        "ImageName        : Windows Server 2025 SERVERDATACENTERCORE",
        "ImageDescription : Windows Server 2025 SERVERDATACENTERCORE",
        "ImageSize        : 8,949,864,520 bytes",
        "",
        "ImageIndex       : 4",
        "ImageName        : Windows Server 2025 SERVERDATACENTER",
        "ImageDescription : Windows Server 2025 SERVERDATACENTER",
        "ImageSize        : 18,946,223,263 bytes",
        "",
        "",
        ""
    ]
```