### PR TITLE
[OpenSUSE] ovt_verify_pkg_install is failed and undefined variable is reported in ovt_verify_pkg_install 

### DIFF
--- a/linux/open_vm_tools/uninstall_ovt.yml
+++ b/linux/open_vm_tools/uninstall_ovt.yml
@@ -24,7 +24,7 @@
       - ovt_uninstall_result.stdout
       - ovt_uninstall_result.rc is defined
       - ovt_uninstall_result.rc | int == 0
-    fail_msg: "Failed to uninstall open-vm-tools by executing command: {{ ' '.join(ovt_uninstall_result.cmd) }}"
+    fail_msg: "Failed to uninstall open-vm-tools by executing command: {{ package_uninstall_cmd }} {{' '.join(ovt_packages) }}"
 
 - name: "Reboot VM to make changes take effect"
   include_tasks: ../utils/reboot.yml

--- a/linux/open_vm_tools/uninstall_ovt.yml
+++ b/linux/open_vm_tools/uninstall_ovt.yml
@@ -7,7 +7,7 @@
 #
 # Uninstall open-vm-tools packages
 - name: "Uninstall packages {{ ovt_packages }}"
-  ansible.builtin.command: "{{ package_uninstall_cmd }} {{' '.join(ovt_packages) }}"
+  ansible.builtin.command: "{{ package_uninstall_cmd }} {{ ' '.join(ovt_packages) }}"
   register: ovt_uninstall_result
   ignore_errors: true
   delegate_to: "{{ vm_guest_ip }}"
@@ -24,7 +24,7 @@
       - ovt_uninstall_result.stdout
       - ovt_uninstall_result.rc is defined
       - ovt_uninstall_result.rc | int == 0
-    fail_msg: "Failed to uninstall open-vm-tools by executing command: {{ package_uninstall_cmd }} {{' '.join(ovt_packages) }}"
+    fail_msg: "Failed to uninstall open-vm-tools by executing command: {{ package_uninstall_cmd }} {{ ' '.join(ovt_packages) }}"
 
 - name: "Reboot VM to make changes take effect"
   include_tasks: ../utils/reboot.yml

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -40,8 +40,8 @@
         package_list: ["gawk", "python3-rpm", "tar"]
         package_state: "present"
 
-- name: "Reconfigure SLED"
-  when: guest_os_ansible_distribution == "SLED"
+- name: "Reconfigure {{ guest_os_ansible_distribution }}"
+  when: guest_os_family == "Suse"
   block:
     - name: "Check 'PackageKit' service state"
       include_tasks: ../utils/get_service_info.yml


### PR DESCRIPTION
Two issue:
1) ovt_verify_pkg_install failed due to running /usr/lib/packagekitd on opensuse-15.6-GA-64bit
2) undefined variable is reported in ovt_verify_pkg_install on opensuse-15.6-GA-64bit

Test result:
1) pass the testing for issue 1:
<img width="583" alt="image" src="https://github.com/vmware/ansible-vsphere-gos-validation/assets/41054978/02e0df8f-88c9-43d3-9760-99376ad26a38">


2) The testing is on-going for issue 2





