### PR TITLE
Print error message when failed to get ESXi server config properties

### DIFF
--- a/common/esxi_get_version_build.yml
+++ b/common/esxi_get_version_build.yml
@@ -16,19 +16,24 @@
     esxi_hostname: "{{ esxi_hostname }}"
     schema: vsphere
     properties:
-      - config.product
+      - config.product.version
+      - config.product.build
       - config.option
   register: gather_host_facts_result
   ignore_errors: true
   no_log: true
 
-- block:
+- name: "Get ESXi server version and build number"
+  when: not gather_host_facts_result.failed
+  block:
     - name: "Set fact of the ESXi server version and build number"
       ansible.builtin.set_fact:
         esxi_version: "{{ gather_host_facts_result.ansible_facts.config.product.version }}"
         esxi_build: "{{ gather_host_facts_result.ansible_facts.config.product.build }}"
 
-    - block:
+    - name: "Get ESXi server update version"
+      when: esxi_version is version('7.0.0', '<')
+      block:
         - name: "Looking for ESXi update level in host config options"
           ansible.builtin.set_fact:
             esxi_update_level: "{{ gather_host_facts_result.ansible_facts.config.option | selectattr('key', 'equalto', 'Misc.HostAgentUpdateLevel') }}"
@@ -37,11 +42,12 @@
           ansible.builtin.set_fact:
             esxi_update_version: "{{ esxi_update_level[0]['value'] }}"
           when: esxi_update_level | length > 0
-      when: esxi_version is version('7.0.0', '<')
-  when: not gather_host_facts_result.failed
 
-- ansible.builtin.debug:
-    msg: "Get ESXi server '{{ esxi_hostname }}' config.product, config.option properties failed"
+- name: "Failed to get ESXi product info"
+  ansible.builtin.fail:
+    msg: >-
+      Failed to get ESXi server properties 'config.product.version', 'config.product.build' and 'config.option'.
+      Caught error: {{ gather_host_facts_result.msg | default('') }}
   when: gather_host_facts_result.failed
 
 # For log plugin to gather ESXi info in result file


### PR DESCRIPTION
If getting ESXi server properties failed, directly fail the test and print out the error message.

Negative test:
```
TASK [Get ESXi server product info] *************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:10
fatal: [localhost]: FAILED! => {
    "censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result",
    "changed": false
}
...ignoring
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'

TASK [Failed to get ESXi product info] **********************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:46
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Failed to get ESXi server properties 'config.product' and 'config.option'. Caught error: Unknown error while connecting to vCenter or ESXi API at x.x.x.x:443 : [Errno 113] No route to host"
}
```

Positive test:
```
TASK [Get ESXi server product info] *************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:10
ok: [localhost] => {
    "censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result",
    "changed": false
}
Read vars_file '../../vars/test_esx.yml'

TASK [Set fact of the ESXi server version and build number] *************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:29
ok: [localhost] => {
    "ansible_facts": {
        "esxi_build": "19193900",
        "esxi_version": "7.0.3"
    },
    "changed": false
}
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'
Read vars_file '../../vars/test_esx.yml'

...

TASK [Print ESXi server version] ****************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:56
ok: [localhost] => {
    "esxi_version": "7.0.3"
}
Read vars_file '../../vars/test_esx.yml'

TASK [Print ESXi server build] ******************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:58
ok: [localhost] => {
    "esxi_build": "19193900"
}
Read vars_file '../../vars/test_esx.yml'

TASK [Print ESXi server update version] *********************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/esxi_get_version_build.yml:60
ok: [localhost] => {
    "esxi_update_version": "N/A"
}

```