### PR TITLE
[Linux] Mask packagekit service for Suse family OS

### DIFF
--- a/autoinstall/SLE/15/SP3/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLED/autoinst.xml
@@ -1542,6 +1542,8 @@
 {% if new_user is defined and new_user != 'root' %}
         echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 {% endif %}
+        echo 'Mask service packagekit.service' >/dev/ttyS0
+        systemctl mask packagekit >/dev/ttyS0
         echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
         ]]>
        </source>

--- a/autoinstall/SLE/15/SP3/SLES/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLES/autoinst.xml
@@ -1430,6 +1430,8 @@
 {% if new_user is defined and new_user != 'root' %}
         echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 {% endif %}
+        echo 'Mask service packagekit.service' >/dev/ttyS0
+        systemctl mask packagekit >/dev/ttyS0
         echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
         ]]>
        </source>

--- a/autoinstall/SLE/15/SP3/SLES_Minimal/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLES_Minimal/autoinst.xml
@@ -1009,6 +1009,8 @@
 {% if new_user is defined and new_user != 'root' %}
         echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 {% endif %}
+        echo 'Mask service packagekit.service' >/dev/ttyS0
+        systemctl mask packagekit >/dev/ttyS0
         echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
         ]]>
        </source>

--- a/autoinstall/SLE/15/SP4/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP4/SLED/autoinst.xml
@@ -1515,6 +1515,8 @@
 {% if new_user is defined and new_user != 'root' %}
         echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 {% endif %}
+        echo 'Mask service packagekit.service' >/dev/ttyS0
+        systemctl mask packagekit >/dev/ttyS0
         echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
         ]]>
        </source>

--- a/autoinstall/openSUSE/15/autoinst.xml
+++ b/autoinstall/openSUSE/15/autoinst.xml
@@ -1411,6 +1411,8 @@
 {% if new_user is defined and new_user != 'root' %}
         echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 {% endif %}
+        echo 'Mask service packagekit.service' >/dev/ttyS0
+        systemctl mask packagekit >/dev/ttyS0
         echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
         ]]>
                 </source>

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -60,6 +60,10 @@
             state: 'stopped'
             enabled: false
           delegate_to: "{{ vm_guest_ip }}"
+        
+        - name: "Mask 'PackageKit' service"
+          ansible.builtin.command: "systemctl mask packagekit"
+          delegate_to: "{{ vm_guest_ip }}"
 
         - name: "Reboot VM to make sure packagekit.service is disabled and stopped"
           include_tasks: ../utils/reboot.yml

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -48,31 +48,17 @@
       vars:
         service_name: "packagekit.service"
 
-    - name: "Stop and disable 'PackageKit' service"
+    - name: "Mask 'PackageKit' service"
       when:
         - service_info
         - service_info.state is defined
-        - service_info.state in ['active', 'running']
       block:
-        - name: "Stop and disable 'PackageKit' service"
-          ansible.builtin.service:
-            name: 'packagekit.service'
-            state: 'stopped'
-            enabled: false
-          delegate_to: "{{ vm_guest_ip }}"
-        
         - name: "Mask 'PackageKit' service"
           ansible.builtin.command: "systemctl mask packagekit"
           delegate_to: "{{ vm_guest_ip }}"
 
         - name: "Reboot VM to make sure packagekit.service is disabled and stopped"
           include_tasks: ../utils/reboot.yml
-
-    - name: "Remove 'PackageKit' package from SLED"
-      include_tasks: ../utils/install_uninstall_package.yml
-      vars:
-        package_list: ["PackageKit"]
-        package_state: "absent"
 
 - name: "Reconfigure FreeBSD"
   when: guest_os_family == "FreeBSD"


### PR DESCRIPTION
Issue:
ovt_verify_pkg_install failed due to running /usr/lib/packagekitd on opensuse-15.6-GA-64bit


Test result:
1) Passed this testcases for 4 times trying

2) The status of packagekit.service is expected when check VM

3) Note:
systemctl disable packagekit.service
     disable makes the unit disabled during boot. But that unit can be started anytime after boot. 

systemctl mask packagekit.service
     mask disables the unit completely. It can't be started without unmasking. That automatically implies it will fail during boot. 

