### PR TITLE
[Linux] Fix PVRDMA failure due to server VM or client VM IP changed for Ubuntu

### DIFF
--- a/linux/network_device_ops/pvrdma_client_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_client_network_device_ops.yml
@@ -43,9 +43,6 @@
       with_list: "{{ range(1, 11) | list }}"
       loop_control:
         loop_var: retry_count
-      when: >
-        (not pvrdma_client_vm_guest_ip) or
-        (pvrdma_client_vm_guest_ip in pvrdma_client_vm_invalid_ips)
 
     - name: "Check client VM's guest IP is not same with server VM's guest IP"
       ansible.builtin.assert:

--- a/linux/network_device_ops/pvrdma_client_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_client_network_device_ops.yml
@@ -38,21 +38,19 @@
       vars:
         vm_power_state_set: 'restarted'
 
-    - name: "Get client VM's guest IP"
-      block:
-        - name: "Refresh client VM's guest IP till it has different IP with server VM"
-          include_tasks: refresh_pvrdma_client_vm_ip.yml
-          with_list: "{{ range(1, 11) | list }}"
-          loop_control:
-            loop_var: retry_count
+    - name: "Refresh client VM's guest IP till it has different IP with server VM"
+      include_tasks: refresh_pvrdma_client_vm_ip.yml
+      with_list: "{{ range(1, 11) | list }}"
+      loop_control:
+        loop_var: retry_count
       when: >
         (not pvrdma_client_vm_guest_ip) or
-        (pvrdma_client_vm_guest_ip == pvrdma_server_vm_guest_ip)
+        (pvrdma_client_vm_guest_ip in pvrdma_client_vm_invalid_ips)
 
     - name: "Check client VM's guest IP is not same with server VM's guest IP"
       ansible.builtin.assert:
         that:
-          - pvrdma_client_vm_guest_ip != pvrdma_server_vm_guest_ip
+          - pvrdma_client_vm_guest_ip not in pvrdma_client_vm_invalid_ips
         fail_msg: >-
           Client VM '{{ pvrdma_client_vm_name }}' guest IP is '{{ pvrdma_client_vm_guest_ip }}',
           which is same with server VM '{{ pvrdma_server_vm_name }}' guest IP after refreshing 10 times.
@@ -92,6 +90,11 @@
         that:
           - ping_success_after_hotadd | bool
         fail_msg: "Failed to ping gateway from PVRDMA device on client VM {{ vm_name }}"
+
+    - name: "Update client VM guest IP when it changes"
+      ansible.builtin.set_fact:
+        pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"
+      when: pvrdma_client_vm_guest_ip != vm_guest_ip
 
     - name: "Check PVRDMA device status and reload it if necessary on client VM"
       include_tasks: check_and_reload_pvrdma.yml

--- a/linux/network_device_ops/pvrdma_client_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_client_network_device_ops.yml
@@ -39,7 +39,12 @@
         vm_power_state_set: 'restarted'
 
     - name: "Refresh client VM's guest IP till it has different IP with server VM"
-      include_tasks: refresh_pvrdma_client_vm_ip.yml
+      include_tasks:
+        file: refresh_pvrdma_client_vm_ip.yml
+        apply:
+          when: >
+             (not pvrdma_client_vm_guest_ip) or
+             (pvrdma_client_vm_guest_ip in pvrdma_client_vm_invalid_ips)
       with_list: "{{ range(1, 11) | list }}"
       loop_control:
         loop_var: retry_count

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -93,7 +93,7 @@
 
         - name: "Update server VM guest IP when it changes"
           ansible.builtin.set_fact:
-            pvrdma_client_vm_invalid_ips: ["{{ pvrdma_server_vm_guest_ip }}", "{{ vm_guest_ip }}"]
+            pvrdma_client_vm_invalid_ips: "{{ pvrdma_client_vm_invalid_ips | union([vm_guest_ip]) }}"
             pvrdma_server_vm_guest_ip: "{{ vm_guest_ip }}"
           when: pvrdma_server_vm_guest_ip != vm_guest_ip
 

--- a/linux/network_device_ops/pvrdma_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_network_device_ops.yml
@@ -28,6 +28,7 @@
             pvrdma_client_vm_name: "{{ vm_name }}_client_{{ current_test_timestamp }}"
             pvrdma_client_vm_guest_ip: ""
             pvrdma_client_test_log_folder: "{{ current_test_log_folder }}/{{ vm_name }}_client_{{ current_test_timestamp }}"
+            pvrdma_client_vm_invalid_ips: ["{{ vm_guest_ip }}"]
 
         - name: "Create test log folders for server VM and client VM"
           include_tasks: ../../common/create_directory.yml
@@ -89,6 +90,12 @@
 
         - name: "Hot add a new {{ adapter_type }} network adapter on server VM and apply network config"
           include_tasks: hot_add_network_adapter.yml
+
+        - name: "Update server VM guest IP when it changes"
+          ansible.builtin.set_fact:
+            pvrdma_client_vm_invalid_ips: ["{{ pvrdma_server_vm_guest_ip }}", "{{ vm_guest_ip }}"]
+            pvrdma_server_vm_guest_ip: "{{ vm_guest_ip }}"
+          when: pvrdma_server_vm_guest_ip != vm_guest_ip
 
         - name: "Set fact of the PVRDMA network adapter mac address for server VM"
           ansible.builtin.set_fact:

--- a/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
+++ b/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
@@ -6,24 +6,19 @@
 #   restart. It needs to take few seconds to refresh its own IP address.
 #   This task file will refresh client VM's IP every 10s.
 #
-- name: "Refresh client VM's guest IP"
-  when: >
-     (not pvrdma_client_vm_guest_ip) or
-     (pvrdma_client_vm_guest_ip in pvrdma_client_vm_invalid_ips)
-  block:
-    - name: "Print retry count for refreshing client VM's guest IP"
-      ansible.builtin.debug: var=retry_count
+- name: "Print retry count for refreshing client VM's guest IP"
+  ansible.builtin.debug: var=retry_count
 
-    - name: "Sleep 10s for client VM's guest IP refreshing"
-      ansible.builtin.pause:
-        seconds: 10
+- name: "Sleep 10s for client VM's guest IP refreshing"
+  ansible.builtin.pause:
+    seconds: 10
 
-    - name: "Get client VM's guest IP"
-      include_tasks: ../../common/vm_get_ip.yml
-      vars:
-        vm_primary_nic_mac: "{{ pvrdma_client_vm_primary_nic_mac }}"
-        vm_get_ip_timeout: "300"
+- name: "Get client VM's guest IP"
+  include_tasks: ../../common/vm_get_ip.yml
+  vars:
+    vm_primary_nic_mac: "{{ pvrdma_client_vm_primary_nic_mac }}"
+    vm_get_ip_timeout: "300"
 
-    - name: "Update the fact of client VM's guest IP"
-      ansible.builtin.set_fact:
-        pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"
+- name: "Update the fact of client VM's guest IP"
+  ansible.builtin.set_fact:
+    pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"

--- a/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
+++ b/linux/network_device_ops/refresh_pvrdma_client_vm_ip.yml
@@ -6,19 +6,24 @@
 #   restart. It needs to take few seconds to refresh its own IP address.
 #   This task file will refresh client VM's IP every 10s.
 #
-- name: "Print retry count for refreshing client VM's guest IP"
-  ansible.builtin.debug: var=retry_count
+- name: "Refresh client VM's guest IP"
+  when: >
+     (not pvrdma_client_vm_guest_ip) or
+     (pvrdma_client_vm_guest_ip in pvrdma_client_vm_invalid_ips)
+  block:
+    - name: "Print retry count for refreshing client VM's guest IP"
+      ansible.builtin.debug: var=retry_count
 
-- name: "Sleep 10s for client VM's guest IP refreshing"
-  ansible.builtin.pause:
-    seconds: 10
+    - name: "Sleep 10s for client VM's guest IP refreshing"
+      ansible.builtin.pause:
+        seconds: 10
 
-- name: "Get client VM's guest IP"
-  include_tasks: ../../common/vm_get_ip.yml
-  vars:
-    vm_primary_nic_mac: "{{ pvrdma_client_vm_primary_nic_mac }}"
-    vm_get_ip_timeout: "300"
+    - name: "Get client VM's guest IP"
+      include_tasks: ../../common/vm_get_ip.yml
+      vars:
+        vm_primary_nic_mac: "{{ pvrdma_client_vm_primary_nic_mac }}"
+        vm_get_ip_timeout: "300"
 
-- name: "Update the fact of client VM's guest IP"
-  ansible.builtin.set_fact:
-    pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"
+    - name: "Update the fact of client VM's guest IP"
+      ansible.builtin.set_fact:
+        pvrdma_client_vm_guest_ip: "{{ vm_guest_ip }}"

--- a/linux/network_device_ops/start_pvrdma_server.yml
+++ b/linux/network_device_ops/start_pvrdma_server.yml
@@ -8,7 +8,7 @@
     pvrdma_server_start_cmd: "rping -s -a {{ pvrdma_server_vm_ipv4 }} -P"
 
 - name: "Start listening process on server VM for RDMA ping-pong test"
-  ansible.builtin.shell: "{{ pvrdma_server_start_cmd }}"
+  ansible.builtin.shell: "{{ pvrdma_server_start_cmd }} &"
   vars:
     ansible_async_dir: /tmp/.ansible_async/
   async: 120
@@ -16,7 +16,16 @@
   delegate_to: "{{ vm_guest_ip }}"
   changed_when: false
   ignore_unreachable: true
+  ignore_errors: true
   register: pvrdma_server_job
+  until:
+    - pvrdma_server_job.started is defined
+    - pvrdma_server_job.started == 1
+  retries: 10
+  delay: 5
+
+- name: "Display async job result"
+  ansible.builtin.debug: var=pvrdma_server_job
 
 - name: "Check async job is started on server VM"
   ansible.builtin.assert:


### PR DESCRIPTION
The VM guest IP might be changed after hot adding a new adapter and apply new netplan config on Ubuntu.
This fix updated the server VM and client VM guest IP after hot adding new adapter. And added retries to start PVRDMA server rping listening.

```
+-------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                |
|                           | bitness='64'                                      |
|                           | distroAddlVersion='22.04.4 LTS (Jammy Jellyfish)' |
|                           | distroName='Ubuntu'                               |
|                           | distroVersion='22.04'                             |
|                           | familyName='Linux'                                |
|                           | kernelVersion='5.15.0-113-generic'                |
|                           | prettyName='Ubuntu 22.04.4 LTS'                   |
+-------------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:10:23)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | pvrdma_network_device_ops | Passed | 00:10:02  |
+-----------------------------------------------------+
```