### PR TITLE
Change to skip running included tasks when condition not meet and refine unnecessary filter

### DIFF
--- a/common/set_vmware_module_hostname.yml
+++ b/common/set_vmware_module_hostname.yml
@@ -5,6 +5,10 @@
 # When vcenter_hostname defined then use it, else use esxi_hostname
 # as the host name when using Ansible VMware modules
 #
+- name: "Initialize vCenter server info configured status"
+  ansible.builtin.set_fact:
+    vcenter_is_defined: false
+
 - name: "Set vCenter hostname for Ansible VMware modules to connect"
   ansible.builtin.set_fact:
     vsphere_host_name: "{{ vcenter_hostname }}"
@@ -25,7 +29,7 @@
     vsphere_host_user: "{{ esxi_username }}"
     vsphere_host_user_password: "{{ esxi_password }}"
     vsphere_host_datacenter: "ha-datacenter"
-  when: vcenter_is_defined is undefined
+  when: not vcenter_is_defined
   no_log: "{{ hide_secrets | default(false) }}"
 
 - name: "Set default VM folder when it's undefined"

--- a/common/vm_get_vbs_status.yml
+++ b/common/vm_get_vbs_status.yml
@@ -2,19 +2,22 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Get Windows VM VBS enablement status
-- name: "Initialize VBS enablement status"
+- name: "Initialize VM VBS enablement status"
   set_fact:
     vm_vbs_enabled: false
-- include_tasks: vm_get_config.yml
+
+- name: "Get VM VBS enablement status"
+  include_tasks: vm_get_config.yml
   vars:
     property_list: ['config.flags.vbsEnabled']
-- name: Set fact of VM VBS enablement status
+
+- name: "Set fact of VM VBS enablement status"
   ansible.builtin.set_fact:
-    vm_vbs_enabled: "{{ vm_config.config.flags.vbsEnabled }}"
+    vm_vbs_enabled: "{{ vm_config.config.flags.vbsEnabled | bool }}"
   when:
     - vm_config.config is defined
     - vm_config.config.flags is defined
     - vm_config.config.flags.vbsEnabled is defined
-- name: "Display VM VBS status"
-  ansible.builtin.debug:
-    msg: "VM VBS is enabled: {{ vm_vbs_enabled }}"
+
+- name: "Display VM VBS enablement status"
+  ansible.builtin.debug: var=vm_vbs_enabled

--- a/common/vm_wait_log_msg.yml
+++ b/common/vm_wait_log_msg.yml
@@ -72,7 +72,7 @@
     - name: "Display log message wait result"
       ansible.builtin.debug:
         msg:
-          - "Found '{{ vm_wait_log_msg }}' message in VM log file '{{ vm_wait_log_name }}': {{ 'Success' if vm_wait_log_msg_success | bool else 'Failure' }}"
+          - "Found '{{ vm_wait_log_msg }}' message in VM log file '{{ vm_wait_log_name }}': {{ 'Success' if vm_wait_log_msg_success else 'Failure' }}"
           - "Found logs list: {{ vm_wait_log_msg_list }}"
 
     - name: "VM log info check failure"
@@ -80,7 +80,7 @@
         msg: "Found '{{ vm_wait_log_msg }}' message in VM log file '{{ vm_wait_log_name }}' appearing '{{ vm_wait_log_msg_list | length }}' times, while expect '{{ vm_wait_log_msg_times | default(1) }} times.'"
       when:
         - vm_wait_log_ignore_errors is undefined or not (vm_wait_log_ignore_errors | bool)
-        - not (vm_wait_log_msg_success | bool)
+        - not vm_wait_log_msg_success
   when:
     - file_in_datastore_result is defined
     - file_in_datastore_result == 'Success'

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -40,7 +40,7 @@
 
     - name: "Get vCenter Server version and build"
       include_tasks: ../common/vcenter_get_version_build.yml
-      when: vcenter_is_defined is defined and vcenter_is_defined
+      when: vcenter_is_defined
 
     - name: "Get ESXi version and build"
       include_tasks: ../common/esxi_get_version_build.yml

--- a/linux/check_efi_firmware/check_efi_firmware.yml
+++ b/linux/check_efi_firmware/check_efi_firmware.yml
@@ -37,7 +37,7 @@
         - name: "Check firmware is EFI in vmware.log and guest OS"
           ansible.builtin.assert:
             that:
-              - vm_wait_log_msg_success | bool
+              - vm_wait_log_msg_success
               - guest_firmware_is_efi
             fail_msg: "Failed to find EFI ROM info in vmware.log or guest OS firmware is not EFI."
             success_msg: "Found EFI ROM info in vmware.log, and guest OS firmware is EFI."

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -6,9 +6,7 @@
   vars:
     skip_msg: "Test case '{{ ansible_play_name }}' is skipped because vCenter server is not configured"
     skip_reason: "Not Applicable"
-  when: >
-    (vcenter_is_defined is undefined) or
-    (not vcenter_is_defined | bool)
+  when: not vcenter_is_defined
 
 - name: "Skip test case"
   include_tasks: ../../common/skip_test_case.yml

--- a/linux/host_verify_saml_token/host_verify_saml_token.yml
+++ b/linux/host_verify_saml_token/host_verify_saml_token.yml
@@ -16,7 +16,7 @@
             skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
             skip_reason: "Not Applicable"
           when: >
-            (vcenter_is_defined is undefined or not vcenter_is_defined) or
+            (not vcenter_is_defined) or
             (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
             (vcenter_ssh_password is undefined or not vcenter_ssh_password)
 

--- a/linux/network_device_ops/check_pvrdma_support_status.yml
+++ b/linux/network_device_ops/check_pvrdma_support_status.yml
@@ -10,9 +10,7 @@
       Test case '{{ ansible_play_name }}' is skipped because vCenter server is not configured,
       which is required for setting up vSphere Distributed Switch networking and cloning PVRDMA client VM.
     skip_reason: "Not Applicable"
-  when: >
-    (vcenter_is_defined is undefined) or
-    (not vcenter_is_defined | bool)
+  when: not vcenter_is_defined
 
 - name: "Skip test case for unsupported guest OS"
   include_tasks: ../../common/skip_test_case.yml
@@ -65,6 +63,4 @@
       Test case is blocked because test environment doesn't have vCenter Server,
       which doesn't meet PVRDMA requirements.
     skip_reason: "Blocked"
-  when: >
-    (vcenter_is_defined is undefined) or
-    (not vcenter_is_defined)
+  when: not vcenter_is_defined

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -91,7 +91,7 @@
           ansible.builtin.set_fact:
             secureboot_enabled_pass: true
           when:
-            - vm_wait_log_msg_success | bool
+            - vm_wait_log_msg_success
             - guest_secureboot_state == 'enabled'
 
         # Disable secureboot

--- a/windows/check_efi_firmware/check_efi_firmware.yml
+++ b/windows/check_efi_firmware/check_efi_firmware.yml
@@ -42,7 +42,7 @@
           ansible.builtin.assert:
             that:
               - firmware_os == "efi"
-              - vm_wait_log_msg_success | bool
+              - vm_wait_log_msg_success
             fail_msg: "Firmware got in guest OS is not EFI, or EFI info not found in vmware.log."
             success_msg: "Firmware got in guest OS is EFI, and EFI info got in vmware.log."
       rescue:

--- a/windows/check_efi_firmware/check_efi_firmware.yml
+++ b/windows/check_efi_firmware/check_efi_firmware.yml
@@ -10,27 +10,30 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
-        - name: Check VM configured firmware type
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
+        - name: "Get VM configured firmware type"
           include_tasks: ../../common/vm_get_config.yml
           vars:
             property_list: ['config.firmware']
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for VM with {{ vm_config.config.firmware }} firmware"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case '{{ ansible_play_name }}', VM firmware is not EFI: {{ vm_config.config.firmware }}"
             skip_reason: "Not Applicable"
           when: vm_config.config.firmware == "bios"
 
-        - name: Set searching keyword in vmware.log
+        - name: "Set searching keyword in vmware.log"
           ansible.builtin.set_fact:
             vmware_log_keyword: "The EFI ROM is .*{{ guest_os_ansible_architecture }}"
 
-        - name: Get firmware info in guest OS
+        - name: "Get firmware info in guest OS"
           include_tasks: ../utils/win_get_firmware.yml
 
-        - name: Search EFI ROM keyword in vmware.log
+        - name: "Search EFI ROM keyword in vmware.log"
           include_tasks: ../../common/vm_wait_log_msg.yml
           vars:
             vm_wait_log_name: "vmware.log"
@@ -46,4 +49,5 @@
             fail_msg: "Firmware got in guest OS is not EFI, or EFI info not found in vmware.log."
             success_msg: "Firmware got in guest OS is EFI, and EFI info got in vmware.log."
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/check_efi_firmware/check_efi_firmware.yml
+++ b/windows/check_efi_firmware/check_efi_firmware.yml
@@ -14,17 +14,13 @@
       block:
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
-        - name: "Get VM configured firmware type"
-          include_tasks: ../../common/vm_get_config.yml
-          vars:
-            property_list: ['config.firmware']
 
-        - name: "Skip test case for VM with {{ vm_config.config.firmware }} firmware"
+        - name: "Skip test case for VM with {{ vm_firmware }} firmware"
           include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Skip test case '{{ ansible_play_name }}', VM firmware is not EFI: {{ vm_config.config.firmware }}"
+            skip_msg: "Skip test case '{{ ansible_play_name }}', VM firmware is not EFI: {{ vm_firmware }}"
             skip_reason: "Not Applicable"
-          when: vm_config.config.firmware == "bios"
+          when: vm_firmware == "bios"
 
         - name: "Set searching keyword in vmware.log"
           ansible.builtin.set_fact:

--- a/windows/check_quiesce_snapshot/check_quiesce_snapshot.yml
+++ b/windows/check_quiesce_snapshot/check_quiesce_snapshot.yml
@@ -24,7 +24,7 @@
 
         - name: "Check disk.EnableUUID in VMX file"
           include_tasks: check_vmx_disk_enable_uuid.yml
-          when: guest_os_product_type | lower == "server"
+          when: guest_os_product_type == "server"
 
         - name: "Enable vss logging"
           include_tasks: ../utils/win_enable_vss_log.yml

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -12,8 +12,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
         - name: "Check VM VBS enablement status"
           when: guest_os_ansible_architecture == "64-bit"
@@ -26,40 +28,46 @@
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
 
-        - name: Set fact of the initial CPU number and cores per socket
+        - name: "Set fact of the initial CPU number to 2"
           ansible.builtin.set_fact:
             initial_cpu_num: 2
-            initial_cores_num: 2
-          when: guest_os_product_type == "client"
-
-        - name: Set fact of the initial CPU number and cores per socket
+        - name: "Set fact of the initial cores per socket"
           ansible.builtin.set_fact:
-            initial_cpu_num: 2
-            initial_cores_num: 1
-          when: guest_os_product_type == "server"
-        - include_tasks: ../../linux/cpu_hot_add_basic/generate_cpu_hot_add_list.yml
+            initial_cores_num: |-
+              {%- if guest_os_product_type == 'server' -%}1
+              {%- elif guest_os_product_type == 'client' -%}2
+              {%- endif -%}
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Generate the list of added CPU number for testing"
+          include_tasks: ../../linux/cpu_hot_add_basic/generate_cpu_hot_add_list.yml
+
+        - name: "Skip test case when the list of added CPU number is empty"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCPU hotadd test value list is empty"
             skip_reason: "Blocked"
           when: cpu_hotadd_num_list | length == 0
 
-        - name: Initialize the CPU hotadd test result
+        - name: "Initialize the CPU hotadd test result"
           ansible.builtin.set_fact:
             cpu_hotadd_results: []
-        - include_tasks: cpu_hot_add_prepare.yml
+        - name: "Preparation for CPU hotadd test"
+          include_tasks: cpu_hot_add_prepare.yml
           vars:
             enable_vm_cpu_hotadd: true
-        - include_tasks: cpu_hot_add_validate.yml
+        - name: "CPU hotadd test on Windows Server"
+          include_tasks: cpu_hot_add_validate.yml
           loop: "{{ cpu_hotadd_num_list }}"
           loop_control:
             loop_var: hotadd_num
           when: guest_os_product_type == "server"
 
-        - include_tasks: cpu_hot_add_test_client.yml
+        - name: "CPU hotadd test on Windows Client"
+          include_tasks: cpu_hot_add_test_client.yml
           when: guest_os_product_type == "client"
-        - name: Display the test results
+
+        - name: "Display the test results"
           ansible.builtin.debug: var=cpu_hotadd_results
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -15,27 +15,28 @@
     - block:
         - include_tasks: ../setup/test_setup.yml
 
-        - block:
+        - name: "Check VM VBS enablement status"
+          when: guest_os_ansible_architecture == "64-bit"
+          block:
             # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
             - include_tasks: ../../common/vm_get_vbs_status.yml
             - include_tasks: ../../common/skip_test_case.yml
               vars:
                 skip_msg: "Skip test case due to CPU hotadd not supported for VM with VBS enabled."
                 skip_reason: "Not Supported"
-              when: vm_vbs_enabled is defined and vm_vbs_enabled | bool
-          when: guest_os_ansible_architecture == "64-bit"
+              when: vm_vbs_enabled
 
         - name: Set fact of the initial CPU number and cores per socket
           ansible.builtin.set_fact:
             initial_cpu_num: 2
             initial_cores_num: 2
-          when: guest_os_product_type | lower == "client"
+          when: guest_os_product_type == "client"
 
         - name: Set fact of the initial CPU number and cores per socket
           ansible.builtin.set_fact:
             initial_cpu_num: 2
             initial_cores_num: 1
-          when: guest_os_product_type | lower == "server"
+          when: guest_os_product_type == "server"
         - include_tasks: ../../linux/cpu_hot_add_basic/generate_cpu_hot_add_list.yml
 
         - include_tasks: ../../common/skip_test_case.yml
@@ -54,10 +55,10 @@
           loop: "{{ cpu_hotadd_num_list }}"
           loop_control:
             loop_var: hotadd_num
-          when: guest_os_product_type | lower == "server"
+          when: guest_os_product_type == "server"
 
         - include_tasks: cpu_hot_add_test_client.yml
-          when: guest_os_product_type | lower == "client"
+          when: guest_os_product_type == "client"
         - name: Display the test results
           ansible.builtin.debug: var=cpu_hotadd_results
       rescue:

--- a/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
@@ -1,40 +1,47 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get current vCPU number from guest facts
-- include_tasks: ../../common/vm_get_guest_facts.yml
-- name: Set fact of vCPU number before hotadd
+- name: "Get VM facts"
+  include_tasks: ../../common/vm_get_guest_facts.yml
+
+- name: "Set fact of vCPU number before hotadd"
   ansible.builtin.set_fact:
     vcpu_before_hotadd: "{{ vm_guest_facts.instance.hw_processor_count }}"
-# Set hotadded vCPU number
-- name: Set fact of hotadd CPU number
-  ansible.builtin.set_fact:
-    vcpu_after_hotadd: "{{( vcpu_before_hotadd | int) + (hotadd_num | int) }}"
 
-- ansible.builtin.debug:
+- name: "Set fact of hotadd CPU number"
+  ansible.builtin.set_fact:
+    vcpu_after_hotadd: "{{ vcpu_before_hotadd | int + hotadd_num | int }}"
+
+- name: "Target CPU number is larger than the maximum number"
+  ansible.builtin.debug:
     msg: "Hotadd '{{ hotadd_num }}', VM vCPU number is '{{ vcpu_after_hotadd }}', greater than '{{ max_num_cpus }}', skip hotadd test"
   when: vcpu_after_hotadd | int > max_num_cpus | int
 
-- block:
-    - include_tasks: ../../common/vm_set_cpu_number.yml
+- name: "Target CPU number not exceed the maximum number"
+  when: vcpu_after_hotadd | int <= max_num_cpus | int
+  block:
+    - name: "Change VM vCPU number"
+      include_tasks: ../../common/vm_set_cpu_number.yml
       vars:
         num_cpus: "{{ vcpu_after_hotadd }}"
         num_cores_per_socket: "{{ initial_cores_num }}"
 
-    - include_tasks: ../utils/win_check_winrm.yml
+    - name: "Check Windows VM winrm connection"
+      include_tasks: ../utils/win_check_winrm.yml
 
-    # In Windows 10 guest OS, use devcon to detect CPU
-    - block:
-        - include_tasks: ../utils/win_get_physical_cpu_devcon.yml
+    - name: "Use devcon to detect CPU in Windows Client"
+      when: guest_os_product_type == "client"
+      block:
+        - name: "Get CPU number in guest OS using devcon"
+          include_tasks: ../utils/win_get_physical_cpu_devcon.yml
           vars:
             target_guest_os_bitness: "{{ guest_os_ansible_architecture }}"
-        - name: Set fact of the CPU detected by devcon
+        - name: "Set fact of the CPU detected by devcon"
           ansible.builtin.set_fact:
             win_cpu_number: "{{ processor_number_devcon }}"
-      when: guest_os_product_type == "client"
 
-    # In Windows Server get CPU number in guest OS directly
-    - include_tasks: ../utils/win_get_cpu_cores_sockets.yml
+    - name: "Get CPU number in Windows Server directly" 
+      include_tasks: ../utils/win_get_cpu_cores_sockets.yml
       when: guest_os_product_type == "server"
 
     # Validate CPU number after hotadd
@@ -45,7 +52,6 @@
           - vm_set_cpu_number_result | int == win_cpu_number | int
         fail_msg: "Hotadd vCPU ({{ vcpu_before_hotadd }}->{{ vcpu_after_hotadd }}) failed"
 
-    - name: Add test result
+    - name: "Add test result"
       ansible.builtin.set_fact:
         cpu_hotadd_results: "{{ cpu_hotadd_results + ['vCPU hotadd succeeds: ' ~ vcpu_before_hotadd ~ '->' ~ vcpu_after_hotadd] }}"
-  when: vcpu_after_hotadd | int <= max_num_cpus | int

--- a/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
@@ -31,11 +31,11 @@
         - name: Set fact of the CPU detected by devcon
           ansible.builtin.set_fact:
             win_cpu_number: "{{ processor_number_devcon }}"
-      when: guest_os_product_type | lower == "client"
+      when: guest_os_product_type == "client"
 
     # In Windows Server get CPU number in guest OS directly
     - include_tasks: ../utils/win_get_cpu_cores_sockets.yml
-      when: guest_os_product_type | lower == "server"
+      when: guest_os_product_type == "server"
 
     # Validate CPU number after hotadd
     - name: "Verify hotadded vCPU can be detected in guest OS"

--- a/windows/deploy_vm/deploy_vm.yml
+++ b/windows/deploy_vm/deploy_vm.yml
@@ -29,13 +29,13 @@
           include_tasks: deploy_vm_from_iso.yml
           when: >
             (vm_deploy_method is undefined) or
-            (vm_deploy_method | lower == 'iso')
+            (vm_deploy_method == 'iso')
 
         - name: "Deploy VM from an OVF template"
           include_tasks: deploy_vm_from_ova.yml
           when:
             - vm_deploy_method is defined
-            - vm_deploy_method | lower == 'ova'
+            - vm_deploy_method == 'ova'
 
         - name: "Print VM guest IP address"
           ansible.builtin.debug: var=vm_guest_ip

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -10,7 +10,7 @@
     boot_disk_controller: "{{ boot_disk_controller if (boot_disk_controller is defined and boot_disk_controller) else 'lsilogicsas' }}"
     secureboot_enabled: "{{ secureboot_enabled if (secureboot_enabled is defined and secureboot_enabled) else false }}"
     network_adapter_type: "{{ 'e1000e' if (windows_has_inbox_driver is undefined or not windows_has_inbox_driver) else network_adapter_type }}"
-    firmware: "{{ firmware if (firmware is defined and firmware) else 'efi' }}"
+    firmware: "{{ firmware | lower if (firmware is defined and firmware) else 'efi' }}"
     boot_disk_size_gb: "{{ [64, boot_disk_size_gb | default(64) | int] | max }}"
 
 - name: "Update test case name for deploying VM from ISO image"
@@ -45,7 +45,7 @@
     vm_exists: true
 
 - name: "Handle VM with EFI firmware"
-  when: firmware | lower == "efi"
+  when: firmware == "efi"
   block:
     - name: "Enable secure boot"
       include_tasks: ../../common/vm_set_boot_options.yml
@@ -78,7 +78,7 @@
     vm_power_state_set: "powered-on"
 
 - name: "VM firmware is EFI"
-  when: firmware | lower == "efi"
+  when: firmware == "efi"
   block:
     - name: "Pause 5 seconds when VM power on"
       ansible.builtin.pause:
@@ -115,7 +115,7 @@
     vm_wait_log_ignore_errors: false
     vm_wait_log_hide_output: false
   when:
-    - firmware | lower == 'efi'
+    - firmware == 'efi'
     - secureboot_enabled is defined and secureboot_enabled
 
 - name: "Wait for VM network adapter is connected"
@@ -143,7 +143,7 @@
   when:
     - enable_vbs is defined and enable_vbs | bool
     - guest_id is match('.*64Guest')
-    - firmware | lower == "efi"
+    - firmware == "efi"
   block:
     - name: "Get guest OS system info"
       include_tasks: ../utils/get_windows_system_info.yml

--- a/windows/eflow_deploy/check_eflow_vm.yml
+++ b/windows/eflow_deploy/check_eflow_vm.yml
@@ -63,7 +63,7 @@
       - eflow_vm_static_ip
       - get_eflow_vm_ip == eflow_vm_static_ip
     fail_msg: "IP address got in EFLOW VM: '{{ get_eflow_vm_ip }}', which is not the same as the specified static one: '{{ eflow_vm_static_ip | default('') }}'"
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 
 - name: "Check EFLOW VM network connectivity"
   include_tasks: ../utils/win_execute_cmd.yml

--- a/windows/eflow_deploy/deploy_eflow_vm.yml
+++ b/windows/eflow_deploy/deploy_eflow_vm.yml
@@ -69,6 +69,7 @@
   when: guest_os_product_type == 'server'
 
 - name: "Add vswitch in Windows Server"
+  when: guest_os_product_type == 'server'
   block:
     - name: "Create new Internal vswitch"
       include_tasks: ../utils/win_create_vswitch.yml
@@ -83,7 +84,6 @@
       ansible.builtin.set_fact:
         eflow_vm_static_ip: "{{ ('.').join(win_vswitch_ip.split('.')[0:-1]) ~ '.249' }}"
         eflow_vm_gateway_ip: "{{ win_vswitch_gateway_ip }}"
-  when: guest_os_product_type == 'server'
 
 # Refer to doc: https://learn.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-on-windows-symmetric?view=iotedge-1.4&tabs=azure-portal%2Cpowershell
 - name: "Download and install EFLOW in guest OS"

--- a/windows/eflow_deploy/deploy_eflow_vm.yml
+++ b/windows/eflow_deploy/deploy_eflow_vm.yml
@@ -8,7 +8,7 @@
 - name: "Set fact of default vswitch name for Windows {{ guest_os_product_type }}"
   ansible.builtin.set_fact:
     win_vswitch_name: |-
-      {%- if guest_os_product_type | lower == 'server' -%}EFLOW-Int
+      {%- if guest_os_product_type == 'server' -%}EFLOW-Int
       {%- else -%}Default Switch
       {%- endif -%}
 
@@ -63,10 +63,10 @@
 # Enable Hyper-V
 - name: "Enable Hyper-V in Windows Client"
   include_tasks: ../utils/win_enable_client_hyperv.yml
-  when: guest_os_product_type | lower == 'client'
+  when: guest_os_product_type == 'client'
 - name: "Enable Hyper-V in Windows Server"
   include_tasks: ../utils/win_enable_server_hyperv.yml
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 
 - name: "Add vswitch in Windows Server"
   block:
@@ -83,7 +83,7 @@
       ansible.builtin.set_fact:
         eflow_vm_static_ip: "{{ ('.').join(win_vswitch_ip.split('.')[0:-1]) ~ '.249' }}"
         eflow_vm_gateway_ip: "{{ win_vswitch_gateway_ip }}"
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 
 # Refer to doc: https://learn.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-on-windows-symmetric?view=iotedge-1.4&tabs=azure-portal%2Cpowershell
 - name: "Download and install EFLOW in guest OS"
@@ -102,7 +102,7 @@
 - name: "Set fact of deploy EFLOW command"
   ansible.builtin.set_fact:
     deploy_eflow_command: |-
-      {%- if guest_os_product_type | lower == 'server' -%}Deploy-Eflow -vSwitchType 'Internal' -vSwitchName '{{ win_vswitch_name }}' -ip4Address {{ eflow_vm_static_ip }} -ip4GatewayAddress {{ eflow_vm_gateway_ip }} -ip4PrefixLength 24
+      {%- if guest_os_product_type == 'server' -%}Deploy-Eflow -vSwitchType 'Internal' -vSwitchName '{{ win_vswitch_name }}' -ip4Address {{ eflow_vm_static_ip }} -ip4GatewayAddress {{ eflow_vm_gateway_ip }} -ip4PrefixLength 24
       {%- else -%}Deploy-Eflow
       {%- endif -%}
 

--- a/windows/eflow_deploy/eflow_deploy.yml
+++ b/windows/eflow_deploy/eflow_deploy.yml
@@ -26,7 +26,7 @@
             skip_reason: "Not Supported"
           when:
             - guest_os_edition | lower not in ['pro', 'enterprise']
-            - guest_os_product_type | lower == 'client'
+            - guest_os_product_type == 'client'
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:

--- a/windows/eflow_deploy/eflow_deploy.yml
+++ b/windows/eflow_deploy/eflow_deploy.yml
@@ -10,17 +10,20 @@
   tasks:
     - name: "Test case block"
       block:
-        - include_tasks: ../setup/test_setup.yml
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
           vars:
             create_current_test_folder: true
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for not supported OS '{{ guest_os_ansible_architecture }}'"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to Hyper-V compatible hardware is 64bit processor, this guest OS is: {{ guest_os_ansible_architecture }}."
             skip_reason: "Not Supported"
           when: guest_os_ansible_architecture != "64-bit"
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for not supported OS edition '{{ guest_os_edition }}'"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to EFLOW supported OS edition is 'Pro' or 'Enterprise', this guest OS is: {{ guest_os_edition }}."
             skip_reason: "Not Supported"
@@ -28,7 +31,8 @@
             - guest_os_edition | lower not in ['pro', 'enterprise']
             - guest_os_product_type == 'client'
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case for not supported OS '{{ guest_os_ansible_distribution_major_ver }} {{ guest_os_build_num }}'"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg:
               - "Skip test case due to EFLOW supported version is 'Windows 10/Windows Server 2019 minimum build 17763 with all current cumulative updates installed' and 'Windows 11/Windows Server 2022'."
@@ -38,8 +42,12 @@
             (guest_os_ansible_distribution_major_ver | int == 10 and guest_os_build_num | int < 17763) or
             (guest_os_ansible_distribution_major_ver | int < 10)
 
-        - include_tasks: deploy_eflow_vm.yml
-        - include_tasks: check_eflow_vm.yml
-        - include_tasks: stop_start_eflow_vm.yml
+        - name: "Deploy EFLOW VM"
+          include_tasks: deploy_eflow_vm.yml
+        - name: "Check EFLOW VM"
+          include_tasks: check_eflow_vm.yml
+        - name: "EFLOW VM stop and start test"
+          include_tasks: stop_start_eflow_vm.yml
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/guest_customization/handle_guest_known_issues.yml
+++ b/windows/guest_customization/handle_guest_known_issues.yml
@@ -19,27 +19,27 @@
         loop_var: win_appx_package
       when:
         - guest_os_ansible_distribution_ver is version('10.0.22000.0', '>=')
-        - guest_os_product_type | lower == 'client'
+        - guest_os_product_type == 'client'
     - name: "Remove Edge.Stable Appx package in Windows Server"
       include_tasks: ../utils/win_remove_appx_package.yml
       vars:
         win_appx_package: "Edge.Stable"
         win_remove_appx_ignore_errors: true
-      when: guest_os_product_type | lower == 'server' 
+      when: guest_os_product_type == 'server' 
 
 # Parameter 'uninstall_onedrive' is used for internal testing only
 # when test case failure is caused by this
 - name: "Uninstall OneDrive in Windows Client"
   include_tasks: uninstall_onedrive.yml
   when:
-    - guest_os_product_type | lower == 'client'
+    - guest_os_product_type == 'client'
     - uninstall_onedrive is defined
     - uninstall_onedrive | bool
 
 # Disable BitLocker which will cause sysprep failure
 # BitLocker is not installed by default on Windows Server
 - name: "Disable BitLocker in Windows Client when it's enabled"
-  when: guest_os_product_type | lower == 'client'
+  when: guest_os_product_type == 'client'
   block:
     - name: "Get BitLocker service status"
       include_tasks: ../utils/win_get_service_status.yml

--- a/windows/guest_customization/uninstall_onedrive.yml
+++ b/windows/guest_customization/uninstall_onedrive.yml
@@ -20,8 +20,7 @@
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "Start-Process -NoNewWindow -Wait -FilePath {{ one_drive_setup_exe }} -ArgumentList '/uninstall'"
-  when:
-    - win_check_file_exist_result
+  when: win_check_file_exist_result
 
 - name: "Remove OneDriveSync Appx package"
   include_tasks: ../utils/win_remove_appx_package.yml

--- a/windows/guest_customization/uninstall_onedrive.yml
+++ b/windows/guest_customization/uninstall_onedrive.yml
@@ -21,7 +21,6 @@
   vars:
     win_powershell_cmd: "Start-Process -NoNewWindow -Wait -FilePath {{ one_drive_setup_exe }} -ArgumentList '/uninstall'"
   when:
-    - win_check_file_exist_result is defined
     - win_check_file_exist_result
 
 - name: "Remove OneDriveSync Appx package"

--- a/windows/guest_customization/win_gosc_prepare.yml
+++ b/windows/guest_customization/win_gosc_prepare.yml
@@ -8,7 +8,7 @@
 - name: "Prepare router VM, vSwitch and portgroup"
   include_tasks: ../../common/network_testbed_setup.yml
   when:
-    - (router_vm_deployed is undefined) or (not router_vm_deployed | bool)
+    - router_vm_deployed is undefined or not router_vm_deployed
     - gosc_network_type == "static"
 
 - name: "Save the VM password before GOSC"

--- a/windows/guest_customization/win_gosc_workflow.yml
+++ b/windows/guest_customization/win_gosc_workflow.yml
@@ -17,9 +17,7 @@
       vars:
         skip_msg: "Test case '{{ ansible_play_name }}' is skipped because vCenter server is not configured"
         skip_reason: "Not Applicable"
-      when: >
-        (vcenter_is_defined is undefined) or
-        (not vcenter_is_defined | bool)
+      when: not vcenter_is_defined
 
     - name: "Prepare Windows GOSC"
       include_tasks: win_gosc_prepare.yml

--- a/windows/guest_os_inplace_upgrade/execute_upgrade_gos.yml
+++ b/windows/guest_os_inplace_upgrade/execute_upgrade_gos.yml
@@ -13,7 +13,7 @@
       - windows_product_key_upgrade is defined
       - windows_product_key_upgrade
     fail_msg: "Windows product key for Windows Server upgrade is not set: {{ windows_product_key_upgrade | default('') }}."
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 
 # Refer to this doc for setup.exe command line options:
 # https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-setup-command-line-options?view=windows-11
@@ -29,7 +29,7 @@
 - name: "Add image index parameter to the command for Windows Server upgrade"
   ansible.builtin.set_fact:
     win_upgrade_setup_cmd: "{{ win_upgrade_setup_cmd ~ ' /imageindex ' ~ win_image_index }}"
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 
 - name: "Display the upgrade command to be executed"
   ansible.builtin.debug: var=win_upgrade_setup_cmd

--- a/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
+++ b/windows/guest_os_inplace_upgrade/mount_upgrade_to_iso.yml
@@ -68,11 +68,11 @@
 - name: "Set fact of Windows Server image keyword"
   ansible.builtin.set_fact:
     win_upgrade_image_keyword: ".*{{ guest_os_edition }}.*Desktop.*|.*SERVER{{ guest_os_edition | upper }}$"
-  when: guest_os_product_type | lower == 'server'
+  when: guest_os_product_type == 'server'
 - name: "Set fact of Windows Client image keyword"
   ansible.builtin.set_fact:
     win_upgrade_image_keyword: "*{{ guest_os_edition }}"
-  when: guest_os_product_type | lower == 'client'
+  when: guest_os_product_type == 'client'
 
 - name: "Get upgrade to image index and name"
   include_tasks: ../utils/win_get_image_index.yml

--- a/windows/host_verify_saml_token/host_verify_saml_token.yml
+++ b/windows/host_verify_saml_token/host_verify_saml_token.yml
@@ -16,7 +16,7 @@
             skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
             skip_reason: "Not Applicable"
           when: >
-            (vcenter_is_defined is undefined or not vcenter_is_defined) or
+            (not vcenter_is_defined) or
             (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
             (vcenter_ssh_password is undefined or not vcenter_ssh_password)
 

--- a/windows/mdag_enable_disable/mdag_enable_disable.yml
+++ b/windows/mdag_enable_disable/mdag_enable_disable.yml
@@ -20,7 +20,7 @@
           vars:
             skip_msg: "Skip test case due to MDAG is not supported on Windows Server."
             skip_reason: "Not Supported"
-          when: guest_os_product_type | lower == 'server'
+          when: guest_os_product_type == 'server'
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
@@ -36,7 +36,7 @@
             skip_reason: "Not Supported"
           when:
             - guest_os_edition | lower not in ['pro', 'enterprise', 'education']
-            - guest_os_product_type | lower == 'client'
+            - guest_os_product_type == 'client'
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -10,18 +10,23 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
-        - block:
+        - name: "Check if VM VBS is enabled"
+          when: guest_os_ansible_architecture == "64-bit"
+          block:
             # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
-            - include_tasks: ../../common/vm_get_vbs_status.yml
-            - include_tasks: ../../common/skip_test_case.yml
+            - name: "Get VM VBS status"
+              include_tasks: ../../common/vm_get_vbs_status.yml
+            - name: "Skip test case when VM VBS is enabled"
+              include_tasks: ../../common/skip_test_case.yml
               vars:
                 skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
-          when: guest_os_ansible_architecture == "64-bit"
 
         - name: "Set fact of initial memory size 2048MB for 32bit client"
           ansible.builtin.set_fact:
@@ -36,14 +41,17 @@
 
         # Memory limit for 32bit Windows is 4GB:
         # https://docs.microsoft.com/en-us/windows/win32/memory/memory-limits-for-windows-releases
-        - name: Set fact of memory hotadd list for 32bit Windows
+        - name: "Set fact of memory hotadd list for 32bit Windows"
           ansible.builtin.set_fact:
             memory_hotadd_size_list: [1024, 1024]
           when: guest_os_ansible_architecture == "32-bit"
-        - include_tasks: ../../linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
+
+        - name: "Generate hotadded memory size list for 64bit Windows"
+          include_tasks: ../../linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
           when: guest_os_ansible_architecture == "64-bit"
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case when hotadded memory size list is empty"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because memory hotadd test value list is empty"
             skip_reason: "Blocked"
@@ -53,19 +61,21 @@
         # to try to see if it can decrease the failure rate
         # - include_tasks: generate_cpu_num_list.yml
 
-        - name: Initialize the memory hotadd test result
+        - name: "Initialize the memory hotadd test result"
           ansible.builtin.set_fact:
             mem_hotadd_results: []
 
-        - include_tasks: ../utils/shutdown_vm.yml
-        # Enable memory hotadd
-        - include_tasks: ../../common/vm_enable_memory_hotadd.yml
+        - name: "Shutdown guest OS"
+          include_tasks: ../utils/shutdown_vm.yml
+        - name: "Enable memory hotadd"
+          include_tasks: ../../common/vm_enable_memory_hotadd.yml
 
-        # Do memory hotadd with different vCPU in the list
-        - include_tasks: hotadd_memory_for_vcpu.yml
+        - name: "Do memory hotadd with vCPU number 2"
+          include_tasks: hotadd_memory_for_vcpu.yml
           vars:
             vcpu_number: 2
-        - name: Display the test results
+        - name: "Display the test results"
           ansible.builtin.debug: var=mem_hotadd_results
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -20,7 +20,7 @@
               vars:
                 skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
                 skip_reason: "Not Supported"
-              when: vm_vbs_enabled is defined and vm_vbs_enabled | bool
+              when: vm_vbs_enabled
           when: guest_os_ansible_architecture == "64-bit"
 
         - name: "Set fact of initial memory size 2048MB for 32bit client"
@@ -28,7 +28,7 @@
             vm_initial_mem_mb: 2048
           when:
             - guest_os_ansible_architecture == "32-bit"
-            - guest_os_product_type | lower == "client"
+            - guest_os_product_type == "client"
         - name: "Set fact of initial memory size 4096MB for 64bit guest"
           ansible.builtin.set_fact:
             vm_initial_mem_mb: 4096

--- a/windows/network_device_ops/e1000e_network_device_ops.yml
+++ b/windows/network_device_ops/e1000e_network_device_ops.yml
@@ -9,17 +9,20 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Set fact of the network adapter type
+    - name: "Set fact of the network adapter type"
       ansible.builtin.set_fact:
         nic_type: 'E1000E'
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
-        # Prepare router VM, vSwitch and portgroup
-        - include_tasks: ../../common/network_testbed_setup.yml
+        - name: "Prepare router VM, vSwitch and portgroup" 
+          include_tasks: ../../common/network_testbed_setup.yml
           when: router_vm_deployed is undefined or not router_vm_deployed
 
-        # Add e1000e network adapter to VM and verify status
-        - include_tasks: network_adapter_deviceops.yml
+        - name: "Add e1000e network adapter to VM and verify status"
+          include_tasks: network_adapter_deviceops.yml
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/network_device_ops/e1000e_network_device_ops.yml
+++ b/windows/network_device_ops/e1000e_network_device_ops.yml
@@ -17,7 +17,7 @@
 
         # Prepare router VM, vSwitch and portgroup
         - include_tasks: ../../common/network_testbed_setup.yml
-          when: router_vm_deployed is undefined or not router_vm_deployed | bool
+          when: router_vm_deployed is undefined or not router_vm_deployed
 
         # Add e1000e network adapter to VM and verify status
         - include_tasks: network_adapter_deviceops.yml

--- a/windows/network_device_ops/vmxnet3_network_device_ops.yml
+++ b/windows/network_device_ops/vmxnet3_network_device_ops.yml
@@ -25,13 +25,13 @@
             skip_msg: "Skip this test case due to OS does not have inboxed {{ nic_type }} driver and VMware Tools is not installed."
             skip_reason: "Blocked"
           when:
-            - not (guest_os_with_inbox_drivers | bool)
-            - not (vmtools_is_installed | bool)
+            - not guest_os_with_inbox_drivers
+            - not vmtools_is_installed
 
         # Prepare router VM, vSwitch and portgroup
         - name: "Prepare network environment"
           include_tasks: ../../common/network_testbed_setup.yml
-          when: router_vm_deployed is undefined or not router_vm_deployed | bool
+          when: router_vm_deployed is undefined or not router_vm_deployed
 
         - name: "Start testing network operations"
           include_tasks: network_adapter_deviceops.yml

--- a/windows/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/windows/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -12,20 +12,24 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
-        # Get VM firmware info
-        - include_tasks: ../../common/vm_get_boot_info.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
+        - name: "Get VM firmware info"
+          include_tasks: ../../common/vm_get_boot_info.yml
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case when VM hardware version < 13"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Secure boot is not supported on VM of {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }} with hardware version {{ vm_hardware_version_num }}"
             skip_reason: "Not Supported"
           when: vm_hardware_version_num | int < 13
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case when VM firmware is {{ vm_firmware }}"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Skip test case due to VM firmware is not EFI: {{ vm_firmware }}"
+            skip_msg: "Skip test case due to VM firmware is '{{ vm_firmware }}', not EFI"
             skip_reason: "Not Applicable"
           when: vm_firmware != 'efi'
 
@@ -41,12 +45,14 @@
                 skip_reason: "Not Applicable"
               when: vm_vbs_enabled
 
-        # Enable, disable secure boot test if VM uses EFI firmware
-        - include_tasks: change_secureboot_config.yml
+        - name: "Enable VM secure boot test"
+          include_tasks: change_secureboot_config.yml
           vars:
             change_secureboot: 'enable'
-        - include_tasks: change_secureboot_config.yml
+        - name: "Disable VM secure boot test"
+          include_tasks: change_secureboot_config.yml
           vars:
             change_secureboot: 'disable'
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/windows/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -25,11 +25,12 @@
 
         - include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Skip test case due to VM firmware is not EFI: {{ vm_firmware | default('NA') }}"
+            skip_msg: "Skip test case due to VM firmware is not EFI: {{ vm_firmware }}"
             skip_reason: "Not Applicable"
-          when: vm_firmware is undefined or vm_firmware | lower != 'efi'
+          when: vm_firmware != 'efi'
 
         - name: "Skip {{ current_testcase_name }} if VBS is enabled"
+          when: guest_os_ansible_architecture == "64-bit"
           block:
             - name: "Get VBS status of VM"
               include_tasks: ../../common/vm_get_vbs_status.yml
@@ -38,8 +39,7 @@
               vars:
                 skip_msg: "Skip test case due to secure boot cannot be disabled for VM with VBS enabled."
                 skip_reason: "Not Applicable"
-              when: vm_vbs_enabled | bool
-          when: guest_os_ansible_architecture == "64-bit"
+              when: vm_vbs_enabled
 
         # Enable, disable secure boot test if VM uses EFI firmware
         - include_tasks: change_secureboot_config.yml

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -43,21 +43,20 @@
 - name: "Get VMware Tools status"
   include_tasks: ../../common/vm_get_vmtools_status.yml
 
-- name: "Block test case because VMware Toos is not installed or not running"
+- name: "Block test case because VMware Tools is not installed or not running"
   include_tasks: ../../common/skip_test_case.yml
   vars:
-    skip_msg: "Test case is blocked because VMware tools installed: {{ vmtools_is_installed | default(false) }}, running: {{ vmtools_is_running | default(false) }}"
+    skip_msg: "Test case is blocked because VMware Tools installed: {{ vmtools_is_installed }}, running: {{ vmtools_is_running }}"
     skip_reason: "Blocked"
   when:
     - skip_test_no_vmtools is defined
     - skip_test_no_vmtools
-    - not (vmtools_is_running is defined and vmtools_is_running | bool)
+    - not vmtools_is_running
 
 - name: "Get VMware Tools version and build"
   include_tasks: ../utils/win_get_vmtools_version_build.yml
   when:
-    - vmtools_is_installed is defined
-    - vmtools_is_installed | bool
+    - vmtools_is_installed
     - vmtools_info_from_vmtoolsd is undefined or not vmtools_info_from_vmtoolsd
 
 - name: "Get guest OS system info"
@@ -67,8 +66,7 @@
 - name: "Get VM guest info including guest id, full name, family and detailed data"
   include_tasks: ../../common/vm_get_guest_info.yml
   when:
-    - vmtools_is_running is defined
-    - vmtools_is_running | bool
+    - vmtools_is_running
     - guestinfo_gathered is undefined or not guestinfo_gathered
 
 - name: "Take a base snapshot if it does not exist"

--- a/windows/setup/win_guest_reconfig.yml
+++ b/windows/setup/win_guest_reconfig.yml
@@ -19,7 +19,7 @@
 
 # Disable Microsoft Store service
 - include_tasks: ../utils/win_disable_store_auto_update.yml
-  when: guest_os_product_type | lower == "client"
+  when: guest_os_product_type == "client"
 
 # Restart guest OS
 - include_tasks: ../utils/win_shutdown_restart.yml

--- a/windows/setup/win_guest_reconfig.yml
+++ b/windows/setup/win_guest_reconfig.yml
@@ -1,27 +1,28 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Disable sleep
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Disable power save in Windows guest OS"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "powercfg /change monitor-timeout-ac 0; powercfg /change disk-timeout-ac 0; powercfg /change standby-timeout-ac 0; powercfg /change hibernate-timeout-ac 0;"
 
-# Disable firewall
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Disable firewall in Windows guest OS"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "netsh advfirewall set allprofiles state off"
 
 # By default, Windows will restart automatically when BSOD,
 # diable this automatic reboot when failure
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Disable auto reboot in Windows guest OS"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "Get-CimInstance Win32_OSRecoveryConfiguration | Set-CimInstance -Property @{AutoReboot=$False}"
 
-# Disable Microsoft Store service
-- include_tasks: ../utils/win_disable_store_auto_update.yml
+- name: "Disable Microsoft Store service in Windows Client"
+  include_tasks: ../utils/win_disable_store_auto_update.yml
   when: guest_os_product_type == "client"
 
-# Restart guest OS
-- include_tasks: ../utils/win_shutdown_restart.yml
+- name: "Restart guest OS"
+  include_tasks: ../utils/win_shutdown_restart.yml
   vars:
     set_win_power_state: "restart"

--- a/windows/utils/add_windows_host.yml
+++ b/windows/utils/add_windows_host.yml
@@ -3,10 +3,20 @@
 ---
 # Add Windows guest IP address to in-memory host inventory
 # Parameters:
-#   win_ansible_connection: 'winrm' or 'psrp', default is 'psrp'.
+#   win_ansible_connection (optional): valid values are 'winrm' or 'psrp'.
+#     Default value is 'psrp'.
 #
+- name: "Check parameter 'win_ansible_connection'"
+  ansible.builtin.assert:
+    that:
+      - win_ansible_connection in ['winrm', 'psrp']
+    fail_msg: >-
+      Parameter 'win_ansible_connection' value '{{ win_ansible_connection }}',
+      is not in the current supported connection types list ['winrm', 'psrp'].
+  when: win_ansible_connection is defined
+
 - name: "Add specified Windows IP to the hosts"
-  add_host:
+  ansible.builtin.add_host:
     hostname: "{{ vm_guest_ip }}"
     groups:
       - "{{ vm_guest_group | default('target_vm') }}"
@@ -20,11 +30,11 @@
   register: add_host_result
   when:
     - win_ansible_connection is defined
-    - win_ansible_connection | lower == 'winrm'
+    - win_ansible_connection == 'winrm'
   no_log: "{{ hide_secrets | default(false) }}"
 
 - name: "Add specified Windows IP to the hosts"
-  add_host:
+  ansible.builtin.add_host:
     hostname: "{{ vm_guest_ip }}"
     groups:
       - "{{ vm_guest_group | default('target_vm') }}"
@@ -47,9 +57,9 @@
   register: add_host_result
   when: >
     (win_ansible_connection is undefined) or
-    (win_ansible_connection | lower == 'psrp')
+    (win_ansible_connection == 'psrp')
   no_log: "{{ hide_secrets | default(false) }}"
 
-- ansible.builtin.debug: var=add_host_result
-  when: enable_debug is defined and enable_debug
+- name: "Display the result of adding Windows host"
+  ansible.builtin.debug: var=add_host_result
   no_log: "{{ hide_secrets | default(false) }}"

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -13,7 +13,7 @@
 - name: "Set guest OS product type to client"
   ansible.builtin.set_fact:
     guest_os_product_type: |-
-      {%- if guest_os_product_type == "workstation" -%}client
+      {%- if guest_os_product_type | lower == "workstation" -%}client
       {%- else -%}{{ guest_os_product_type | lower }}
       {%- endif -%}
 

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -8,7 +8,8 @@
     vm_guest_os_distribution: ''
     guest_os_edition: ''
 
-- include_tasks: ../../common/get_guest_system_info.yml
+- name: "Get VM guest system info"
+  include_tasks: ../../common/get_guest_system_info.yml
 
 - name: "Set guest OS product type to client"
   ansible.builtin.set_fact:

--- a/windows/utils/get_windows_system_info.yml
+++ b/windows/utils/get_windows_system_info.yml
@@ -12,8 +12,10 @@
 
 - name: "Set guest OS product type to client"
   ansible.builtin.set_fact:
-    guest_os_product_type: 'client'
-  when: guest_os_product_type | lower == 'workstation'
+    guest_os_product_type: |-
+      {%- if guest_os_product_type == "workstation" -%}client
+      {%- else -%}{{ guest_os_product_type | lower }}
+      {%- endif -%}
 
 - name: "Set fact of guest OS build number"
   ansible.builtin.set_fact:
@@ -27,7 +29,7 @@
     guest_os_with_inbox_drivers: true
   when:
     - guest_os_ansible_distribution_major_ver | int >= 10
-    - (guest_os_product_type | lower == 'server' and guest_os_build_num | int >= 20348) or (guest_os_product_type | lower == 'client' and guest_os_build_num | int >= 22449)
+    - (guest_os_product_type == 'server' and guest_os_build_num | int >= 20348) or (guest_os_product_type == 'client' and guest_os_build_num | int >= 22449)
 
 - name: "Get Windows guest OS edition from distribution info"
   ansible.builtin.set_fact:

--- a/windows/utils/shutdown_vm.yml
+++ b/windows/utils/shutdown_vm.yml
@@ -12,13 +12,11 @@
     vm_power_state_set: 'shutdown-guest'
   when:
     - vmtools_is_running is defined
-    - vmtools_is_running | bool
+    - vmtools_is_running
 
 - include_tasks: win_shutdown_restart.yml
   vars:
     set_win_power_state: 'shutdown'
   when: >
-    (vmtools_is_installed is undefined) or
-    (not vmtools_is_installed | bool) or
     (vmtools_is_running is undefined) or
-    (not vmtools_is_running | bool)
+    (not vmtools_is_running)

--- a/windows/utils/shutdown_vm.yml
+++ b/windows/utils/shutdown_vm.yml
@@ -5,16 +5,19 @@
 # shutdown VM softly, if VMware tools not installed, then use command in guest
 # OS to shutdown it.
 #
-- include_tasks: ../../common/vm_get_vmtools_status.yml
+- name: "Get VMware Tools status"
+  include_tasks: ../../common/vm_get_vmtools_status.yml
 
-- include_tasks: ../../common/vm_set_power_state.yml
+- name: "Shutdown guest OS through VMware Tools"
+  include_tasks: ../../common/vm_set_power_state.yml
   vars:
     vm_power_state_set: 'shutdown-guest'
   when:
     - vmtools_is_running is defined
     - vmtools_is_running
 
-- include_tasks: win_shutdown_restart.yml
+- name: "Shutdown guest OS inside guest OS"
+  include_tasks: win_shutdown_restart.yml
   vars:
     set_win_power_state: 'shutdown'
   when: >

--- a/windows/utils/win_check_winbsod.yml
+++ b/windows/utils/win_check_winbsod.yml
@@ -3,11 +3,12 @@
 ---
 # Check Windows guest BSOD keyword in vmware.log,
 # default timeout is 60s
-- name: Set fact of the key string to be searched
+- name: "Set fact of the key string to be searched"
   ansible.builtin.set_fact:
     guest_bsod_keyword: "WinBSOD:"
 
-- include_tasks: ../../common/vm_wait_log_msg.yml
+- name: "Searching keyword in vmware.log"
+  include_tasks: ../../common/vm_wait_log_msg.yml
   vars:
     vm_wait_log_name: "vmware.log"
     vm_wait_log_msg: "{{ guest_bsod_keyword }}"
@@ -15,8 +16,7 @@
     vm_wait_log_delay: 3
     vm_wait_log_ignore_errors: true
 
-# Fail when get Windows guest BSOD keyword in vmware.log
-- name: VM log info check failure
+- name: "Testing failed when get '{{ guest_bsod_keyword }}' in vmware.log"
   ansible.builtin.fail:
     msg: "Get Windows guest BSOD keyword '{{ guest_bsod_keyword }}' in vmware.log."
-  when: vm_wait_log_msg_success | bool
+  when: vm_wait_log_msg_success

--- a/windows/utils/win_enable_vbs_guest.yml
+++ b/windows/utils/win_enable_vbs_guest.yml
@@ -35,10 +35,10 @@
       reg add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v "LsaCfgFlags" /t REG_DWORD /d 1 /f
   when: >
     (guest_os_build_num | int < 22621) or
-    (guest_os_product_type | lower == 'client' and 
+    (guest_os_product_type == 'client' and 
     guest_os_build_num | int >= 22621 and 
     guest_os_edition | lower not in ['enterprise', 'education']) or
-    (guest_os_product_type | lower == 'server')
+    (guest_os_product_type == 'server')
 
 # Try to enable 'HVCIMATRequired' feature from registry while it does not take effect.
 # Refer to 3rd party issue: https://partner.microsoft.com/en-us/dashboard/collaborate/engagements/1759/feedback/wits/Bugs/786316

--- a/windows/utils/win_enable_vss_log.yml
+++ b/windows/utils/win_enable_vss_log.yml
@@ -26,7 +26,7 @@
   include_tasks: win_execute_cmd.yml
   vars:
     win_powershell_cmd: "Copy-Item '{{ vmtools_conf_template }}' -Destination '{{ vmtools_conf_path }}'"
-  when: win_check_file_exist_result is defined and not win_check_file_exist_result
+  when: not win_check_file_exist_result
 
 - name: "Enable vss log in VMware Tools config file"
   community.windows.win_lineinfile:

--- a/windows/utils/win_get_folder.yml
+++ b/windows/utils/win_get_folder.yml
@@ -26,16 +26,16 @@
       vars:
         win_get_files_folders_folder: "{{ win_get_folder_src_path }}"
 
-    - name: "Fetch files in source folder from guest OS recusively"
-      include_tasks:
-        file: win_get_file_folder.yml
-        apply:
-          when: win_get_files_folders_list | length != 0
-      vars:
-        win_get_dst_path: "{{ win_get_folder_dst_path }}"
-      with_items: "{{ win_get_files_folders_list }}"
-      loop_control:
-        loop_var: win_get_src_path
+    - name: "Fetch files in source folder from guest OS"
+      when: win_get_files_folders_list | length != 0
+      block:
+        - name: "Fetch files recusively"
+          include_tasks: win_get_file_folder.yml
+          vars:
+            win_get_dst_path: "{{ win_get_folder_dst_path }}"
+          with_items: "{{ win_get_files_folders_list }}"
+          loop_control:
+            loop_var: win_get_src_path
 
     - name: "No files or sub folders in source folder"
       ansible.builtin.debug:

--- a/windows/utils/win_get_folder.yml
+++ b/windows/utils/win_get_folder.yml
@@ -26,16 +26,16 @@
       vars:
         win_get_files_folders_folder: "{{ win_get_folder_src_path }}"
 
-    - name: "Fetch files in source folder from guest OS"
-      when: win_get_files_folders_list | length != 0
-      block:
-        - name: "Fetch files recusively"
-          include_tasks: win_get_file_folder.yml
-          vars:
-            win_get_dst_path: "{{ win_get_folder_dst_path }}"
-          with_items: "{{ win_get_files_folders_list }}"
-          loop_control:
-            loop_var: win_get_src_path
+    - name: "Fetch files in source folder from guest OS recusively"
+      include_tasks:
+        file: win_get_file_folder.yml
+        apply:
+          when: win_get_files_folders_list | length != 0
+      vars:
+        win_get_dst_path: "{{ win_get_folder_dst_path }}"
+      with_items: "{{ win_get_files_folders_list }}"
+      loop_control:
+        loop_var: win_get_src_path
 
     - name: "No files or sub folders in source folder"
       ansible.builtin.debug:

--- a/windows/utils/win_get_pmem_disk_list.yml
+++ b/windows/utils/win_get_pmem_disk_list.yml
@@ -10,22 +10,24 @@
     win_pmem_disk_id_list: []
     win_pmem_disk_list: []
 
-# Get persistent memory disk unique ID list
-- include_tasks: win_execute_cmd.yml
+- name: "Get persistent memory disk unique ID list"
+  include_tasks: win_execute_cmd.yml
   vars:
     win_powershell_cmd: "get-physicaldisk | where BusType -eq 'SCM' | select UniqueId | fl"
+
 - name: "Get persistent memory disk unique ID list"
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length > 0
   block:
     - name: "Set fact of persistent memory disk unique ID list"
       ansible.builtin.set_fact:
         win_pmem_disk_id_list: "{{ win_pmem_disk_id_list + [item.split(':')[1].strip()] }}"
       when: item | length != 0 and item.split(':') | length > 1
       with_items: "{{ win_powershell_cmd_output.stdout_lines }}"
-  when:
-    - win_powershell_cmd_output.stdout_lines is defined
-    - win_powershell_cmd_output.stdout_lines | length > 0
 
-- include_tasks: win_get_pmem_disk_by_id.yml
+- name: "Get persistent memory disk by unique ID"
+  include_tasks: win_get_pmem_disk_by_id.yml
   with_items: "{{ win_pmem_disk_id_list }}"
   when: win_pmem_disk_unique_id
   loop_control:

--- a/windows/utils/win_get_set_disk_online.yml
+++ b/windows/utils/win_get_set_disk_online.yml
@@ -7,8 +7,8 @@
 # Parameters:
 #   win_online_disk_num: the disk number.
 #   win_online_disk_uid: the disk UniqueId.
-#   win_online_disk_ops: 'set' or 'get' specified disk online status, default
-#   value is 'get'.
+#   win_online_disk_ops (optional): if set to true, will execute online disk
+#     operation first, then get disk online status, else only get disk online status.
 #
 - name: "Check required parameter"
   ansible.builtin.assert:
@@ -38,7 +38,7 @@
     win_powershell_cmd: "{{ win_cmd_online_disk }}"
   when:
     - win_online_disk_ops is defined
-    - win_online_disk_ops == 'set'
+    - win_online_disk_ops | bool
 
 - name: "Get disk online status"
   include_tasks: win_execute_cmd.yml
@@ -51,11 +51,5 @@
     - win_powershell_cmd_output.stdout_lines | length != 0
     - win_powershell_cmd_output.stdout_lines[0] | lower == 'online'
 
-- name: "Check disk online status"
-  ansible.builtin.assert:
-    that:
-      - win_is_disk_online
-    fail_msg: "After online disk, still get offline status in result: '{{ win_powershell_cmd_output.stdout_lines }}'"
-  when:
-    - win_online_disk_ops is defined
-    - win_online_disk_ops == 'set'
+- name: "Print disk online status"
+  ansible.builtin.debug: var=win_is_disk_online

--- a/windows/utils/win_get_set_disk_online.yml
+++ b/windows/utils/win_get_set_disk_online.yml
@@ -38,7 +38,7 @@
     win_powershell_cmd: "{{ win_cmd_online_disk }}"
   when:
     - win_online_disk_ops is defined
-    - win_online_disk_ops | lower == 'set'
+    - win_online_disk_ops == 'set'
 
 - name: "Get disk online status"
   include_tasks: win_execute_cmd.yml
@@ -58,4 +58,4 @@
     fail_msg: "After online disk, still get offline status in result: '{{ win_powershell_cmd_output.stdout_lines }}'"
   when:
     - win_online_disk_ops is defined
-    - win_online_disk_ops | lower == 'set'
+    - win_online_disk_ops == 'set'

--- a/windows/utils/win_pause_resume_win_update.yml
+++ b/windows/utils/win_pause_resume_win_update.yml
@@ -38,8 +38,7 @@
 - name: "Make sure PowerShell script exists in guest OS"
   ansible.builtin.assert:
     that:
-      - win_check_file_exist_result is defined
-      - win_check_file_exist_result | bool
+      - win_check_file_exist_result
     fail_msg: "PowerShell script is not found in guest OS in this path: {{ remote_ps_file }}"
 
 # Pause Windows Update is not a demand task, so ignore errors

--- a/windows/vbs_enable_disable/vbs_disable_test.yml
+++ b/windows/vbs_enable_disable/vbs_disable_test.yml
@@ -23,9 +23,8 @@
 - name: "Check VM VBS status after disable"
   ansible.builtin.assert:
     that:
-      - vm_vbs_enabled is defined
-      - not vm_vbs_enabled | bool
-    fail_msg: "VM VBS enabled status is '{{ vm_vbs_enabled | default('') }}', not disabled after disabling it."
+      - not vm_vbs_enabled
+    fail_msg: "VM VBS enabled status is '{{ vm_vbs_enabled }}', not disabled after disabling it."
 
 - name: "Get VBS status in guest OS"
   include_tasks: ../utils/win_get_vbs_guest.yml

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -25,9 +25,9 @@
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Skip test case due to VM firmware is not EFI: {{ vm_firmware | default('NA') }}"
+            skip_msg: "Skip test case due to VM firmware is not EFI: {{ vm_firmware }}"
             skip_reason: "Not Applicable"
-          when: vm_firmware | lower != 'efi'
+          when: vm_firmware != 'efi'
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml

--- a/windows/vbs_enable_disable/vbs_enable_test.yml
+++ b/windows/vbs_enable_disable/vbs_enable_test.yml
@@ -33,9 +33,8 @@
     - name: "Check VM VBS status after enable"
       ansible.builtin.assert:
         that:
-          - vm_vbs_enabled is defined
-          - vm_vbs_enabled | bool
-        fail_msg: "VM VBS status is '{{ vm_vbs_enabled | default('') }}', not enabled after enabling it."
+          - vm_vbs_enabled
+        fail_msg: "VM VBS status is '{{ vm_vbs_enabled }}', not enabled after enabling it."
   when: not vm_vbs_enabled_before
 
 - name: "Get Device Guard available security properties in guest OS"

--- a/windows/vhba_hot_add_remove/paravirtual_vhba_device_ops.yml
+++ b/windows/vhba_hot_add_remove/paravirtual_vhba_device_ops.yml
@@ -20,7 +20,7 @@
             skip_msg: "Test case '{{ current_testcase_name }}' is blocked because guest OS has no inbox PVSCSI driver or VMware tools is not installed"
             skip_reason: "Blocked"
           when:
-            - not (vmtools_is_running is defined and vmtools_is_running | bool)
+            - not vmtools_is_running
             - not guest_os_with_inbox_drivers
 
         - include_tasks: vhba_test.yml

--- a/windows/vhba_hot_add_remove/sata_vhba_device_ops.yml
+++ b/windows/vhba_hot_add_remove/sata_vhba_device_ops.yml
@@ -16,7 +16,7 @@
 
         - name: "Get boot disk controller type of VM with BIOS firmware"
           include_tasks: ../utils/win_get_boot_disk_ctl_type.yml
-          when: vm_firmware | lower == "bios"
+          when: vm_firmware == "bios"
 
         - name: "Test on SATA disk"
           include_tasks: vhba_test.yml

--- a/windows/vhba_hot_add_remove/vhba_test_prepare.yml
+++ b/windows/vhba_hot_add_remove/vhba_test_prepare.yml
@@ -55,5 +55,5 @@
   when:
     - test_purpose == "hot-add"
     - test_disk_controller_type == 'sata'
-    - (vm_firmware | lower == "bios")
-    - (win_boot_disk_ctl_type | lower not in ['ide', 'sata'])
+    - vm_firmware == 'bios'
+    - win_boot_disk_ctl_type not in ['ide', 'sata']

--- a/windows/vtpm_cold_add_remove/cold_add_vtpm.yml
+++ b/windows/vtpm_cold_add_remove/cold_add_vtpm.yml
@@ -46,15 +46,15 @@
   ansible.builtin.set_fact:
     retry_vm_guest_ip: ""
 - name: "Retry to get cloned VM IP address"
-  block:
-    - name: "Get cloned VM IP address"
-      include_tasks: retry_vm_get_ip.yml
-      with_list: "{{ range(1, 11) | list }}"
-      loop_control:
-        loop_var: retry_count
-  when: >
-    (not retry_vm_guest_ip) or
-    (retry_vm_guest_ip == vm_ip_clone_from)
+  include_tasks:
+    file: retry_vm_get_ip.yml
+    apply:
+      when: >
+        (not retry_vm_guest_ip) or 
+        (retry_vm_guest_ip == vm_ip_clone_from)
+  with_list: "{{ range(1, 11) | list }}"
+  loop_control:
+    loop_var: retry_count
 
 - name: "Check cloned VM IP is not the same as parent VM IP address"
   ansible.builtin.assert:

--- a/windows/vtpm_cold_add_remove/vtpm_cold_add_remove.yml
+++ b/windows/vtpm_cold_add_remove/vtpm_cold_add_remove.yml
@@ -21,9 +21,7 @@
               Test case '{{ ansible_play_name }}' is skipped because vCenter server is not configured,
               while vTPM device configuration requires to connect to it in this test case.
             skip_reason: "Not Applicable"
-          when: >
-            (vcenter_is_defined is undefined) or
-            (not vcenter_is_defined | bool)
+          when: not vcenter_is_defined
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
@@ -37,7 +35,7 @@
           vars:
             skip_msg: "Skip test case due to VM firmware is: {{ vm_firmware }}, not EFI."
             skip_reason: "Not Applicable"
-          when: vm_firmware | lower != 'efi'
+          when: vm_firmware != 'efi'
 
         - name: "Cold add and remove VM vTPM device test"
           include_tasks: vtpm_add_remove_test.yml

--- a/windows/windows_update_install/prepare_msu_file.yml
+++ b/windows/windows_update_install/prepare_msu_file.yml
@@ -105,5 +105,5 @@
     - name: "Verify if the .msu file is copied to {{ msu_dest_dir }}"
       ansible.builtin.assert:
         that:
-          - win_check_file_exist_result | bool
+          - win_check_file_exist_result
         fail_msg: "The .msu file is not found in {{ msu_dest_dir }} in guest OS."

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -63,7 +63,7 @@
               vars:
                 skip_msg: "Skip test case due to under development VMware Tools can not test on VM with VBS enabled."
                 skip_reason: "Not Applicable"
-              when: vm_vbs_enabled is defined and vm_vbs_enabled | bool
+              when: vm_vbs_enabled
 
         - name: "Handle update_vmtools is set to false situation"
           when:

--- a/windows/wintools_uninstall_verify/uninstall_vmtools.yml
+++ b/windows/wintools_uninstall_verify/uninstall_vmtools.yml
@@ -1,21 +1,23 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get VMware Tools product ID from registry
-- include_tasks: ../utils/win_execute_cmd.yml
+- name: "Get VMware Tools product ID from registry"
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "Get-ChildItem 'HKLM:\\software\\microsoft\\windows\\currentversion\\uninstall' | where-object {$_.getvalue('DisplayName') -match 'VMware Tools'} | foreach-object {$_.name} | split-path -leaf"
 
 - name: "Set fact of VMware Tools product ID"
   ansible.builtin.set_fact:
     get_product_id: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
-- ansible.builtin.debug:
-    msg: "Get VMware Tools product ID: {{ get_product_id }}"
+
+- name: "Display VMware Tools product ID"
+  ansible.builtin.debug: var=get_product_id
 
 - name: "Uninstall VMware Tools in guest OS"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "msiexec.exe /q /x '{{ get_product_id }}' /norestart"
+
 - name: "Verify return code and no error message"
   ansible.builtin.assert:
     that:
@@ -24,17 +26,21 @@
     success_msg: "VMware Tools uninstall operation succeed in guest OS"
     fail_msg: "VMware Tools uninstall operation failed in guest OS"
 
-- include_tasks: ../utils/win_shutdown_restart.yml
+- name: "Pause 5 seconds after executing VMware Tools uninstall command"
+  ansible.builtin.pause:
+    seconds: 5
+
+- name: "Restart guest OS after VMware Tools uninstall"
+  include_tasks: ../utils/win_shutdown_restart.yml
   vars:
     set_win_power_state: "restart"
 
-# Get VMware Tools status after uninstall
-- include_tasks: ../../common/vm_get_vmtools_status.yml
+- name: "Get VMware Tools status after uninstall"
+  include_tasks: ../../common/vm_get_vmtools_status.yml
+
 - name: "Verify VMware Tools is not running and not installed after uninstall"
   ansible.builtin.assert:
     that:
-      - vmtools_is_installed is defined
-      - not vmtools_is_installed | bool
-      - vmtools_is_running is defined
-      - not vmtools_is_running | bool
+      - not vmtools_is_installed
+      - not vmtools_is_running
     fail_msg: "VMware Tools installed and running status: '{{ vmtools_is_installed }}/{{ vmtools_is_running }}', which should be 'false/false' after VMware Tools uninstall."

--- a/windows/wintools_uninstall_verify/wintools_uninstall_verify.yml
+++ b/windows/wintools_uninstall_verify/wintools_uninstall_verify.yml
@@ -9,8 +9,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - block:
-        - include_tasks: ../setup/test_setup.yml
+    - name: "Test case block"
+      block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
 
         # VMware Tools status got in test_setup before this test
         - name: "Set fact of the VMware Tools status before uninstall"
@@ -21,7 +23,8 @@
           ansible.builtin.debug:
             msg: "VMware Tools installed: {{ vmtools_is_installed_before }}, running: {{ vmtools_is_running_before }}"
 
-        - include_tasks: ../../common/skip_test_case.yml
+        - name: "Skip test case when VMware Tools is not installed"
+          include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Test case '{{ ansible_play_name }}' is blocked because VMware Tools installed: {{ vmtools_is_installed_before }}, running: {{ vmtools_is_running_before }}"
             skip_reason: "Blocked"
@@ -32,36 +35,43 @@
             msg: "VMware tools installed: {{ vmtools_is_installed_before }}, running: {{ vmtools_is_running_before }}"
           when: not vmtools_is_running_before
 
-        - include_tasks: prepare_pvscsi_vmxnet3_device.yml
+        - name: "Make sure PVSCSI controller and VMXNET3 network adatper exist"
+          include_tasks: prepare_pvscsi_vmxnet3_device.yml
           when: guest_os_with_inbox_drivers
 
-        # Check no problem device
-        - include_tasks: ../utils/win_get_problem_device.yml
+        - name: "Get problem device list"
+          include_tasks: ../utils/win_get_problem_device.yml
         - name: "Check no problem device listed"
           ansible.builtin.assert:
             that:
               - not gos_has_problem_device
             fail_msg: "Problem devices were found in guest before VMware Tools uninstall, please check listed problem devices: {{ gos_problem_device_list }}"
 
-        - include_tasks: uninstall_vmtools.yml
-        - include_tasks: verify_drivers_status.yml
+        - name: "Uninstall VMware Tools"
+          include_tasks: uninstall_vmtools.yml
+        - name: "Verify PVSCSI and VMXNET3 drivers"
+          include_tasks: verify_drivers_status.yml
           when: guest_os_with_inbox_drivers
 
-        - name: "Remove added network adapter, portgroup and vSwitch"
-          block:
-            - include_tasks: ../../common/vm_remove_network_adapter.yml
-              vars:
-                netadapter_mac_addr: "{{ new_network_adapter_mac }}"
-            - include_tasks: ../../common/esxi_remove_portgroup.yml
-              vars:
-                vswitch_name: "{{ new_device_vswitch }}"
-                portgroup_name: "{{ new_device_pg }}"
-            - include_tasks: ../../common/esxi_remove_vswitch.yml
-              vars:
-                vswitch_name: "{{ new_device_vswitch }}"
+        - name: "Cleanup network configurations for added network adapter"
           when:
             - guest_os_with_inbox_drivers
             - new_network_adapter_mac is defined
             - new_network_adapter_mac
+          block:
+            - name: "Remove added network adapter"
+              include_tasks: ../../common/vm_remove_network_adapter.yml
+              vars:
+                netadapter_mac_addr: "{{ new_network_adapter_mac }}"
+            - name: "Remove added portgroup"
+              include_tasks: ../../common/esxi_remove_portgroup.yml
+              vars:
+                vswitch_name: "{{ new_device_vswitch }}"
+                portgroup_name: "{{ new_device_pg }}"
+            - name: "Remove added vSwitch"
+              include_tasks: ../../common/esxi_remove_vswitch.yml
+              vars:
+                vswitch_name: "{{ new_device_vswitch }}"
       rescue:
-        - include_tasks: ../../common/test_rescue.yml
+        - name: "Test case failure"
+          include_tasks: ../../common/test_rescue.yml

--- a/windows/wintools_uninstall_verify/wintools_uninstall_verify.yml
+++ b/windows/wintools_uninstall_verify/wintools_uninstall_verify.yml
@@ -15,8 +15,8 @@
         # VMware Tools status got in test_setup before this test
         - name: "Set fact of the VMware Tools status before uninstall"
           ansible.builtin.set_fact:
-            vmtools_is_installed_before: "{{ vmtools_is_installed | default(false) }}"
-            vmtools_is_running_before: "{{ vmtools_is_running | default(false) }}"
+            vmtools_is_installed_before: "{{ vmtools_is_installed }}"
+            vmtools_is_running_before: "{{ vmtools_is_running }}"
         - name: "Display the VMware Tools status before uninstall"
           ansible.builtin.debug:
             msg: "VMware Tools installed: {{ vmtools_is_installed_before }}, running: {{ vmtools_is_running_before }}"
@@ -33,7 +33,7 @@
           when: not vmtools_is_running_before
 
         - include_tasks: prepare_pvscsi_vmxnet3_device.yml
-          when: guest_os_with_inbox_drivers | bool
+          when: guest_os_with_inbox_drivers
 
         # Check no problem device
         - include_tasks: ../utils/win_get_problem_device.yml
@@ -45,8 +45,7 @@
 
         - include_tasks: uninstall_vmtools.yml
         - include_tasks: verify_drivers_status.yml
-          when:
-            - guest_os_with_inbox_drivers | bool
+          when: guest_os_with_inbox_drivers
 
         - name: "Remove added network adapter, portgroup and vSwitch"
           block:
@@ -61,7 +60,7 @@
               vars:
                 vswitch_name: "{{ new_device_vswitch }}"
           when:
-            - guest_os_with_inbox_drivers | bool
+            - guest_os_with_inbox_drivers
             - new_network_adapter_mac is defined
             - new_network_adapter_mac
       rescue:

--- a/windows/wsl_distro_install_uninstall/install_wsl.yml
+++ b/windows/wsl_distro_install_uninstall/install_wsl.yml
@@ -14,6 +14,7 @@
     skip_set_wsl_ver: false
 
 - name: "Install WSL for Windows Client"
+  when: guest_os_product_type == 'client'
   block:
     - name: "Set installation command for inbox version of WSL"
       ansible.builtin.set_fact:
@@ -34,9 +35,9 @@
       vars:
         win_powershell_cmd: "{{ wsl_install_cmd }}"
         win_execute_cmd_ignore_error: true
-  when: (guest_os_product_type == 'client')
 
 - name: "Install WSL for Windows Server"
+  when: guest_os_product_type == 'server'
   block:
     # Due to issue https://github.com/microsoft/WSL/issues/9258, install "Debian" for Server.
     - name: "Set the distribution name"
@@ -60,7 +61,6 @@
       ansible.builtin.set_fact:
         skip_set_wsl_ver: true
       when: guest_os_build_num | int <= 23048
-  when: (guest_os_product_type == 'server')
 
 - name: "Process the WSL output message"
   include_tasks: wsl_convert_binary_to_txt.yml
@@ -91,6 +91,9 @@
 
 # Set WSL default version to 2
 - name: "Set WSL default version to 2"
+  when:
+    - wsl_default_version | int != 2
+    - not skip_set_wsl_ver
   block:
     - name: "Set WSL default version to 2"
       include_tasks: ../utils/win_execute_cmd.yml
@@ -113,9 +116,6 @@
 
     - name: "Check WSL version after setting"
       include_tasks: check_wsl_version.yml
-  when:
-    - wsl_default_version | int != 2
-    - not skip_set_wsl_ver
 
 - name: "Validate the WSL version"
   ansible.builtin.assert:

--- a/windows/wsl_distro_install_uninstall/install_wsl.yml
+++ b/windows/wsl_distro_install_uninstall/install_wsl.yml
@@ -34,7 +34,7 @@
       vars:
         win_powershell_cmd: "{{ wsl_install_cmd }}"
         win_execute_cmd_ignore_error: true
-  when: (guest_os_product_type | lower == 'client')
+  when: (guest_os_product_type == 'client')
 
 - name: "Install WSL for Windows Server"
   block:
@@ -60,7 +60,7 @@
       ansible.builtin.set_fact:
         skip_set_wsl_ver: true
       when: guest_os_build_num | int <= 23048
-  when: (guest_os_product_type | lower == 'server')
+  when: (guest_os_product_type == 'server')
 
 - name: "Process the WSL output message"
   include_tasks: wsl_convert_binary_to_txt.yml

--- a/windows/wsl_distro_install_uninstall/wsl_distro_install_uninstall.yml
+++ b/windows/wsl_distro_install_uninstall/wsl_distro_install_uninstall.yml
@@ -24,8 +24,8 @@
             skip_reason: "Not Supported"
           when: >
             (guest_os_ansible_distribution_major_ver | int < 10) or
-            (guest_os_product_type | lower == 'server' and guest_os_build_num | int < 16299) or
-            (guest_os_product_type | lower == 'client' and guest_os_build_num | int < 19041)
+            (guest_os_product_type == 'server' and guest_os_build_num | int < 16299) or
+            (guest_os_product_type == 'client' and guest_os_build_num | int < 19041)
 
         - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml


### PR DESCRIPTION
Some `| lower` and `| bool` are not necessary since the variable is already in the lower case or bool type when defined and set.