### PR TITLE
update autoinst.xml without separate /home partition for opensuse/sle-15.6

### DIFF
--- a/autoinstall/SLE/15/SP3/SLES/autoinst.xml
+++ b/autoinstall/SLE/15/SP3/SLES/autoinst.xml
@@ -686,7 +686,7 @@
           <partition_nr t="integer">2</partition_nr>
           <quotas t="boolean">true</quotas>
           <resize t="boolean">false</resize>
-          <size>26306674688</size>
+          <size>max</size>
           <subvolumes t="list">
             <subvolume t="map">
               <copy_on_write t="boolean">false</copy_on_write>
@@ -710,6 +710,10 @@
             </subvolume>
             <subvolume t="map">
               <copy_on_write t="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
               <path>opt</path>
             </subvolume>
             <subvolume t="map">
@@ -722,17 +726,6 @@
             </subvolume>
           </subvolumes>
           <subvolumes_prefix>@</subvolumes_prefix>
-        </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <filesystem t="symbol">xfs</filesystem>
-          <format t="boolean">true</format>
-          <mount>/home</mount>
-          <mountby t="symbol">uuid</mountby>
-          <partition_id t="integer">131</partition_id>
-          <partition_nr t="integer">3</partition_nr>
-          <resize t="boolean">false</resize>
-          <size>13956546560</size>
         </partition>
         <partition t="map">
           <create t="boolean">true</create>

--- a/autoinstall/SLE/15/SP4/SLED/autoinst.xml
+++ b/autoinstall/SLE/15/SP4/SLED/autoinst.xml
@@ -640,7 +640,7 @@
           <partition_nr t="integer">2</partition_nr>
           <quotas t="boolean">true</quotas>
           <resize t="boolean">false</resize>
-          <size>15323889664</size>
+          <size>max</size>
           <subvolumes t="list">
             <subvolume t="map">
               <copy_on_write t="boolean">false</copy_on_write>

--- a/autoinstall/openSUSE/15/autoinst.xml
+++ b/autoinstall/openSUSE/15/autoinst.xml
@@ -602,7 +602,7 @@
                     <partition_nr t="integer">2</partition_nr>
                     <quotas t="boolean">false</quotas>
                     <resize t="boolean">false</resize>
-                    <size>42411736576</size>
+                    <size>max</size>
                     <subvolumes t="list">
                         <subvolume t="map">
                             <copy_on_write t="boolean">false</copy_on_write>


### PR DESCRIPTION
- Update autoinst.xml without separate /home partition for SLE and openSUSE
  - Per https://documentation.suse.com/sles/15-SP3/single-html/SLES-autoyast/index.html: One partition can have the value max to use all remaining space. 
- Autoinstall and testing passed with sles-15.3/15.6, sled-15.6 and opensuse-15.6
```
# cat /etc/os-release
NAME="SLES"
VERSION="15-SP6"
VERSION_ID="15.6"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP6"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp6"
DOCUMENTATION_URL="https://documentation.suse.com/"
# df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda2        78G  4.6G   72G   7% /
devtmpfs        4.0M     0  4.0M   0% /dev
tmpfs           1.8G     0  1.8G   0% /dev/shm
efivarfs        256K   55K  197K  22% /sys/firmware/efi/efivars
tmpfs           731M   18M  714M   3% /run
/dev/sda2        78G  4.6G   72G   7% /.snapshots
/dev/sda2        78G  4.6G   72G   7% /boot/grub2/i386-pc
/dev/sda2        78G  4.6G   72G   7% /boot/grub2/x86_64-efi
/dev/sda2        78G  4.6G   72G   7% /home
/dev/sda2        78G  4.6G   72G   7% /opt
/dev/sda2        78G  4.6G   72G   7% /root
/dev/sda2        78G  4.6G   72G   7% /srv
/dev/sda2        78G  4.6G   72G   7% /tmp
/dev/sda2        78G  4.6G   72G   7% /usr/local
/dev/sda2        78G  4.6G   72G   7% /var
/dev/sda1       511M  5.9M  506M   2% /boot/efi
tmpfs           366M   72K  366M   1% /run/user/464
tmpfs           366M   52K  366M   1% /run/user/0
``` 