### PR TITLE
[Linux] Update Photon OS GPG key file to 4096 bit

### DIFF
--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -202,6 +202,9 @@
 - name: "Enable VMware Photon OS online repositories"
   when: guest_os_ansible_distribution == 'VMware Photon OS'
   block:
+    - name: "Get default RPM GPG key file"
+      include_tasks: get_rpm_gpg_key_file.yml
+
     - name: "Set the fact of VMware Photon OS {{ guest_os_ansible_distribution_major_ver }} online repositories"
       ansible.builtin.set_fact:
         photon_online_repos: ["photon", "photon-updates"]

--- a/linux/utils/get_rpm_gpg_key_file.yml
+++ b/linux/utils/get_rpm_gpg_key_file.yml
@@ -44,10 +44,36 @@
       when: guest_os_ansible_distribution_major_ver | int >= 9
   when: guest_os_ansible_distribution == "Rocky"
 
-- name: "Set default RPM GPG key file for VMware Photon OS"
-  ansible.builtin.set_fact:
-    guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY"
+- name: "Set RPM GPG key file for VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
+  block:
+    - name: "Set command for updating GPG key file"
+      ansible.builtin.set_fact:
+        guest_gpg_key_update_cmd: |-
+          {%- if guest_os_ansible_distribution_major_ver | int == 3 -%}tdnf update -y photon-repos-3.0-8.ph3 --refresh
+          {%- elif guest_os_ansible_distribution_major_ver | int == 4 -%}tdnf update -y photon-repos-4.0-3.ph4 --enablerepo=photon --refresh
+          {%- endif -%}
+
+    - name: "Update and set RPM GPG key for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
+      when: guest_gpg_key_update_cmd
+      block:
+        - name: "Update RPM GPG key on VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
+          ansible.builtin.shell: "{{ guest_gpg_key_update_cmd }}"
+          delegate_to: "{{ vm_guest_ip }}"
+
+        - name: "Update RPM GPG key files in repo files"
+          ansible.builtin.shell: "sed -r -i 's#gpgkey=(file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY)$#gpgkey=\\1 \\1-4096#' /etc/yum.repos.d/*.repo"
+          delegate_to: "{{ vm_guest_ip }}"
+          ignore_errors: true
+
+        - name: "Set default RPM GPG key file for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
+          ansible.builtin.set_fact:
+            guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096"
+
+    - name: "Set default RPM GPG key file for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
+      ansible.builtin.set_fact:
+        guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY"
+      when: not guest_gpg_key_update_cmd
 
 - name: "Set default RPM GPG key file for ProLinux"
   ansible.builtin.set_fact:

--- a/linux/utils/get_rpm_gpg_key_file.yml
+++ b/linux/utils/get_rpm_gpg_key_file.yml
@@ -54,6 +54,8 @@
           {%- elif guest_os_ansible_distribution_major_ver | int == 4 -%}tdnf update -y photon-repos-4.0-3.ph4 --enablerepo=photon --refresh
           {%- endif -%}
 
+    # 1024bit GPG key expired on VMware Photon OS 3.0 & 4.0, we need to get 4096 bit GPG key
+    # VMware Photon 5.0 already has 4096 bit GPG key, no need to update
     - name: "Update and set RPM GPG key for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
       when: guest_gpg_key_update_cmd
       block:
@@ -66,14 +68,10 @@
           delegate_to: "{{ vm_guest_ip }}"
           ignore_errors: true
 
-        - name: "Set default RPM GPG key file for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
-          ansible.builtin.set_fact:
-            guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096"
-
+    # Use 4096 bit GPG key on VMware Photon OS
     - name: "Set default RPM GPG key file for VMware Photon OS {{ guest_os_ansible_distribution_ver }}"
       ansible.builtin.set_fact:
-        guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY"
-      when: not guest_gpg_key_update_cmd
+        guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096"
 
 - name: "Set default RPM GPG key file for ProLinux"
   ansible.builtin.set_fact:
@@ -81,6 +79,7 @@
   when: guest_os_ansible_distribution == "ProLinux"
 
 - name: "Check GPG key file '{{ guest_rpm_gpg_key_path }}' exists or not"
+  when: guest_rpm_gpg_key_path
   block:
     - name: "Check GPG key file '{{ guest_rpm_gpg_key_path }}' exists or not"
       include_tasks: get_file_stat_info.yml
@@ -90,29 +89,36 @@
     - name: "Set fact of RPM GPG key file exists or not"
       ansible.builtin.set_fact:
         guest_rpm_gpg_key_exists: "{{ guest_file_exists }}"
-  when: guest_rpm_gpg_key_path
 
-- name: "Look for an alternative RPM GPG key file"
-  block:
-    - name: "Look for RPM GPG key files"
-      ansible.builtin.command: "ls /etc/pki/rpm-gpg/RPM-GPG-KEY-*"
-      delegate_to: "{{ vm_guest_ip }}"
-      register: list_rpm_gpg_keys
-      changed_when: false
-      ignore_errors: true
-
-    - name: "Set default GPG key file for {{ guest_os_ansible_distribution }}"
-      ansible.builtin.set_fact:
-        guest_rpm_gpg_key_path: "{{ list_rpm_gpg_keys.stdout_lines[0] }}"
-        guest_rpm_gpg_key_exists: true
-      when:
-        - list_rpm_gpg_keys.stdout_lines is defined
-        - list_rpm_gpg_keys.stdout_lines | length > 0
-
-    - name: "Set RPM GPG key file to empty as no RPM GPG key file found"
-      ansible.builtin.set_fact:
-        guest_rpm_gpg_key_path: ""
-      when: >
-        list_rpm_gpg_keys.stdout_lines is undefined or
-        list_rpm_gpg_keys.stdout_lines | length == 0
+- name: "GPG key file doesn't exist"
   when: not (guest_rpm_gpg_key_exists | bool)
+  block:
+    - name: "No RPM GPG key file on VMware Photon OS"
+      ansible.builtin.fail:
+        msg: "Not found RPM GPG key file {{ guest_rpm_gpg_key_path }} VMware Photon OS"
+      when: guest_os_ansible_distribution == "VMware Photon OS"
+
+    - name: "Look for an alternative RPM GPG key file for {{ guest_os_ansible_distribution }}"
+      when: guest_os_ansible_distribution != "VMware Photon OS"
+      block:
+        - name: "Look for RPM GPG key files"
+          ansible.builtin.command: "ls /etc/pki/rpm-gpg/RPM-GPG-KEY-*"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: list_rpm_gpg_keys
+          changed_when: false
+          ignore_errors: true
+
+        - name: "Set default GPG key file for {{ guest_os_ansible_distribution }}"
+          ansible.builtin.set_fact:
+            guest_rpm_gpg_key_path: "{{ list_rpm_gpg_keys.stdout_lines[0] }}"
+            guest_rpm_gpg_key_exists: true
+          when:
+            - list_rpm_gpg_keys.stdout_lines is defined
+            - list_rpm_gpg_keys.stdout_lines | length > 0
+
+        - name: "Set RPM GPG key file to empty as no RPM GPG key file found"
+          ansible.builtin.set_fact:
+            guest_rpm_gpg_key_path: ""
+          when: >
+            list_rpm_gpg_keys.stdout_lines is undefined or
+            list_rpm_gpg_keys.stdout_lines | length == 0


### PR DESCRIPTION
Photon OS package installation requires 4096 bit GPG key now, otherwise it will led to package installation failures like below:
```
    "invocation": {
        "module_args": {
            "_raw_params": "tdnf install -y cloud-init",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true
        }
    },
    "msg": "non-zero return code",
    "rc": 234,

   ...

    "stdout_lines": [
        "",
        "Installing:",
        "lzo                      x86_64       2.10-1.ph4       photon       143.85k 147304",
        "python3-pyserial         noarch       3.5-1.ph4        photon       853.34k 873822",
        "btrfs-progs              x86_64       5.7-3.ph4        photon         4.88M 5122206",
        "",
        "Total installed size:   5.86M 6143332",
        "",
        "Upgrading:",
        "cloud-init               noarch       24.1.4-1.ph4     photon         5.92M 6211808",
        "",
        "Total installed size:   5.92M 6211808",
        "",
        "Downloading:",
        "",
        "",
        "",
        "",
        "importing key from file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY"
    ]
```

This fix is followed Photon OS team's guidance to fetch 4096 bit GPG key and then update it to repo files:
```
    "invocation": {
        "module_args": {
            "_raw_params": "tdnf install -y cloud-init",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true
        }
    },
    "msg": "",
    "rc": 0,

     ...

    "stdout_lines": [
        "",
        "Installing:",
        "lzo                      x86_64       2.10-1.ph4       photon       143.85k 147304",
        "python3-pyserial         noarch       3.5-1.ph4        photon       853.34k 873822",
        "btrfs-progs              x86_64       5.7-3.ph4        photon         4.88M 5122206",
        "",
        "Total installed size:   5.86M 6143332",
        "",
        "Upgrading:",
        "cloud-init               noarch       24.1.4-1.ph4     photon         5.92M 6211808",
        "",
        "Total installed size:   5.92M 6211808",
        "",
        "Downloading:",
        "",
        "",
        "",
        "",
        "importing key from file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY",
        "importing key from file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096",
        "Testing transaction",
        "Running transaction",
        "Installing/Updating: python3-pyserial-3.5-1.ph4.noarch",
        "Installing/Updating: lzo-2.10-1.ph4.x86_64",
        "Installing/Updating: btrfs-progs-5.7-3.ph4.x86_64",
        "Installing/Updating: cloud-init-24.1.4-1.ph4.noarch",
        "Removing: cloud-init-21.4-2.ph4.noarch",
        "",
        "Complete!"
    ]
}
```