### PR TITLE
Force to install latest required packages on Photon OS

### DIFF
--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -34,11 +34,11 @@
       vars:
         check_update_cmd: "tdnf makecache"
 
-    - name: "Install 'gawk', 'python3-rpm', 'tar' on VMware Photon OS"
+    - name: "Install 'sudo', 'gawk', 'python3-rpm', 'tar' on VMware Photon OS"
       include_tasks: ../utils/install_uninstall_package.yml
       vars:
-        package_list: ["gawk", "python3-rpm", "tar"]
-        package_state: "present"
+        package_list: ["sudo", "gawk", "python3-rpm", "tar"]
+        package_state: "latest"
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when: guest_os_family == "Suse"

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -38,6 +38,10 @@
   include_tasks: ../utils/get_linux_system_info.yml
   when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
+- name: "Take a base snapshot if it does not exist"
+  include_tasks: create_base_snapshot.yml
+  when: not (base_snapshot_exists | bool)
+
 - name: "Get VMware Tools version and build"
   include_tasks: ../utils/get_guest_ovt_version_build.yml
   when:
@@ -52,12 +56,11 @@
     - vmtools_is_running | bool
     - guestinfo_gathered is undefined or not guestinfo_gathered
 
-- name: "Take a base snapshot if it does not exist"
-  include_tasks: create_base_snapshot.yml
-  when: not (base_snapshot_exists | bool)
-
 # Hit issue in Ubuntu 22.04 casually: Temporary failure in name resolution. Restarting servcie can fix it
 - name: "Check if it needs to restart systemd-resolved or not to get DNS servers"
+  when:
+    - guest_os_ansible_distribution == "Ubuntu"
+    - guest_os_ansible_distribution_ver == "22.04"
   block:
     - name: "Get DNS servers"
       ansible.builtin.command: "resolvectl status"
@@ -71,6 +74,3 @@
         service_enabled: true
         service_state: "restarted"
       when: dns_servers_output.stdout.find("DNS Servers:") == -1
-  when:
-    - guest_os_ansible_distribution == "Ubuntu"
-    - guest_os_ansible_distribution_ver == "22.04"

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -34,26 +34,29 @@
   ansible.builtin.set_fact:
     package_manage_list: []
 
-- name: "Get installed packages on {{ guest_os_ansible_distribution }}"
-  include_tasks: get_installed_packages.yml
-
-- name: "Set fact of packages which needs to be installed"
-  ansible.builtin.set_fact:
-    package_manage_list: "{{ package_list | difference(guest_installed_packages) }}"
-    package_manage_op: "Install"
-  when: package_state in ['installed', 'present']
-
 - name: "Set fact of packages which needs to be installed with latest version"
   ansible.builtin.set_fact:
     package_manage_list: "{{ package_list }}"
     package_manage_op: "Install latest"
-  when: package_state in ['latest']
+  when: package_state == 'latest'
 
-- name: "Set fact of packages which needs to be uninstalled"
-  ansible.builtin.set_fact:
-    package_manage_list: "{{ package_list | select('in', guest_installed_packages) }}"
-    package_manage_op: "Uninstall"
-  when: package_state in ['absent', 'removed']
+- name: "Get packages to be installed or uninstalled"
+  when: package_state != 'latest'
+  block:
+    - name: "Get installed packages on {{ guest_os_ansible_distribution }}"
+      include_tasks: get_installed_packages.yml
+
+    - name: "Set fact of packages which needs to be installed"
+      ansible.builtin.set_fact:
+        package_manage_list: "{{ package_list | difference(guest_installed_packages) }}"
+        package_manage_op: "Install"
+      when: package_state in ['installed', 'present']
+
+    - name: "Set fact of packages which needs to be uninstalled"
+      ansible.builtin.set_fact:
+        package_manage_list: "{{ package_list | select('in', guest_installed_packages) }}"
+        package_manage_op: "Uninstall"
+      when: package_state in ['absent', 'removed']
 
 - name: "Display the pacakge list and operation"
   ansible.builtin.debug:


### PR DESCRIPTION
When deploying VM from Photon OS 4.0 OVA, it can't install required packages `python3-rpm` at cloud-init config because the expired 1024 GPG key, which would led to getting installed packages failed or installing packages failed in the VM because of:
```
task path: /home/worker/workspace/Ansible_Regression_Photon_4.0_OVA/ansible-vsphere-gos-validation/linux/utils/get_installed_packages.yml:12
fatal: [localhost -> 10.185.15.85]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "manager": [
                "auto"
            ],
            "strategy": "first"
        }
    },
    "msg": "Could not detect a supported package manager from the following list: ['pkg_info', 'apk', 'portage', 'pkg', 'apt', 'pacman', 'rpm'], or the required Python library is not installed. Check warnings for details.",
    "warnings": [
        "Found \"rpm\" but Failed to import the required Python library (rpm) on photon-ova-20240614115745's Python /usr/bin/python3.10. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter",
        "Platform linux on host localhost is using the discovered Python interpreter at /usr/bin/python3.10, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.15/reference_appendices/interpreter_discovery.html for more information."
    ]
}
error message:
Could not detect a supported package manager from the following list: ['pkg_info', 'apk', 'portage', 'pkg', 'apt', 'pacman', 'rpm'], or the required Python library is not installed. Check warnings for details.
```

This fix forces Photon OS VM to install latest required packages, so that it can update GPG key firstly, then install those packages.