### PR TITLE
[Windows] fix issue in win_get_driver_installer.yml

### DIFF
--- a/windows/utils/win_get_driver_installer.yml
+++ b/windows/utils/win_get_driver_installer.yml
@@ -35,7 +35,7 @@
 
 - name: "Set fact of the driver installer info list"
   ansible.builtin.set_fact:
-    win_driver_installer_list: "{{ win_powershell_cmd_output.stdout_lines[0].split(' ')[-1] }}"
+    win_driver_installer_list: "{{ win_powershell_cmd_output.stdout_lines[0].strip().split(' ')[-1].split('\\0') }}"
   when:
     - win_powershell_cmd_output.stdout_lines is defined
     - win_powershell_cmd_output.stdout_lines | length == 1


### PR DESCRIPTION
"Get-ItemPropertyValue" was changed to "reg query" in former merge request, so that changing the result handling for getting the list of driver installers.