### PR TITLE
[FreeBSD]fix: install open-vm-tools-nox11 by mistake for freebsd 64bit

### DIFF
--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -62,7 +62,11 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
-packages_to_install='bash sudo xorg xf86-video-vmware'
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
+    packages_to_install='bash sudo xorg xf86-video-vmware'
+else
+    packages_to_install='bash sudo'
+fi
 for package_to_install in $packages_to_install
 do
     echo "Install package $package_to_install ..." > /dev/ttyu0

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -94,10 +94,10 @@ EOF
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
     packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else 
-    packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+    packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
 fi
 
 for package_to_install in $packages_to_install

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -62,6 +62,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
+machtype=$(uname -m)
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
     packages_to_install='bash sudo xorg xf86-video-vmware'
 else
@@ -96,7 +97,6 @@ FreeBSD_latest: {
 EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
     packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -63,7 +63,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # We install packages from ISO image
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
-if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
     packages_to_install='bash sudo xorg xf86-video-vmware'
 else
     packages_to_install='bash sudo'
@@ -98,7 +98,7 @@ EOF
 
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 echo "Machine type is $machtype" > /dev/ttyu0
-if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
     packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else 
     packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/13/installerconfig
+++ b/autoinstall/FreeBSD/13/installerconfig
@@ -94,7 +94,7 @@ EOF
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-if [[ "$machtype" =~ 64 ]]; then
+if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
     packages_to_install='sddm kde5 open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else 
     packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -64,10 +64,10 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
     packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 else
-    packages_to_install='bash sudo xf86-video-vmware'
+    packages_to_install='bash sudo'
 fi
 
 for package_to_install in $packages_to_install
@@ -86,10 +86,10 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
     packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else
-    packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+    packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
 fi
 
 for package_to_install in $packages_to_install

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -64,7 +64,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
     packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 else
     packages_to_install='bash sudo'
@@ -86,7 +86,7 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_84" ]; then
+if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
     packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else
     packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -64,7 +64,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-if [[ "$machtype" =~ 64 ]]; then
+if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
     packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
 else
     packages_to_install='bash sudo xf86-video-vmware'
@@ -86,7 +86,7 @@ done
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-if [[ "$machtype" =~ 64 ]]; then
+if [ $machtype == "amd64" ] || [ $machtype == "x86_84" ]; then
     packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else
     packages_to_install='open-vm-tools-nox11 xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'


### PR DESCRIPTION
Issue:
install open-vm-tools-nox11 by mistake for freebsd 64bit


Test result:

1) Test result for FreeBSD 14 & 13 32bit:
-----------------------------------------------------------------+
|  1 | deploy_vm_bios_nvme_vmxnet3 |   Passed         | 00:38:36  |
|  2 | ovt_verify_status           | * Not Applicable | 00:00:45  |
+-----------------------------------------------------------------+

2)  Test result for FreeBSD 14 & 13 64bit:
Test Results (Total: 2, Passed: 2, Elapsed Time: 00:38:27)
+------------------------------------------------------+
| ID | Name                       | Status | Exec Time |
+------------------------------------------------------+
|  1 | deploy_vm_efi_nvme_vmxnet3 | Passed | 00:37:14  |
|  2 | ovt_verify_status          | Passed | 00:00:59  |
+------------------------------------------------------+
