### PR TITLE
[FreeBSD 32bit] Remove kde5 for FreeBSD 13&14 32bit

### DIFF
--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -81,8 +81,8 @@ rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
 mkdir -p /usr/local/etc/pkg/repos
-cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
-FreeBSD: {
+cat >/usr/local/etc/pkg/repos/FreeBSD_latest.conf <<EOF
+FreeBSD_latest: {
     url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest",
     mirror_type: "srv",
     signature_type: "fingerprints",

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -81,9 +81,9 @@ rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
 mkdir -p /usr/local/etc/pkg/repos
-cat >/usr/local/etc/pkg/repos/FreeBSD_latest.conf <<EOF
-FreeBSD_latest: {
-    url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest",
+cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
+FreeBSD: {
+    url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
     mirror_type: "srv",
     signature_type: "fingerprints",
     fingerprints: "/usr/share/keys/pkg",

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -92,12 +92,14 @@ FreeBSD_latest: {
 EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-echo "MACHTYPE: $MACHTYPE"
-{% if MACHTYPE.find('64') != -1 %}
-packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
-{% else %}
-packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
-{% endif %}
+machtype=$(uname -m)
+echo "Machine type is $machtype" > /dev/ttyu0
+if [[ "$machtype" =~ 64 ]]; then
+    packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+else 
+    packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+fi
+
 for package_to_install in $packages_to_install
 do
     ret=1

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -92,12 +92,11 @@ FreeBSD_latest: {
 EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-machtype=$(env | grep MACHTYPE)
-
-{% if machtype.find('64') != -1 %}
+echo "MACHTYPE: $MACHTYPE"
+{% if MACHTYPE.find('64') != -1 %}
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 {% else %}
-packages_to_install='open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 {% endif %}
 for package_to_install in $packages_to_install
 do

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -92,7 +92,9 @@ FreeBSD_latest: {
 EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-{% if guest_id.find('64Guest') != -1 %}
+machtype=$(env | grep MACHTYPE)
+
+{% if machtype.find('64') != -1 %}
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 {% else %}
 packages_to_install='open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -80,7 +80,6 @@ done
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
-{% if guest_id.find('64Guest') == -1 %}
 mkdir -p /usr/local/etc/pkg/repos
 cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
 FreeBSD: {
@@ -91,7 +90,6 @@ FreeBSD: {
     enabled: yes
 }
 EOF
-{% endif %}
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -92,7 +92,11 @@ FreeBSD_latest: {
 EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
+{% if guest_id.find('64Guest') != -1 %}
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+{% else %}
+packages_to_install='open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+{% endif %}
 for package_to_install in $packages_to_install
 do
     ret=1

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -80,16 +80,18 @@ done
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 
 # Modify the offical repo to latest
+{% if guest_id.find('64Guest') == -1 %}
 mkdir -p /usr/local/etc/pkg/repos
 cat >/usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
 FreeBSD: {
-    url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest",
+    url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest",
     mirror_type: "srv",
     signature_type: "fingerprints",
     fingerprints: "/usr/share/keys/pkg",
     enabled: yes
 }
 EOF
+{% endif %}
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -62,12 +62,13 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
-echo "MACHTYPE: $MACHTYPE"
-{% if MACHTYPE.find('64') != -1 %}
-packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
-{% else %}
-packages_to_install='bash sudo xf86-video-vmware'
-{% endif %}
+machtype=$(uname -m)
+echo "Machine type is $machtype" > /dev/ttyu0
+if [[ "$machtype" =~ 64 ]]; then
+    packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
+else
+    packages_to_install='bash sudo xf86-video-vmware'
+fi
 
 for package_to_install in $packages_to_install
 do
@@ -85,11 +86,12 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-{% if MACHTYPE.find('64') != -1 %}
-packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
-{% else %}
-packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
-{% endif %}
+if [[ "$machtype" =~ 64 ]]; then
+    packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+else
+    packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+fi
+
 for package_to_install in $packages_to_install
 do
     ret=1

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -62,7 +62,12 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
+{% if guest_id.find('64Guest') != -1 %}
 packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
+{% else %}
+packages_to_install='bash sudo xf86-video-vmware'
+{% endif %}
+
 for package_to_install in $packages_to_install
 do
     echo "Install package $package_to_install ..." > /dev/ttyu0

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -62,8 +62,8 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
-machtype=$(env | grep MACHTYPE)
-{% if machtype.find('64') != -1 %}
+echo "MACHTYPE: $MACHTYPE"
+{% if MACHTYPE.find('64') != -1 %}
 packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 {% else %}
 packages_to_install='bash sudo xf86-video-vmware'
@@ -85,7 +85,11 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
+{% if MACHTYPE.find('64') != -1 %}
 packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+{% else %}
+packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+{% endif %}
 for package_to_install in $packages_to_install
 do
     ret=1

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -62,7 +62,8 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
-{% if guest_id.find('64Guest') != -1 %}
+machtype=$(env | grep MACHTYPE)
+{% if machtype.find('64') != -1 %}
 packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 {% else %}
 packages_to_install='bash sudo xf86-video-vmware'


### PR DESCRIPTION
Description:
Remove kde5 for FreeBSD 13&14 32bit

Test result:
1) FreeBSD 13 32bit
<img width="527" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/d30876c8-139d-4257-913e-2522bf1c91fd">

2) FreeBSD 13 64bit
<img width="468" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/7e95b080-9dc0-4331-9a49-77cdd45fcdf2">

3)FreeBSD 14 64bit
<img width="483" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/d194623c-c859-4164-b64a-bee8e56fc29a">

4)FreeBSD 14 32bit
<img width="468" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/5911d915-5408-4aa8-8944-8b2a04c8b203">
