### PR TITLE
[Linux] Support to test installing open-vm-tools from source on Suse family OS

### DIFF
--- a/linux/open_vm_tools/install_ovt_from_source.yml
+++ b/linux/open_vm_tools/install_ovt_from_source.yml
@@ -141,13 +141,6 @@
 - name: "Check open-vm-tools required files are installed"
   include_tasks: check_ovt_files_exist.yml
 
-- name: "Add and enable open-vm-tools service"
-  include_tasks: add_enable_service.yml
-  vars:
-    service_name: "{{ ovt_service_name }}"
-    service_file: "{{ ovt_service_file }}"
-    service_file_local_path: "{{ ovt_service_file_local_path | default('') }}"
-
 - name: "Add and enable VGAuthService service"
   include_tasks: add_enable_service.yml
   vars:
@@ -157,3 +150,10 @@
   when:
     - vgauth_service_name
     - vgauth_service_file
+
+- name: "Add and enable open-vm-tools service"
+  include_tasks: add_enable_service.yml
+  vars:
+    service_name: "{{ ovt_service_name }}"
+    service_file: "{{ ovt_service_file }}"
+    service_file_local_path: "{{ ovt_service_file_local_path | default('') }}"

--- a/linux/open_vm_tools/pre_ovt_install.yml
+++ b/linux/open_vm_tools/pre_ovt_install.yml
@@ -84,7 +84,7 @@
     skip_reason: "Not Supported"
   when:
     - linux_ovt_install_type == "source"
-    - guest_os_family not in ["Debian", "FreeBSD"]
+    - guest_os_family not in ["Suse", "Debian", "FreeBSD"]
 
 - name: "Initialize fact whether to uninstall open-vm-tools"
   ansible.builtin.set_fact:

--- a/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
@@ -1,6 +1,6 @@
 # This file lists the dependent packages for building open-vm-tools source tarball
-{% if guest_os_family == 'Debian' %}
 dependencies:
+{% if guest_os_family == 'Debian' %}
   - gcc
   - g++
   - make
@@ -24,5 +24,46 @@ dependencies:
   - libgtk-3-dev
   - libgtkmm-3.0-dev
   - lsof
-configure_options: []
+{% elif guest_os_family == 'Suse' %}
+  - autoconf
+  - automake
+  - doxygen
+  - fuse3
+  - fuse3-devel
+  - gcc
+  - gcc-c++
+  - gdk-pixbuf-xlib-devel
+  - glib2-devel
+  - gtk3-devel
+  - gtkmm3-devel
+  - libcurl-devel
+  - libdnet-devel
+  - libdrm-devel
+  - libmspack-devel
+  - libopenssl-devel
+  - libtirpc-devel
+  - libtool
+  - libudev-devel
+  - libX11-devel
+  - libXext-devel
+  - libXi-devel
+  - libXinerama-devel
+  - libxml2-devel
+  - libXrandr-devel
+  - libXrender-devel
+  - libXtst-devel
+  - make
+  - net-tools
+  - pam-devel
+  - pkg-config
+  - procps-devel
+  - rpcgen
+  - rpm-build
+  - udev
+  - update-desktop-files
+  - valgrind-devel
+  - xmlsec1-devel
+  - xmlsec1-openssl-devel
+  - xorg-x11-devel
 {% endif %}
+configure_options: []

--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -37,7 +37,7 @@
 
 # Disable all existing repos
 - include_tasks: ../utils/disable_repo.yml
-  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED']
+  when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', "openSUSE Leap"]
 
 # Get the fact of system devices
 - include_tasks: ../../common/get_system_info.yml

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -127,16 +127,24 @@
             baseurl: "http://prolinux-repo.tmaxos.com/prolinux/$releasever/os/$basearch/AppStream"
       when: guest_os_ansible_distribution_major_ver | int >= 8
 
-- name: "Add online repositories for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+- name: "Set online repositories for {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    online_repos:
+      - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_OSS"
+        baseurl: "http://download.opensuse.org/distribution/leap/$releasever/repo/oss"
+  when: guest_os_ansible_distribution == "openSUSE Leap"
+
+- name: "Add online repositories for {{ vm_guest_os_distribution }}"
   include_tasks: add_repo_from_baseurl.yml
   vars:
     repo_name: "{{ online_repo.name }}"
     repo_baseurl: "{{ online_repo.baseurl }}"
-    gpg_check: true
+    gpg_check: "{{ guest_os_family == 'RedHat' }}"
   with_list: "{{ online_repos }}"
   loop_control:
     loop_var: "online_repo"
-  when: guest_os_ansible_distribution in ["CentOS", "Rocky", "OracleLinux", "ProLinux"]
+  when: guest_os_ansible_distribution in ["CentOS", "Rocky", "OracleLinux",
+                                          "ProLinux", "openSUSE Leap"]
 
 - name: "Set APT sources list for {{ guest_os_ansible_distribution }}"
   when: guest_os_family == "Debian"


### PR DESCRIPTION
This fix is to enable ovt_verify_src_install for Suse family OS, including SLED, SLES and openSUSE.

Regression tests passed with SLED 15 SP6, SLES 15 SP6, openSUSE Leap 15.6, Debian 10&11&12, Pardus 21&23, Ubuntu 20.04&22.04&23.04.