### PR TITLE
[Linux] Skip LSILogic and LSILogicSAS testing for RHCOS 4.16.0 or later

### DIFF
--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -16,9 +16,11 @@
       when:
         - new_disk_ctrl_type in ["lsilogic", "lsilogicsas"]
         - guest_os_family == "RedHat"
-        - guest_os_ansible_distribution_major_ver | int >= 8
+        - ((guest_os_ansible_distribution == "RHCOS" and
+            guest_os_ansible_distribution_ver is version('4.16', '>=')) or
+           (guest_os_ansible_distribution not in ["RHCOS",  "Kylin Linux Advanced Server"] and
+           guest_os_ansible_distribution_major_ver | int >= 8))
         - "'uek' not in guest_os_ansible_kernel"
-        - guest_os_ansible_distribution != "Kylin Linux Advanced Server"
 
     - name: "Skip test case for unsupported hardware version"
       include_tasks: ../../common/skip_test_case.yml


### PR DESCRIPTION
Since RHCOS 4.16.0, LSILogic and LSILogicSAS  controllers are not supported. Skip the two vHBA test cases.