### PR TITLE
[FreeBSD 14] Missing the desktop cause the failure of testcase ovt_verify_status  at detecting vmtoolsd user process

### DIFF
--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -66,9 +66,9 @@ machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
 packages_to_install='bash sudo wget curl e2fsprogs iozone lsblk'
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    packages_to_install='$packages_to_install xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse'
+    packages_to_install="$packages_to_install xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse"
 else
-    packages_to_install='$packages_to_install open-vm-tools-nox11'
+    packages_to_install="$packages_to_install open-vm-tools-nox11"
 fi
 
 failed_packages=""

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -64,7 +64,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
-packages_to_install='bash sudo wget curl e2fsprogs iozone lsblk'
+packages_to_install="bash sudo wget curl e2fsprogs iozone lsblk"
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
     packages_to_install="$packages_to_install xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse"
 else

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -91,9 +91,6 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 if [ "$failed_packages" != "" ]; then
     echo "To install the following packages from offical repo: $failed_packages" > /dev/ttyu0
-fi
-
-if [ "$failed_packages" != "" ]; then
     for package_to_install in $failed_packages
     do
         ret=1

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -78,10 +78,10 @@ do
     ret=$?
     if [ $ret == 0 ]
     then 
-        echo "Succeed to install the package($package_to_install)" > /dev/ttyu0
+        echo "Succeed to install the package($package_to_install) from ISO repo" > /dev/ttyu0
     else
         failed_packages="$failed_packages $package_to_install"
-        echo "Failed to install the package($package_to_install)" > /dev/ttyu0
+        echo "Failed to install the package($package_to_install) from ISO repo" > /dev/ttyu0
     fi
 done
 

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -90,7 +90,7 @@ do
 done
 
 if [ "$failed_packages" == "" ]; then
-    echo "Failed to install the packages from ISO repo: ($failed_packages)" > /dev/ttyu0
+    echo "Failed to install the packages from ISO repo: $failed_packages" > /dev/ttyu0
 fi
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
@@ -104,7 +104,7 @@ fi
 if [ "$failed_packages" != "" ]; then
     packages_to_install="$failed_packages $packages_to_install"
 fi
-echo "To install the packages from offical repo: ($packages_to_install)" > /dev/ttyu0
+echo "To install the packages from offical repo: $packages_to_install" > /dev/ttyu0
 
 for package_to_install in $packages_to_install
 do

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -65,9 +65,9 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    packages_to_install='bash sudo xorg kde5 xf86-video-vmware'
+    packages_to_install='bash sudo xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
 else
-    packages_to_install='bash sudo'
+    packages_to_install='bash sudo open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
 fi
 
 failed_packages=""
@@ -80,33 +80,20 @@ do
     then 
         echo "Succeed to install the package($package_to_install)" > /dev/ttyu0
     else
-        if [ "$failed_packages" == "" ]; then
-            failed_packages="$package_to_install"
-        else
-            failed_packages="$failed_packages $package_to_install"
-        fi
+        failed_packages="$failed_packages $package_to_install"
         echo "Failed to install the package($package_to_install)" > /dev/ttyu0
     fi
 done
 
-if [ "$failed_packages" == "" ]; then
-    echo "Failed to install the packages from ISO repo: $failed_packages" > /dev/ttyu0
-fi
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
-if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    packages_to_install='sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
-else
-    packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
-fi
 
 if [ "$failed_packages" != "" ]; then
-    packages_to_install="$failed_packages $packages_to_install"
+    echo "To install the failed packages from offical repo: $failed_packages" > /dev/ttyu0
 fi
-echo "To install the packages from offical repo: $packages_to_install" > /dev/ttyu0
 
-for package_to_install in $packages_to_install
+for package_to_install in $failed_packages
 do
     ret=1
     try_count=1

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -93,25 +93,27 @@ if [ "$failed_packages" != "" ]; then
     echo "To install the following packages from offical repo: $failed_packages" > /dev/ttyu0
 fi
 
-for package_to_install in $failed_packages
-do
-    ret=1
-    try_count=1
-    until [ $ret -eq 0 ] || [ $try_count -ge 10 ]
+if [ "$failed_packages" != "" ]; then
+    for package_to_install in $failed_packages
     do
-        echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
-        env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
-        ret=$?
-        try_count=$((try_count+1))
-        if [ $ret -eq 0 ]; then
-             echo "Successfully installed the package $package_to_install from online repo" > /dev/ttyu0
+        ret=1
+        try_count=1
+        until [ $ret -eq 0 ] || [ $try_count -ge 10 ]
+        do
+            echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
+            env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
+            ret=$?
+            try_count=$((try_count+1))
+            if [ $ret -eq 0 ]; then
+                echo "Successfully installed the package $package_to_install from online repo" > /dev/ttyu0
+            fi
+        done
+
+        if [ $ret -ne 0 ] && [ $try_count -ge 10 ]; then
+            echo "Error: Failed to install $package_to_install from ISO and online repo" > /dev/ttyu0
         fi
     done
-
-    if [ $ret -ne 0 ] && [ $try_count -ge 10 ]; then
-        echo "Error: Failed to install $package_to_install from ISO and online repo" > /dev/ttyu0
-    fi
-done
+fi
 
 # Add new user. 
 {% if new_user is defined and new_user != 'root' %}

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -64,10 +64,11 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 machtype=$(uname -m)
 echo "Machine type is $machtype" > /dev/ttyu0
+packages_to_install='bash sudo wget curl e2fsprogs iozone lsblk'
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    packages_to_install='bash sudo xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse wget curl e2fsprogs iozone lsblk'
+    packages_to_install='$packages_to_install xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse'
 else
-    packages_to_install='bash sudo open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
+    packages_to_install='$packages_to_install open-vm-tools-nox11'
 fi
 
 failed_packages=""
@@ -78,10 +79,9 @@ do
     ret=$?
     if [ $ret == 0 ]
     then 
-        echo "Succeed to install the package($package_to_install) from ISO repo" > /dev/ttyu0
+        echo "Successfully installed the package $package_to_install from ISO repo" > /dev/ttyu0
     else
         failed_packages="$failed_packages $package_to_install"
-        echo "Failed to install the package($package_to_install) from ISO repo" > /dev/ttyu0
     fi
 done
 
@@ -90,21 +90,27 @@ rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 
 if [ "$failed_packages" != "" ]; then
-    echo "To install the failed packages from offical repo: $failed_packages" > /dev/ttyu0
+    echo "To install the following packages from offical repo: $failed_packages" > /dev/ttyu0
 fi
 
 for package_to_install in $failed_packages
 do
     ret=1
     try_count=1
-    until [ $ret -eq 0 ]
+    until [ $ret -eq 0 ] || [ $try_count -ge 10 ]
     do
         echo "Install package $package_to_install (try $try_count time) ..." > /dev/ttyu0
         env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
         ret=$?
         try_count=$((try_count+1))
+        if [ $ret -eq 0 ]; then
+             echo "Successfully installed the package $package_to_install from online repo" > /dev/ttyu0
+        fi
     done
-    echo "The package($package_to_install) is already installed" > /dev/ttyu0
+
+    if [ $ret -ne 0 ] && [ $try_count -ge 10 ]; then
+        echo "Error: Failed to install $package_to_install from ISO and online repo" > /dev/ttyu0
+    fi
 done
 
 # Add new user. 

--- a/autoinstall/FreeBSD/14/installerconfig
+++ b/autoinstall/FreeBSD/14/installerconfig
@@ -70,19 +70,28 @@ else
     packages_to_install='bash sudo'
 fi
 
+failed_packages=""
 for package_to_install in $packages_to_install
 do
     echo "Install package $package_to_install ..." > /dev/ttyu0
     env ASSUME_ALWAYS_YES=YES pkg install -y $package_to_install
     ret=$?
     if [ $ret == 0 ]
-    then    
+    then 
         echo "Succeed to install the package($package_to_install)" > /dev/ttyu0
     else
+        if [ "$failed_packages" == "" ]; then
+            failed_packages="$package_to_install"
+        else
+            failed_packages="$failed_packages $package_to_install"
+        fi
         echo "Failed to install the package($package_to_install)" > /dev/ttyu0
     fi
 done
 
+if [ "$failed_packages" == "" ]; then
+    echo "Failed to install the packages from ISO repo: ($failed_packages)" > /dev/ttyu0
+fi
 # Disable ISO repo and enable default repo
 rm -rf /usr/local/etc/pkg/repos/FreeBSD_install_cdrom.conf
 env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
@@ -91,6 +100,11 @@ if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
 else
     packages_to_install='open-vm-tools-nox11 wget curl e2fsprogs iozone lsblk'
 fi
+
+if [ "$failed_packages" != "" ]; then
+    packages_to_install="$failed_packages $packages_to_install"
+fi
+echo "To install the packages from offical repo: ($packages_to_install)" > /dev/ttyu0
 
 for package_to_install in $packages_to_install
 do


### PR DESCRIPTION
**Description**
testcase ovt_verify_status  is failed at detecting vmtoolsd user process


**Root Cause**
It's because the Xserver is failed to bootup which caused by failure to install package xf86-video-vmware at autoinstall.

**Test result**
Passed to rerun all the failure async pacakges
<img width="397" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/a805e072-fad5-41df-b32b-843e1b7b40ca">
