### PR TITLE
[Linux] Add support for RHEL 10 and CentOS 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 |:-------------------------------------------------------| :------------------------------: | :----------------------: | :--------------------------------: |
 | Red Hat Enterprise Linux 7.x, 8.x, 9.x                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | CentOS 7.x, 8.x                                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| CentOS Stream 8, 9                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| CentOS Stream 8, 9, 10                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/autoinstall/RHEL/8/server_with_GUI/ks.cfg
+++ b/autoinstall/RHEL/8/server_with_GUI/ks.cfg
@@ -1,13 +1,16 @@
-#version=RHEL8
+#version=RHEL8,RHEL9,RHEL10
 ignoredisk --only-use={{ boot_disk_name }}
 autopart --type=lvm
 # Partition clearing information
 clearpart --none --initlabel
+
 # Use graphical install
 graphical
 repo --name="AppStream" --baseurl=file:///run/install/repo/AppStream
+
 # Use CDROM installation media
 cdrom
+
 # Keyboard layouts
 keyboard --vckeymap=us --xlayouts='us'
 # System language
@@ -17,8 +20,9 @@ lang en_US.UTF-8
 eula --agreed
 
 # Network information
-network --bootproto=dhcp --ipv6=auto
+network --bootproto=dhcp --ipv6=auto --activate
 network --hostname=localhost.localdomain
+
 # Root password
 rootpw --iscrypted {{ vm_password_hash }}
 
@@ -37,9 +41,12 @@ firstboot --disable
 
 # System services
 services --enabled="chronyd"
-services --disabled="firewalld"
+
+# Disable firewall
+firewall --disabled
+
 # System timezone
-timezone America/New_York --isUtc
+timezone America/New_York --utc
 
 # Shutdown when the install is finished.
 shutdown
@@ -49,8 +56,6 @@ shutdown
 kexec-tools
 open-vm-tools-desktop
 cloud-init
-java-1.8.0-openjdk-headless
-java-1.8.0-openjdk
 ndctl
 iproute
 rdma-core
@@ -62,12 +67,6 @@ perftest
 %end
 
 %addon com_redhat_kdump --enable --reserve-mb='auto'
-%end
-
-%anaconda
-pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
-pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
-pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
 %end
 
 %post --interpreter=/usr/bin/bash --log=/root/ks-post.log

--- a/autoinstall/RHEL/8/server_without_GUI/ks.cfg
+++ b/autoinstall/RHEL/8/server_without_GUI/ks.cfg
@@ -1,15 +1,19 @@
-#version=RHEL8
+#version=RHEL8,RHEL9,RHEL10
 ignoredisk --only-use={{ boot_disk_name }}
 autopart --type=lvm
 # Partition clearing information
 clearpart --none --initlabel
+
 # Use graphical install
 graphical
 repo --name="AppStream" --baseurl=file:///run/install/repo/AppStream
+
 # Use CDROM installation media
 cdrom
+
 # Keyboard layouts
 keyboard --vckeymap=us --xlayouts='us'
+
 # System language
 lang en_US.UTF-8
 
@@ -17,8 +21,9 @@ lang en_US.UTF-8
 eula --agreed
 
 # Network information
-network  --bootproto=dhcp --ipv6=auto
-network  --hostname=localhost.localdomain
+network --bootproto=dhcp --ipv6=auto --activate
+network --hostname=localhost.localdomain
+
 # Root password
 rootpw --iscrypted {{ vm_password_hash }}
 
@@ -30,14 +35,14 @@ user --name={{ new_user }} --password={{ vm_password_hash }} --groups=root,wheel
 sshkey --username={{ new_user }} "{{ ssh_public_key }}"
 {% endif %}
 
-# X Window System configuration information
-xconfig  --startxonboot
-# Run the Setup Agent on first boot
-#firstboot --enable
 # System services
 services --enabled="chronyd"
+
+# Disable firewall
+firewall --disabled
+
 # System timezone
-timezone America/New_York --isUtc
+timezone America/New_York --utc
 
 # Shutdown when the install is finished.
 shutdown
@@ -46,17 +51,9 @@ shutdown
 kexec-tools
 perl-interpreter
 cloud-init
-java-1.8.0-openjdk-headless
-java-1.8.0-openjdk
 %end
 
 %addon com_redhat_kdump --enable --reserve-mb='auto'
-%end
-
-%anaconda
-pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
-pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
-pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
 %end
 
 %post --interpreter=/usr/bin/bash --log=/root/ks-post.log

--- a/linux/guest_customization/check_network_config.yml
+++ b/linux/guest_customization/check_network_config.yml
@@ -62,7 +62,7 @@
     - guest_default_gateway | length > 0
     - guest_default_gateway[0].split() | length >= 3
 
-- name: "Check IP address, netmaks, gateway settings for GOSC with DHCP IP"
+- name: "Check IP address, netmask, gateway settings for GOSC with DHCP IP"
   when: ip_assignment == "dhcp"
   block:
     - name: "Save DHCP GOSC network check result"
@@ -84,7 +84,7 @@
         - key: "guest_gateway_success"
           value: "VM DHCP IPv4 gateway is '{{ guest_ipv4_gateway }}', expected IPv4 gateway should not be empty"
 
-- name: "Check static IP address, netmaks, gateway settings for GOSC with static IP"
+- name: "Check static IP address, netmask, gateway settings for GOSC with static IP"
   when: ip_assignment == "static"
   block:
     - name: "Save static GOSC network facts check result"

--- a/linux/guest_customization/check_network_config.yml
+++ b/linux/guest_customization/check_network_config.yml
@@ -12,63 +12,67 @@
     guest_netmask_success: ""
     guest_gateway_success: ""
 
-# Get IP address and netmask
-- include_tasks: ../../common/vm_shell_in_guest.yml
+- name: "Show guest OS IP address after GOSC"
+  include_tasks: ../../common/vm_shell_in_guest.yml
   vars:
     vm_shell_cmd: "{{ ip_command }}"
     vm_shell_args: "-br addr show"
     vm_shell_out: "/tmp/ip_addr_show.txt"
 
-- include_tasks: ../../common/vm_guest_file_operation.yml
+- name: "Fetch the result file of showing IP address"
+  include_tasks: ../../common/vm_guest_file_operation.yml
   vars:
     operation: "fetch_file"
     src_path: "/tmp/ip_addr_show.txt"
     dest_path: "{{ current_test_log_folder }}/ip_addr_show.txt"
 
-- name: "Get IPv4 address"
+- name: "Get guest OS IPv4 address after GOSC"
   ansible.builtin.set_fact:
     guest_ip_addr_show: "{{ lookup('file', current_test_log_folder ~ '/ip_addr_show.txt').split('\n') | select('search', '^e(n|th).*') }}"
 
-- name: "Set facts of guest network interface names and IPv4 address"
+- name: "Set facts of guest OS network interface name and IPv4 address after GOSC"
   ansible.builtin.set_fact:
     guest_iface_name: "{{ guest_ip_addr_show[0].split()[0] }}"
     guest_ipv4_address: "{{ guest_ip_addr_show[0] | regex_search('(\\d+\\.){3}(\\d+)/(\\d+)') | ansible.utils.ipaddr('address') }}"
     guest_ipv4_netmask: "{{ guest_ip_addr_show[0] | regex_search('(\\d+\\.){3}(\\d+)/(\\d+)') | ansible.utils.ipaddr('netmask') }}"
   when: guest_ip_addr_show | length > 0
 
-# Get default gateway
-- include_tasks: ../../common/vm_shell_in_guest.yml
+- name: "Show guest OS default gateway after GOSC"
+  include_tasks: ../../common/vm_shell_in_guest.yml
   vars:
     vm_shell_cmd: "{{ ip_command }}"
     vm_shell_args: "-4 route show"
     vm_shell_out: "/tmp/ip_route_show.txt"
 
-- include_tasks: ../../common/vm_guest_file_operation.yml
+- name: "Fetch the result file of showing default gateway"
+  include_tasks: ../../common/vm_guest_file_operation.yml
   vars:
     operation: "fetch_file"
     src_path: "/tmp/ip_route_show.txt"
     dest_path: "{{ current_test_log_folder }}/ip_route_show.txt"
 
-- name: "Get default gateway"
+- name: "Get guest OS default gateway after GOSC"
   ansible.builtin.set_fact:
     guest_default_gateway: "{{ lookup('file', current_test_log_folder ~ '/ip_route_show.txt').split('\n') | select('match', '^default') }}"
 
-- name: "Set fact of GOSC network gateway"
+- name: "Set fact of guest OS default gateway after GOSC"
   ansible.builtin.set_fact:
     guest_ipv4_gateway: "{{ guest_default_gateway[0].split()[2] }}"
   when:
     - guest_default_gateway | length > 0
     - guest_default_gateway[0].split() | length >= 3
 
-# Check IP address, netmaks, gateway settings for GOSC with DHCP IP
-- block:
+- name: "Check IP address, netmaks, gateway settings for GOSC with DHCP IP"
+  when: ip_assignment == "dhcp"
+  block:
     - name: "Save DHCP GOSC network check result"
       ansible.builtin.set_fact:
         guest_ipv4_success: "{{ guest_ipv4_address != '' }}"
         guest_netmask_success: "{{ guest_ipv4_netmask != '' }}"
         guest_gateway_success: "{{ guest_ipv4_gateway != '' }}"
 
-    - include_tasks: set_gosc_validation_result.yml
+    - name: "Set GOSC validation result for DHCP networking config"
+      include_tasks: set_gosc_validation_result.yml
       vars:
         gosc_check_item: "{{ item.key }}"
         gosc_check_error_msg: "{{ item.value }}"
@@ -79,17 +83,18 @@
           value: "VM DHCP IPv4 netmask is '{{ guest_ipv4_netmask }}', expected IPv4 netmask should not be empty"
         - key: "guest_gateway_success"
           value: "VM DHCP IPv4 gateway is '{{ guest_ipv4_gateway }}', expected IPv4 gateway should not be empty"
-  when: ip_assignment == "dhcp"
 
-# Check static IP address, netmaks, gateway settings for GOSC with static IP
-- block:
+- name: "Check static IP address, netmaks, gateway settings for GOSC with static IP"
+  when: ip_assignment == "static"
+  block:
     - name: "Save static GOSC network facts check result"
       ansible.builtin.set_fact:
         guest_ipv4_success: "{{ guest_ipv4_address == linux_gosc_spec['ip'] }}"
         guest_netmask_success: "{{ guest_ipv4_netmask == linux_gosc_spec['netmask'] }}"
         guest_gateway_success: "{{ guest_ipv4_gateway == linux_gosc_spec['gateway'] }}"
 
-    - include_tasks: set_gosc_validation_result.yml
+    - name: "Set GOSC validation result for static networking config"
+      include_tasks: set_gosc_validation_result.yml
       vars:
         gosc_check_item: "{{ item.key }}"
         gosc_check_error_msg: "{{ item.value }}"
@@ -100,7 +105,6 @@
           value: "VM static IPv4 netmask is '{{ guest_ipv4_netmask }}', expected IPv4 netmask is {{ linux_gosc_spec['netmask'] }}"
         - key: "guest_gateway_success"
           value: "VM static IPv4 gateway is '{{ guest_ipv4_gateway }}', expected IPv4 gateway is {{ linux_gosc_spec['gateway'] }}"
-  when: ip_assignment == "static"
 
 - name: "Print GOSC network IP address check result"
   ansible.builtin.debug: var=guest_ipv4_success
@@ -109,10 +113,16 @@
 - name: "Print GOSC network gateway check result"
   ansible.builtin.debug: var=guest_gateway_success
 
-# Collect network config files for non-Photon Linux
 # On Ubuntu Desktop 19.10 and later or Ubuntu Server 17.10 and later, network configure files
 # are /etc/netplan/*.yaml
-- block:
+- name: "Set network configuration file for {{ vm_guest_os_distribution }}"
+  when: >
+    (guest_os_ansible_distribution == "Ubuntu") and
+    (((guest_os_with_gui is undefined or not guest_os_with_gui | bool) and
+      guest_os_ansible_distribution_ver is version('17.10', '>=')) or
+     (guest_os_with_gui is defined and guest_os_with_gui | bool and
+      guest_os_ansible_distribution_ver is version('19.10', '>=')))
+  block:
     - name: "Set traditional GOSC network configuration file on Ubuntu {{ guest_os_ansible_distribution_ver }}"
       ansible.builtin.set_fact:
         src_network_file: "/etc/netplan/99-netcfg-vmware.yaml"
@@ -122,82 +132,116 @@
       ansible.builtin.set_fact:
         src_network_file: "/etc/netplan/50-cloud-init.yaml"
       when: "gosc_workflow == 'cloud-init'"
-  when: >
-    (guest_os_ansible_distribution == "Ubuntu") and
-    (((guest_os_with_gui is undefined or not guest_os_with_gui | bool) and
-      guest_os_ansible_distribution_ver is version('17.10', '>=')) or
-     (guest_os_with_gui is defined and guest_os_with_gui | bool and
-      guest_os_ansible_distribution_ver is version('19.10', '>=')))
 
 # On Debian 10/11 or Ubuntu Desktop eariler than 19.10, the network configure file is
 # /etc/network/interfaces
-- block:
-    - name: "Set traditional GOSC network configuration files on Ubuntu Desktop/Debian OS"
-      ansible.builtin.set_fact:
-        src_network_file: "/etc/network/interfaces"
-      when: "gosc_workflow == 'perl'"
-
-    - block:
-        - name: "Set cloud-init GOSC network configuration files on Ubuntu/Debian OS"
-          ansible.builtin.set_fact:
-            src_network_file: "/etc/network/interfaces.d/50-cloud-init.cfg"
-          when: guest_os_ansible_distribution == "Ubuntu"
-
-        - name: "Set cloud-init GOSC network configuration files on Ubuntu/Debian OS"
-          ansible.builtin.set_fact:
-            src_network_file: "/etc/network/interfaces.d/50-cloud-init"
-          when: guest_os_ansible_distribution == "Debian"
-      when: "gosc_workflow == 'cloud-init'"
+- name: "Set network configuration file for {{ vm_guest_os_distribution }}"
   when: >
     (guest_os_ansible_distribution == "Debian") or
     (guest_os_ansible_distribution == "Ubuntu" and
      guest_os_ansible_distribution_ver is version('19.10', '<') and
      guest_os_with_gui is defined and guest_os_with_gui | bool)
+  block:
+    - name: "Set traditional GOSC network configuration file on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        src_network_file: "/etc/network/interfaces"
+      when: "gosc_workflow == 'perl'"
 
-- name: "Set GOSC network configuration files on RedHat"
-  ansible.builtin.set_fact:
-    src_network_file: "/etc/sysconfig/network-scripts/ifcfg-{{ guest_iface_name }}"
+    - name: "Set cloud-init GOSC network configuration file on {{ vm_guest_os_distribution }}"
+      when: "gosc_workflow == 'cloud-init'"
+      block:
+        - name: "Set cloud-init GOSC network configuration file on {{ vm_guest_os_distribution }}"
+          ansible.builtin.set_fact:
+            src_network_file: "/etc/network/interfaces.d/50-cloud-init.cfg"
+          when: guest_os_ansible_distribution == "Ubuntu"
+
+        - name: "Set cloud-init GOSC network configuration file on {{ vm_guest_os_distribution }}"
+          ansible.builtin.set_fact:
+            src_network_file: "/etc/network/interfaces.d/50-cloud-init"
+          when: guest_os_ansible_distribution == "Debian"
+
+- name: "Collect network configuration file for {{ vm_guest_os_distribution }}"
   when: guest_os_family == "RedHat"
+  block:
+    - name: "Set GOSC network configuration file on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        src_network_file: /etc/sysconfig/network-scripts/ifcfg-{{ guest_iface_name }}
+      when: guest_os_network_manager != "NetworkManager"
 
-- name: "Set GOSC network configuration files on SLE"
+    - name: "Set GOSC network configuration file on {{ vm_guest_os_distribution }}"
+      when: guest_os_network_manager == "NetworkManager"
+      block:
+        - name: "List network configuration files on {{ vm_guest_os_distribution }}"
+          include_tasks: ../../common/vm_shell_in_guest.yml
+          vars:
+            vm_shell_cmd: "/usr/bin/nmcli"
+            vm_shell_args: "-t -f DEVICE,FILENAME connection show --active"
+            vm_shell_out: "/tmp/nmcli_connection_show.txt"
+
+        - name: "Fetch the result of listing network configuration files on {{ vm_guest_os_distribution }}"
+          include_tasks: ../../common/vm_guest_file_operation.yml
+          vars:
+            operation: "fetch_file"
+            src_path: "/tmp/nmcli_connection_show.txt"
+            dest_path: "{{ current_test_log_folder }}/nmcli_connection_show.txt"
+
+        - name: "Get network connection on {{ vm_guest_os_distribution }}"
+          ansible.builtin.set_fact:
+            guest_network_connection: "{{ lookup('file', current_test_log_folder ~ '/nmcli_connection_show.txt').split('\n') |
+                                          select('match', guest_iface_name) }}"
+
+        - name: "Get network configuration file  on {{ vm_guest_os_distribution }}"
+          ansible.builtin.set_fact:
+            src_network_file: "{{ guest_network_connection[0].split(':')[-1] }}"
+          when: guest_network_connection | length == 1
+
+- name: "Set GOSC network configuration file on {{ vm_guest_os_distribution }}"
   ansible.builtin.set_fact:
     src_network_file: "/etc/sysconfig/network/ifcfg-{{ guest_iface_name }}"
   when: guest_os_family == "Suse"
 
-- block:
-    - name: "Print the network configuration file on {{ guest_os_ansible_distribution }}"
+- name: "Collect network configuration file on {{ vm_guest_os_distribution }}"
+  when:
+    - src_network_file is defined
+    - src_network_file
+  block:
+    - name: "Print the network configuration file on {{ vm_guest_os_distribution }}"
       ansible.builtin.debug: var=src_network_file
 
-    - name: "Set GOSC network configuration files on VMware Photon OS"
+    - name: "Set local path to collected GOSC network configuration file"
       ansible.builtin.set_fact:
         network_config_path: "{{ current_test_log_folder }}{{ src_network_file }}"
-    - include_tasks: ../../common/vm_guest_file_operation.yml
+
+    - name: "Fetch network configuration file on {{ vm_guest_os_distribution }}"
+      include_tasks: ../../common/vm_guest_file_operation.yml
       vars:
         operation: "fetch_file"
         src_path: "{{ src_network_file }}"
         dest_path: "{{ network_config_path }}"
-  when:
-    - guest_os_ansible_distribution != "VMware Photon OS"
-    - src_network_file is defined and src_network_file
 
-# Collect network config files for VMware Photon OS
-- block:
-    - include_tasks: ../../common/vm_shell_in_guest.yml
+- name: "Collect network configuration files for {{ vm_guest_os_distribution }}"
+  when: guest_os_ansible_distribution == 'VMware Photon OS'
+  block:
+    - name: "List network configuration files on {{ vm_guest_os_distribution }}"
+      include_tasks: ../../common/vm_shell_in_guest.yml
       vars:
         vm_shell_cmd: "/usr/bin/ls"
         vm_shell_args: "/etc/systemd/network/*.network"
         vm_shell_out: "/tmp/list_network_files.txt"
 
-    - include_tasks: ../../common/vm_guest_file_operation.yml
+    - name: "Fetch the result of listing network configuration files on {{ vm_guest_os_distribution }}"
+      include_tasks: ../../common/vm_guest_file_operation.yml
       vars:
         operation: "fetch_file"
         src_path: "/tmp/list_network_files.txt"
         dest_path: "{{ current_test_log_folder }}/list_network_files.txt"
 
-    - name: "Look for network file on VMware Photon OS"
+    - name: "Get network configuration files on {{ vm_guest_os_distribution }}"
       ansible.builtin.set_fact:
         guest_network_files: "{{ lookup('file', current_test_log_folder ~ '/list_network_files.txt').split('\n') }}"
-    - include_tasks: ../../common/vm_guest_file_operation.yml
+
+    - name: "Fetch network configuration files on {{ vm_guest_os_distribution }}"
+      include_tasks: ../../common/vm_guest_file_operation.yml
       vars:
         operation: "fetch_file"
         src_path: "{{ src_network_file }}"
@@ -206,4 +250,3 @@
       loop_control:
         loop_var: "src_network_file"
       when: guest_network_files | length > 0
-  when: guest_os_ansible_distribution == "VMware Photon OS"

--- a/linux/guest_customization/linux_gosc_start.yml
+++ b/linux/guest_customization/linux_gosc_start.yml
@@ -38,6 +38,13 @@
 - name: "Shutdown OS"
   include_tasks: ../utils/shutdown.yml
 
+- name: "Set fact of GOSC log files"
+  ansible.builtin.set_fact:
+    gosc_deploypkg_log_file: "/var/log/vmware-imc/toolsDeployPkg.log"
+    gosc_deploypkg_log_local: "{{ current_test_log_folder }}/toolsDeployPkg.log"
+    gosc_cloudinit_log_file: "/var/log/cloud-init.log"
+    gosc_cloudinit_log_local: "{{ current_test_log_folder }}/cloud-init.log"
+
 - name: "Execute guest customization"
   include_tasks: linux_gosc_execution.yml
   vars:
@@ -71,13 +78,6 @@
 - name: "Update VM's guest IP in inventory"
   include_tasks: ../../common/update_inventory.yml
   when: ip_assignment == "dhcp"
-
-- name: "Set fact of GOSC log files"
-  ansible.builtin.set_fact:
-    gosc_deploypkg_log_file: "/var/log/vmware-imc/toolsDeployPkg.log"
-    gosc_deploypkg_log_local: "{{ current_test_log_folder }}/toolsDeployPkg.log"
-    gosc_cloudinit_log_file: "/var/log/cloud-init.log"
-    gosc_cloudinit_log_local: "{{ current_test_log_folder }}/cloud-init.log"
 
 # Wait GOSC completes message in logs
 - name: "Wait for traditional GOSC complete message"

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -144,6 +144,10 @@
             (not cloudinit_version) or
             not (cloudinit_version is version(gosc_required_cloudinit_version, '>='))
 
+    - name: "Get guest OS network manager"
+      include_tasks: ../utils/get_network_manager.yml
+      when: guest_os_network_manager is undefined
+
     - name: "Get DNS server info before GOSC"
       include_tasks: ../utils/get_system_dns.yml
 

--- a/linux/utils/get_network_config_file.yml
+++ b/linux/utils/get_network_config_file.yml
@@ -13,27 +13,24 @@
 
 - name: "Get network device manager in guest OS"
   include_tasks: get_network_manager.yml
-  when: guest_os_network_manager is undefined or not guest_os_network_manager
+  when: guest_os_network_manager is undefined
 
 - name: "Get network config file from NetworkManager"
+  when: guest_os_network_manager == "NetworkManager"
   block:
     - name: "Get network connections"
-      ansible.builtin.shell: |
-        conn_name=$(nmcli -t -f GENERAL.CONNECTION device show {{ network_adapter_name }} | cut -d ':' -f 2);
-        nmcli -t -f NAME,ACTIVE,FILENAME connection show --active | grep "$conn_name:"
+      ansible.builtin.shell: "nmcli -t -f DEVICE,FILENAME connection show --active | grep '{{ network_adapter_name }}:'"
       delegate_to: "{{ vm_guest_ip }}"
       register: "network_conn_result"
       ignore_errors: true
 
     - name: "Set fact of network config file for '{{ network_adapter_name }}' on {{ guest_os_ansible_distribution }}"
       ansible.builtin.set_fact:
-        network_config_path: "{{ network_conn_result.stdout_lines[0].split(':')[2] }}"
+        network_config_path: "{{ network_conn_result.stdout_lines[0].split(':')[1] }}"
       when:
         - network_conn_result.rc is defined
         - network_conn_result.rc == 0
         - network_conn_result.stdout_lines | length == 1
-        - network_conn_result.stdout_lines[0].split(':') | length == 3
-  when: guest_os_network_manager == "NetworkManager"
 
 # Set fact of network config file in guest OS except VMware Photon OS
 - name: "Set fact of network config file"

--- a/linux/utils/get_rpm_gpg_key_file.yml
+++ b/linux/utils/get_rpm_gpg_key_file.yml
@@ -13,17 +13,16 @@
     guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
   when: guest_os_ansible_distribution == "RedHat"
 
-- name: "Set default RPM GPG key file for CentOS"
-  block:
-    - name: "Set default RPM GPG key file for CentOS {{ guest_os_ansible_distribution_major_ver }}"
-      ansible.builtin.set_fact:
-        guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
-      when: guest_os_ansible_distribution_major_ver | int == 7
-
-    - name: "Set default RPM GPG key file for CentOS {{ guest_os_ansible_distribution_major_ver }}"
-      ansible.builtin.set_fact:
-        guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
-      when: guest_os_ansible_distribution_major_ver | int >= 8
+- name: "Set default RPM GPG key file for {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    guest_rpm_gpg_key_path: |-
+      {%- if guest_os_ansible_distribution_major_ver | int == 7 -%}
+      /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+      {%- elif guest_os_ansible_distribution_major_ver | int in [8, 9] -%}
+      /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+      {%- elif guest_os_ansible_distribution_major_ver | int >= 10 -%}
+      /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+      {%- endif -%}
   when: guest_os_ansible_distribution == "CentOS"
 
 - name: "Set default RPM GPG key file for Oracle Linux"
@@ -32,6 +31,7 @@
   when: guest_os_ansible_distribution == "OracleLinux"
 
 - name: "Set default RPM GPG key file for Rocky Linux"
+  when: guest_os_ansible_distribution == "Rocky"
   block:
     - name: "Set GPG key path for Rocky Linux {{ guest_os_ansible_distribution_ver }}"
       ansible.builtin.set_fact:
@@ -42,7 +42,6 @@
       ansible.builtin.set_fact:
         guest_rpm_gpg_key_path: "/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-{{ guest_os_ansible_distribution_major_ver }}"
       when: guest_os_ansible_distribution_major_ver | int >= 9
-  when: guest_os_ansible_distribution == "Rocky"
 
 - name: "Set RPM GPG key file for VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
@@ -102,7 +101,7 @@
       when: guest_os_ansible_distribution != "VMware Photon OS"
       block:
         - name: "Look for RPM GPG key files"
-          ansible.builtin.command: "ls /etc/pki/rpm-gpg/RPM-GPG-KEY-*"
+          ansible.builtin.command: "ls -1 /etc/pki/rpm-gpg/RPM-GPG-KEY-*"
           delegate_to: "{{ vm_guest_ip }}"
           register: list_rpm_gpg_keys
           changed_when: false

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -99,7 +99,7 @@
       include_tasks: ../utils/collect_dmesg.yml
       vars:
         dmesg_options: "-c"
-        dmesg_output_file_name: "dmesg_before_vhba_test.txt"
+        dmesg_output_file_name: "dmesg_before_vhba_test.log"
 
     - name: "Clear /var/log/messages"
       ansible.builtin.shell: "cat /dev/null >/var/log/messages"


### PR DESCRIPTION
CentOS Stream 10 ISO has been published, there is RHEL 10 nightly ISO for testing.
Automation testing needs to be well prepared for incoming RHEL 10.0 releases.

Changes in this fix are tested on CentOS Stream 10. Testing on RHEL 10 nightly are on-going. Unattended config file will keep using kickstart files under autoinstall/RHEL/8 with some compatible changes. `pwpolicy` was deprecated in RHEL 9.0, and removing it won't affect our automation testing, so this fix directly removed them.

In CentOS Stream 10, network connections are completely managed by NetworkManager, there is no /etc/sysconfig/network-scripts/ directory any more. So GOSC test cases also updated to collect network config files.

`check_inbox_driver` failed due to missing `vmw_vmci`, `vmw_vsock_vmci_transport` and `vmw_balloon`. Those need to be confirmed with OS vendor by OS lead. 

```
+------------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                         |
+------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                 |
|                           | bitness='64'                                                       |
|                           | cpeString='cpe:/o:centos:centos:10'                                |
|                           | distroAddlVersion='10'                                             |
|                           | distroName='CentOS Stream'                                         |
|                           | distroVersion='10'                                                 |
|                           | familyName='Linux'                                                 |
|                           | kernelVersion='6.8.0-0.rc3.20240209git1f719a2f3fa6.31.el10.x86_64' |
|                           | prettyName='CentOS Stream 10'                                      |
+------------------------------------------------------------------------------------------------+


Test Results (Total: 31, Passed: 27, Failed: 1, Skipped: 3, Elapsed Time: 02:01:24)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:20:36  |
| 02 | check_inbox_driver                   | * Failed        | 00:01:04  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:06:17  |
| 04 | ovt_verify_status                    |   Passed        | 00:00:50  |
| 05 | vgauth_check_service                 |   Passed        | 00:00:50  |
| 06 | host_verify_saml_token               |   Passed        | 00:01:38  |
| 07 | check_ip_address                     |   Passed        | 00:00:31  |
| 08 | check_os_fullname                    |   Passed        | 00:01:03  |
| 09 | stat_balloon                         |   Passed        | 00:00:35  |
| 10 | stat_hosttime                        |   Passed        | 00:00:43  |
| 11 | device_list                          |   Passed        | 00:02:22  |
| 12 | check_quiesce_snapshot_custom_script |   Passed        | 00:00:55  |
| 13 | memory_hot_add_basic                 |   Passed        | 00:05:02  |
| 14 | cpu_hot_add_basic                    |   Passed        | 00:04:30  |
| 15 | cpu_multicores_per_socket            |   Passed        | 00:07:13  |
| 16 | check_efi_firmware                   |   Passed        | 00:00:36  |
| 17 | secureboot_enable_disable            | * Not Supported | 00:00:34  |
| 18 | e1000e_network_device_ops            |   Passed        | 00:03:34  |
| 19 | vmxnet3_network_device_ops           |   Passed        | 00:02:51  |
| 20 | pvrdma_network_device_ops            |   Passed        | 00:07:35  |
| 21 | gosc_perl_dhcp                       |   Passed        | 00:05:19  |
| 22 | gosc_perl_staticip                   |   Passed        | 00:04:58  |
| 23 | gosc_cloudinit_dhcp                  |   Passed        | 00:05:48  |
| 24 | gosc_cloudinit_staticip              |   Passed        | 00:05:32  |
| 25 | paravirtual_vhba_device_ops          |   Passed        | 00:05:49  |
| 26 | lsilogic_vhba_device_ops             | * Not Supported | 00:00:28  |
| 27 | lsilogicsas_vhba_device_ops          | * Not Supported | 00:00:31  |
| 28 | sata_vhba_device_ops                 |   Passed        | 00:06:13  |
| 29 | nvme_vhba_device_ops                 |   Passed        | 00:06:07  |
| 30 | nvdimm_cold_add_remove               |   Passed        | 00:06:53  |
| 31 | ovt_verify_pkg_uninstall             |   Passed        | 00:02:37  |
+-------------------------------------------------------------------------+
```