### PR TITLE
Change docker images' path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ This compatible guest operating systems list is used for this project only. For 
 
 ### Docker images
 * Latest (Release v3.1):
-  * projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:latest
+  * projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:latest
 * Release v3.1:
-  * projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v3.1
+  * projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v3.1
 
 Launch testing using Docker image
 1. Execute below commands in your machine
 ```
-$ docker pull projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:latest
-$ docker run -it --privileged projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:latest
+$ docker pull projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:latest
+$ docker run -it --privileged projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:latest
 ```
 2. Launch testing in the started container following the steps in this section [Steps to Launch Testing](#steps-to-launch-testing)

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -10,7 +10,7 @@ releases:
       - FusionOS 22 and 23
       - Kylin Linux Advanced Server V10
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v3.1
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v3.1
       Ansible: ansible-core 2.15.8
       Python: 3.11.7
       Ansible collections:
@@ -67,7 +67,7 @@ releases:
       - Add parameter esxi_hostname to vm_create
       - Change the boot disk to be first in boot order for ubuntu 23.04 desktop after deploy_vm
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v3.0
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v3.0
       Ansible: ansible-core 2.15.4
       Python: 3.10.11
       Ansible collections:
@@ -124,7 +124,7 @@ releases:
       - windows/mdag_enable_disable/mdag_enable_disable.yml
       - windows/stat_hosttime/stat_hosttime.yml
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.3
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v2.3
       Ansible: ansible-core 2.15.0
       Python: 3.10.0
       Ansible collections:
@@ -168,7 +168,7 @@ releases:
       - windows/eflow_deploy/eflow_deploy.yml
       - windows/wsl_distro_install_uninstall/wsl_distro_install_uninstall.yml
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.2
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v2.2
       Ansible: ansible-core 2.14.1
       Python: 3.10.0
       Ansible collections:
@@ -212,7 +212,7 @@ releases:
       - windows/vbs_enable_disable/vbs_enable_disable.yml
       - windows/nvdimm_cold_add_remove/nvdimm_cold_add_remove.yml
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.1
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v2.1
       Ansible: ansible-core 2.13.4
       Python: 3.10.0
       Ansible collections:
@@ -269,7 +269,7 @@ releases:
       new_testcases:
       - windows/check_inbox_driver/check_inbox_driver.yml
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v2.0
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v2.0
       Ansible: ansible-core 2.13.0
       Python: 3.10.0
       Ansible collections:
@@ -316,7 +316,7 @@ releases:
       - Add containing Java in Linux auto install config files.
       - Remove parameter use_saved_base_ip in test/vars.yml for Linux testing.
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v1.3
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v1.3
       Ansible: ansible-core 2.12.1
       Python: 3.10.0
       community.vmware: 2.0.0
@@ -343,7 +343,7 @@ releases:
       - Add not gather localhost facts in test case playbooks.
       - Make improvemnets in getting GOSC log files for Linux and Windows.
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v1.2
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v1.2
       Ansible: ansible 2.11.5
       Python: 3.9.1
       community.vmware: 1.14.0
@@ -376,14 +376,14 @@ releases:
       - windows/vhba_hot_add_remove/sata_vhba_device_ops.yml
       - windows/vhba_hot_add_remove/nvme_vhba_device_ops.yml
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v1.1
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v1.1
       Ansible: ansible core 2.11.1
       Python: 3.9.1
       community.vmware: 1.11.0
     release_date: '2021-07-15'
   1.0:
     docker_image:
-      path: projects.registry.vmware.com/gos_cert/ansible-vsphere-gos-validation:v1.0
+      path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation:v1.0
       Ansible: ansible 2.10.7
       Python: 3.9.1
       community.vmware: 1.7.0


### PR DESCRIPTION
Docker images published for each releases are moved to this path: projects.packages.broadcom.com/gos_cert/ansible-vsphere-gos-validation