### PR TITLE
Replace VMware KB links with Broadcom KB links

### DIFF
--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -151,7 +151,7 @@ releases:
       - Add PVSCSI and VMXNET3 drivers check when guest OS contains inbox drivers in test case "wintools_uninstall_verify".
       - Change test case result from "No Run" to "Skipped" in the situation of parameter values' set and VM current status.
       - Change result checking for retry tasks and add printing error message in log plugin.
-      - Skip test case "secureboot_enable_disable" for OS listed in https://kb.vmware.com/s/article/88737 when VM's hardware version >= 20.
+      - Skip test case "secureboot_enable_disable" for OS listed in https://knowledge.broadcom.com/external/article?legacyId=88737 when VM's hardware version >= 20.
       bugfixes:
       - Fix undefined parameter issue in test case "windows/paravirtual_vhba_device_ops".
       - Fix "Failed to update apt cache: unknown reason" for Ubuntu.

--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -58,7 +58,7 @@
         esxi_shell: "/bin/sh"
       when: esxi_version is version('8.0.0', '<')
 
-    # Refer to https://kb.vmware.com/s/article/87386
+    # Refer to https://knowledge.broadcom.com/external/article?legacyId=87386
     - name: "Set ESXi server default shell to /bin/supershell on {{ esxi_version }}"
       ansible.builtin.set_fact:
         esxi_shell: "/bin/supershell"

--- a/linux/deploy_vm/delete_unattend_install_iso.yml
+++ b/linux/deploy_vm/delete_unattend_install_iso.yml
@@ -14,7 +14,7 @@
   loop_control:
     loop_var: vm_cdrom
 
-# It could fail but doesn't affect tests, see https://kb.vmware.com/s/article/78653
+# It could fail but doesn't affect tests, see https://knowledge.broadcom.com/external/article?legacyId=78653
 - name: "Delete uploaded unattend install ISO from ESXi datastore"
   include_tasks: ../../common/esxi_check_delete_datastore_file.yml
   vars:

--- a/linux/deploy_vm/deploy_vm.yml
+++ b/linux/deploy_vm/deploy_vm.yml
@@ -75,8 +75,8 @@
             msg: >-
               Linux guest OS could be hung on ESXi {{ esxi_version }} server
               based on Intel {{ esxi_cpu_code_name }} CPU. Refer to KB articles
-              https://kb.vmware.com/s/article/92361 and
-              https://kb.vmware.com/s/article/91250.
+              https://knowledge.broadcom.com/external/article?legacyId=92361 and
+              https://knowledge.broadcom.com/external/article?legacyId=91250.
           tags:
             - known_issue
           when:

--- a/linux/network_device_ops/hot_remove_network_adapter.yml
+++ b/linux/network_device_ops/hot_remove_network_adapter.yml
@@ -25,7 +25,7 @@
       ansible.builtin.debug:
         msg:
           - "Hot removing PVRDMA network adapter could cause kernel crash on Oracle Linux 8.8."
-          - "Please refer to https://kb.vmware.com/s/article/93131 for details."
+          - "Please refer to https://knowledge.broadcom.com/external/article?legacyId=93131 for details."
       tags:
         - known_issue
       when:

--- a/linux/secureboot_enable_disable/check_secureboot_support_status.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_support_status.yml
@@ -37,7 +37,7 @@
         skip_msg: >-
           Skip test case {{ ansible_play_name }} because {{ vm_guest_os_distribution }} image has
           vulnerable bootloader, which is denied for secure boot from ESXi 8.0 release.
-          Please refer to https://kb.vmware.com/s/article/88737.
+          Please refer to https://knowledge.broadcom.com/external/article?legacyId=88737.
         skip_reason: "Not Supported"
       when: >
         (guest_os_ansible_distribution in ["RedHat", "AlmaLinux"] and

--- a/linux/utils/enable_vgauth_logging.yml
+++ b/linux/utils/enable_vgauth_logging.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Enable debug logging for VGAuthService within Linux guest OS
-# See https://kb.vmware.com/s/article/1007873 for details.
+# See https://knowledge.broadcom.com/external/article?legacyId=1007873 for details.
 #
 - name: "Set facts about VGAuthService"
   include_tasks: set_vgauth_facts.yml

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Enable debug logging for VMware Tools within Linux guest OS
-# See https://kb.vmware.com/s/article/1007873 for details.
+# See https://knowledge.broadcom.com/external/article?legacyId=1007873 for details.
 # Parameters:
 #   vmtools_log_dir: The log directory in guest OS for VMware Tools debug logs
 #

--- a/linux/vhba_hot_add_remove/wait_device_list_changed.yml
+++ b/linux/vhba_hot_add_remove/wait_device_list_changed.yml
@@ -128,7 +128,7 @@
             msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
               - "VM's boot disk controller is not NVMe, so unload and reload nvme driver to see NVMe device changes as a workaround."
-              - "Please refer to https://kb.vmware.com/s/article/2147574."
+              - "Please refer to https://knowledge.broadcom.com/external/article?legacyId=2147574."
           tags:
             - known_issue
 
@@ -143,7 +143,7 @@
             msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller when VM's hardware version is {{ vm_hardware_version_num }}. Ignore this known issue."
               - "VM's boot disk controller is NVMe, so reboot guest OS to see NVMe device changes as a workaround."
-              - "Please refer to https://kb.vmware.com/s/article/2147574."
+              - "Please refer to https://knowledge.broadcom.com/external/article?legacyId=2147574."
           tags:
             - known_issue
 
@@ -162,7 +162,7 @@
           ansible.builtin.debug:
             msg:
               - "Guest OS can't detect hot add, remove disk attached to NVMe controller. Ignore this known issue."
-              - "Please refer to https://kb.vmware.com/s/article/2147574."
+              - "Please refer to https://knowledge.broadcom.com/external/article?legacyId=2147574."
           tags:
             - known_issue
 

--- a/windows/check_os_fullname/check_os_fullname.yml
+++ b/windows/check_os_fullname/check_os_fullname.yml
@@ -36,7 +36,7 @@
           ansible.builtin.debug:
             msg:
               - "The guestID of Windows 11 guest in guestinfo is empty on ESXi 7.0U3c. Ignore this known issue."
-              - "Please refer to https://kb.vmware.com/s/article/86517."
+              - "Please refer to https://knowledge.broadcom.com/external/article?legacyId=86517."
           tags:
             - known_issue
           when:

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -16,7 +16,7 @@
         - include_tasks: ../setup/test_setup.yml
 
         - block:
-            # Refer to KB article https://kb.vmware.com/s/article/52584
+            # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
             - include_tasks: ../../common/vm_get_vbs_status.yml
             - include_tasks: ../../common/skip_test_case.yml
               vars:

--- a/windows/guest_customization/handle_guest_known_issues.yml
+++ b/windows/guest_customization/handle_guest_known_issues.yml
@@ -5,7 +5,7 @@
 # "Package <PackageFullName> was installed for a user, but not provisioned for all users.
 # This package will not function properly in the sysprep image."
 # For more information, please refer to this KB article or Microsoft doc linked:
-# https://kb.vmware.com/s/article/87307
+# https://knowledge.broadcom.com/external/article?legacyId=87307
 - name: "Workaround for SYSPREP error caused by Appx package"
   block:
     - name: "Remove Appx packages in Windows Client"

--- a/windows/guest_os_inplace_upgrade/handle_known_issue.yml
+++ b/windows/guest_os_inplace_upgrade/handle_known_issue.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # There is known issue on PVSCSI driver and VMXNET3 driver in VMware Tools 12.0.5 and later,
-# Please refer to this KB article: https://kb.vmware.com/s/article/89290
+# Please refer to this KB article: https://knowledge.broadcom.com/external/article?legacyId=89290
 #
 - name: "Initialize the fact of loaded driver version"
   ansible.builtin.set_fact:
@@ -20,7 +20,7 @@
       ansible.builtin.debug:
         msg:
           - "PVSCSI and VMXNET3 drivers installed by VMware Tools (12.0.5 =< VMware Tools version < 12.2.0) in Windows Server 2019 are not compatible with Windows Server 2022 and later after upgrade."
-          - "Refer to KB: https://kb.vmware.com/s/article/89290."
+          - "Refer to KB: https://knowledge.broadcom.com/external/article?legacyId=89290."
           - "Windows Server 2022 will load inbox PVSCSI and VMXNET3 drivers automatically when there is network connection during guest OS upgrading."
       tags:
         - known_issue
@@ -32,7 +32,7 @@
           ansible.builtin.debug:
             msg:
               - "PVSCSI and VMXNET3 drivers installed by VMware Tools (12.0.5 =< VMware Tools version < 12.2.0) in Windows 10 are not compatible with Windows 11 and later after upgrade."
-              - "KB article: https://kb.vmware.com/s/article/89290."
+              - "KB article: https://knowledge.broadcom.com/external/article?legacyId=89290."
               - "The workaround is removing incompatible drivers then installing compatible drivers before OS upgrade."
           tags:
             - known_issue

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,7 +14,7 @@
         - include_tasks: ../setup/test_setup.yml
 
         - block:
-            # Refer to KB article https://kb.vmware.com/s/article/52584
+            # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
             - include_tasks: ../../common/vm_get_vbs_status.yml
             - include_tasks: ../../common/skip_test_case.yml
               vars:

--- a/windows/utils/win_enable_vgauth_log.yml
+++ b/windows/utils/win_enable_vgauth_log.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Enable debug logging for VGAuthService within Windows guest OS
-# See https://kb.vmware.com/s/article/1007873 for details.
+# See https://knowledge.broadcom.com/external/article?legacyId=1007873 for details.
 #
 - name: "Set facts of VGAuthService config file"
   ansible.builtin.set_fact:

--- a/windows/vbs_enable_disable/vbs_enable_disable.yml
+++ b/windows/vbs_enable_disable/vbs_enable_disable.yml
@@ -46,7 +46,7 @@
           vars:
             skip_msg: >- 
               Skip test case due to the supported minimum OS version build on AMD server is 17763. The current OS version
-              build is {{ guest_os_build_num }}. Please refer to https://kb.vmware.com/s/article/2009916.
+              build is {{ guest_os_build_num }}. Please refer to https://knowledge.broadcom.com/external/article?legacyId=2009916.
             skip_reason: "Not Applicable"
           when:
             - esxi_cpu_vendor == "amd"

--- a/windows/vbs_enable_disable/vbs_enable_test.yml
+++ b/windows/vbs_enable_disable/vbs_enable_test.yml
@@ -75,7 +75,7 @@
     - name: "Known issue - NX protections are not present in AvailableSecurityProperties on ESXi 7.0.3"
       ansible.builtin.debug:
         msg:
-          - "The issue of 'NX protections are not present in guest OS AvailableSecurityProperties' exists on this ESXi 7.0.3 build '{{ esxi_build }}', which is fixed in ESXi 7.0U3l patch build 21424296. Please refer to KB article: https://kb.vmware.com/s/article/91199."
+          - "The issue of 'NX protections are not present in guest OS AvailableSecurityProperties' exists on this ESXi 7.0.3 build '{{ esxi_build }}', which is fixed in ESXi 7.0U3l patch build 21424296. Please refer to KB article: https://knowledge.broadcom.com/external/article?legacyId=91199."
       tags:
         - known_issue
   when:


### PR DESCRIPTION
VMware KB links are redirected to Broadcom KB links now. This change is to use the Broadcom KB links.
GOSC related KB links were updated in https://github.com/vmware/ansible-vsphere-gos-validation/pull/608.