### PR TITLE
[Windows] Add removing Copilot appx package before running GOSC test cases

### DIFF
--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -112,7 +112,7 @@
 - name: "Get VM IP address"
   include_tasks: ../../common/vm_get_ip.yml
   vars:
-    vm_get_ip_timeout: 3600
+    vm_get_ip_timeout: 5400
 
 - name: "Check WinRM is connectable"
   include_tasks: ../utils/win_check_winrm.yml

--- a/windows/guest_customization/handle_guest_known_issues.yml
+++ b/windows/guest_customization/handle_guest_known_issues.yml
@@ -10,6 +10,8 @@
   block:
     - name: "Remove Appx packages in Windows Client"
       include_tasks: ../utils/win_remove_appx_package.yml
+      vars:
+        win_remove_appx_ignore_errors: true
       loop:
         - "BingSearch"
         - "Microsoft.Copilot"
@@ -22,6 +24,7 @@
       include_tasks: ../utils/win_remove_appx_package.yml
       vars:
         win_appx_package: "Edge.Stable"
+        win_remove_appx_ignore_errors: true
       when: guest_os_product_type | lower == 'server' 
 
 # Parameter 'uninstall_onedrive' is used for internal testing only

--- a/windows/guest_customization/handle_guest_known_issues.yml
+++ b/windows/guest_customization/handle_guest_known_issues.yml
@@ -8,10 +8,13 @@
 # https://kb.vmware.com/s/article/87307
 - name: "Workaround for SYSPREP error caused by Appx package"
   block:
-    - name: "Remove BingSearch Appx package in Windows Client"
+    - name: "Remove Appx packages in Windows Client"
       include_tasks: ../utils/win_remove_appx_package.yml
-      vars:
-        win_appx_package: "BingSearch"
+      loop:
+        - "BingSearch"
+        - "Microsoft.Copilot"
+      loop_control:
+        loop_var: win_appx_package
       when:
         - guest_os_ansible_distribution_ver is version('10.0.22000.0', '>=')
         - guest_os_product_type | lower == 'client'

--- a/windows/utils/win_remove_appx_package.yml
+++ b/windows/utils/win_remove_appx_package.yml
@@ -29,7 +29,7 @@
     win_appx_packages_list: "{{ win_powershell_cmd_output.stdout_lines | select }}"
   when:
     - win_powershell_cmd_output.stdout_lines is defined
-    - win_powershell_cmd_output.stdout_lines | select | length != 0
+    - win_powershell_cmd_output.stdout_lines | length != 0
 
 - name: "Remove Appx packages got with specified keyword"
   when: win_appx_packages_list | length > 0

--- a/windows/utils/win_remove_appx_package.yml
+++ b/windows/utils/win_remove_appx_package.yml
@@ -34,7 +34,7 @@
 - name: "Remove Appx packages got with specified keyword"
   when: win_appx_packages_list | length > 0
   block:
-    - name: "Remove Appx package {{ item }}"
+    - name: "Remove Appx package in guest OS"
       include_tasks: win_execute_cmd.yml
       vars:
         win_powershell_cmd: "Remove-AppxPackage -Package {{ item }}"

--- a/windows/utils/win_remove_appx_package.yml
+++ b/windows/utils/win_remove_appx_package.yml
@@ -1,40 +1,47 @@
 # Copyright 2023-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Remove installed Appx package in Windows guest OS
+# Remove specified installed Appx package in Windows guest OS
 # Parameters:
-#   win_appx_package: the keyword in Appx package name
+#   win_appx_package: the keyword in the fullname of Appx package.
+#   win_remove_appx_ignore_errors (optional): whether to ignore errors
+#     when getting and removing specified Appx packages. Default is false.
 #
 - name: "Check required parameter"
   ansible.builtin.assert:
     that:
       - win_appx_package is defined
       - win_appx_package
-    fail_msg: "Parameter 'win_appx_package' is required to be set to a keyword of Appx package name."
+    fail_msg: "Parameter 'win_appx_package' is required to be set to a keyword of Appx package's fullname."
 
-- name: "Initialize installed Appx package name"
+- name: "Initialize the list of installed Appx packages"
   ansible.builtin.set_fact:
-    win_appx_package_name: ''
+    win_appx_packages_list: []
 
-- name: "Get installed Appx package"
+- name: "Get installed Appx packages with keyword in the fullname"
   include_tasks: win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "(Get-AppxPackage -AllUsers | Where PackageFullName -Like '*{{ win_appx_package }}*').PackageFullName"
+    win_powershell_cmd: "(Get-AppxPackage -AllUsers -Name '*{{ win_appx_package }}*').PackageFullName"
+    win_execute_cmd_ignore_error: "{{ win_remove_appx_ignore_errors | default(false) }}"
 
-- name: "Set fact of installed Appx package name"
+- name: "Set fact of the list of installed Appx packages"
   ansible.builtin.set_fact:
-    win_appx_package_name: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
+    win_appx_packages_list: "{{ win_powershell_cmd_output.stdout_lines | select }}"
   when:
     - win_powershell_cmd_output.stdout_lines is defined
-    - win_powershell_cmd_output.stdout_lines | length != 0
+    - win_powershell_cmd_output.stdout_lines | select | length != 0
 
-- name: "Remove installed Appx package"
-  include_tasks: win_execute_cmd.yml
-  vars:
-    win_powershell_cmd: "Remove-AppxPackage -Package {{ win_appx_package_name }}"
-  when: win_appx_package_name
+- name: "Remove Appx packages got with specified keyword"
+  when: win_appx_packages_list | length > 0
+  block:
+    - name: "Remove Appx package {{ item }}"
+      include_tasks: win_execute_cmd.yml
+      vars:
+        win_powershell_cmd: "Remove-AppxPackage -Package {{ item }}"
+        win_execute_cmd_ignore_error: "{{ win_remove_appx_ignore_errors | default(false) }}"
+      loop: "{{ win_appx_packages_list }}"
 
-- name: "No Appx package"
+- name: "Not get installed Appx package"
   ansible.builtin.debug:
-    msg: "Not get installed Appx package with '{{ win_appx_package }}' in the name, skip removing task."
-  when: not win_appx_package_name
+    msg: "Not get installed Appx package with keyword '{{ win_appx_package }}' in the fullname, skip removing task."
+  when: win_appx_packages_list | length == 0


### PR DESCRIPTION
In test cases "gosc_sanity_staticip" and "gosc_sanity_dhcp", get below sysprep error, according to Microsoft doc, we'll remove this Appx package before doing sysprep.

2024-06-20 22:22:28, Error                 SYSPRP Package Microsoft.Copilot_0.4.2.0_neutral__8wekyb3d8bbwe was installed for a user, but not provisioned for all users. This package will not function properly in the sysprep image.
2024-06-20 22:22:28, Error                 SYSPRP Failed to remove apps for the current user: 0x80073cf2.
2024-06-20 22:22:28, Error                 SYSPRP Exit code of RemoveAllApps thread was 0x3cf2.
2024-06-20 22:22:28, Error                 SYSPRP ActionPlatform::LaunchModule: Failure occurred while executing 'SysprepGeneralizeValidate' from C:\Windows\System32\AppxSysprep.dll; dwRet = 0x3cf2
2024-06-20 22:22:28, Error                 SYSPRP SysprepSession::Validate: Error in validating actions from C:\Windows\System32\Sysprep\ActionFiles\Generalize.xml; dwRet = 0x3cf2
2024-06-20 22:22:28, Error                 SYSPRP RunPlatformActions:Failed while validating Sysprep session actions; dwRet = 0x3cf2
2024-06-20 22:22:28, Error      [0x0f0070] SYSPRP RunDlls:An error occurred while running registry sysprep DLLs, halting sysprep execution. dwRet = 0x3cf2
2024-06-20 22:22:28, Error      [0x0f00d8] SYSPRP WinMain:Hit failure while pre-validate sysprep generalize internal providers; hr = 0x80073cf2