### PR TITLE
[Linux] Enable cloud-init services after modifying configs for cloud-init GOSC

### DIFF
--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -21,6 +21,10 @@
 - name: "Print VM guest IP address"
   ansible.builtin.debug: var=vm_guest_ip
 
+- name: "Get guest OS system info"
+  include_tasks: ../utils/get_linux_system_info.yml
+  when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
+
 - name: "Get VMware tools status"
   include_tasks: ../../common/vm_get_vmtools_status.yml
 
@@ -33,10 +37,6 @@
     - skip_test_no_vmtools is defined
     - skip_test_no_vmtools
     - not (vmtools_is_running is defined and vmtools_is_running | bool)
-
-- name: "Get guest OS system info"
-  include_tasks: ../utils/get_linux_system_info.yml
-  when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
 - name: "Take a base snapshot if it does not exist"
   include_tasks: create_base_snapshot.yml

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -25,13 +25,13 @@
   include_tasks: ../utils/get_linux_system_info.yml
   when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
-- name: "Get VMware tools status"
+- name: "Get VMware Tools status"
   include_tasks: ../../common/vm_get_vmtools_status.yml
 
 - name: "Block test case because VMware Toos is not installed or not running"
   include_tasks: ../../common/skip_test_case.yml
   vars:
-    skip_msg: "Test case is blocked because VMware tools installed: {{ vmtools_is_installed | default(false) }}, running: {{ vmtools_is_running | default(false) }}"
+    skip_msg: "Test case is blocked because VMware Tools installed: {{ vmtools_is_installed | default(false) }}, running: {{ vmtools_is_running | default(false) }}"
     skip_reason: "Blocked"
   when:
     - skip_test_no_vmtools is defined

--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -21,8 +21,8 @@
       Can't enable clout-init GOSC because {{ guest_cloud_cfg_path }} doesn't exist.
       Please check whether cloud-init is installed.
   when:
-     - enable_cloudinit_gosc | bool
-     - not guest_cloud_cfg_exists | bool
+     - enable_cloudinit_gosc
+     - not guest_cloud_cfg_exists
 
 - name: "Update cloud-init configs"
   when: guest_cloud_cfg_exists | bool
@@ -39,18 +39,20 @@
       delegate_to: "{{ vm_guest_ip }}"
 
     - name: "Enable cloud-init GOSC for cloud-init workflow"
-      when: enable_cloudinit_gosc | bool
+      when: enable_cloudinit_gosc
       block:
-        - name: "Enable cloud-init services but not start them"
-          include_tasks: service_operation.yml
-          vars:
-            service_enabled: true
-            service_state: "stopped"
-          loop:
-            - cloud-init-local
-            - cloud-init
-            - cloud-config
-            - cloud-final
+        - name: "Set fact of cloud-init services"
+          ansible.builtin.set_fact:
+            cloud_init_services:
+              - cloud-init-local
+              - cloud-init
+              - cloud-config
+              - cloud-final
+
+        - name: "Stop cloud-init services"
+          ansible.builtin.shell: "systemctl stop {{ service_name }}"
+          delegate_to: "{{ vm_guest_ip }}"
+          loop: "{{ cloud_init_services }}"
           loop_control:
             loop_var: service_name
 
@@ -91,8 +93,8 @@
             - network_config_result.stdout_lines is defined
             - network_config_result.stdout_lines | length >= 1
 
-        # For ubuntu, we should remove files to let gosc with cloud-init work well
-        - name: "Remove files if exists"
+        # For ubuntu, we should remove files to make sure cloud-init GOSC works well
+        - name: "Remove cloud-init files if they exist on {{ vm_guest_os_distribution }}"
           ansible.builtin.file:
             path: "{{ config_file_for_netplan }}"
             state: absent
@@ -103,9 +105,7 @@
             - "{{ guest_cloud_cfg_d_path }}/50-curtin-networking.cfg"
             - "{{ guest_cloud_cfg_d_path }}/subiquity-disable-cloudinit-networking.cfg"
             - "{{ guest_cloud_cfg_d_path }}/99-installer.cfg"
-          when:
-            - guest_os_ansible_distribution is defined
-            - guest_os_ansible_distribution == "Ubuntu"
+          when: guest_os_ansible_distribution == "Ubuntu"
           loop_control:
             loop_var: config_file_for_netplan
           delegate_to: "{{ vm_guest_ip }}"
@@ -116,8 +116,15 @@
           delegate_to: "{{ vm_guest_ip }}"
           ignore_errors: true
 
+        - name: "Enable cloud-init services"
+          ansible.builtin.shell: "systemctl enable {{ service_name }}"
+          delegate_to: "{{ vm_guest_ip }}"
+          loop: "{{ cloud_init_services }}"
+          loop_control:
+            loop_var: service_name
+
     - name: "Disable cloud-init GOSC for perl workflow"
-      when: not enable_cloudinit_gosc | bool
+      when: not enable_cloudinit_gosc
       block:
         - name: "Disable cloud-init GOSC in {{ guest_cloud_cfg_path }}"
           ansible.builtin.lineinfile:
@@ -138,29 +145,33 @@
           ansible.builtin.set_fact:
             cloudinit_gosc_disabled: "{{ result.rc != 0 }}"
 
-        - name: "Disable cloud-init network config"
-          block:
-            - name: "Disable cloud-init network config"
-              include_tasks: replace_or_add_line_in_file.yml
-              vars:
-                file: "{{ file_path }}"
-                reg_exp: '^[#\s]*{{ network_config_keyword }}'
-                line_content: 'network: {config: disabled}'
-              with_items: "{{ network_config_result.stdout_lines }}"
-              loop_control:
-                loop_var: file_path
-              when:
-                - network_config_result.stdout_lines is defined
-                - network_config_result.stdout_lines | length >= 1
+        - name: "Assert cloud-init GOSC is disabled"
+          ansible.builtin.assert:
+            that:
+              - cloudinit_gosc_disabled
+            fail_msg: "Failed to disable cloud-init GOSC"
 
-            - name: "Disable cloud-init network config"
-              include_tasks: replace_or_add_line_in_file.yml
-              vars:
-                file: "{{ guest_cloud_cfg_path }}"
-                line_content: "network: {config: disabled}"
-              when: >
-                network_config_result.stdout_lines is undefined or
-                network_config_result.stdout_lines | length == 0
+        - name: "Disable cloud-init network config"
+          include_tasks: replace_or_add_line_in_file.yml
+          vars:
+            file: "{{ file_path }}"
+            reg_exp: '^[#\s]*{{ network_config_keyword }}'
+            line_content: 'network: {config: disabled}'
+          with_items: "{{ network_config_result.stdout_lines }}"
+          loop_control:
+            loop_var: file_path
+          when:
+            - network_config_result.stdout_lines is defined
+            - network_config_result.stdout_lines | length >= 1
+
+        - name: "Disable cloud-init network config"
+          include_tasks: replace_or_add_line_in_file.yml
+          vars:
+            file: "{{ guest_cloud_cfg_path }}"
+            line_content: "network: {config: disabled}"
+          when: >
+            network_config_result.stdout_lines is undefined or
+            network_config_result.stdout_lines | length == 0
 
         # For ubuntu, create file /etc/cloud/cloud-init.disabled to disable cloud-init
         - name: "Create file /etc/cloud/cloud-init.disabled to disable gosc with cloud-init for Ubuntu"
@@ -170,9 +181,3 @@
             mode: "777"
           when: guest_os_ansible_distribution == "Ubuntu"
           delegate_to: "{{ vm_guest_ip }}"
-
-        - name: "Assert cloud-init GOSC is disabled"
-          ansible.builtin.assert:
-            that:
-              - cloudinit_gosc_disabled
-            fail_msg: "Failed to disable cloud-init GOSC"

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -105,6 +105,14 @@
                 {{ package_manager }} remove -y {{ package_manage_list_str }}
               {%- endif -%}
 
+        - name: "Update VMware Photon OS repo cache"
+          include_tasks: repo_update.yml
+          vars:
+            check_update_cmd: "tdnf makecache"
+          when:
+            - guest_os_ansible_distribution == "VMware Photon OS"
+            - package_state in ['installed', 'latest', 'present']
+
         - name: "{{ package_manage_op }} packages on VMware Photon OS"
           ansible.builtin.command: "{{ package_manage_cmd }}"
           delegate_to: "{{ vm_guest_ip }}"

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -88,7 +88,7 @@
     - name: "{{ package_manage_op }} packages on {{ guest_os_ansible_distribution }}"
       when: guest_os_ansible_distribution in ["VMware Photon OS", "FreeBSD"]
       block:
-        - name: "Set facts of packages and command for VMware Photon OS"
+        - name: "Set facts of packages and command for {{ guest_os_ansible_distribution }}"
           ansible.builtin.set_fact:
             package_manage_list_str: "{{ ' '.join(package_manage_list) }}"
             package_manager: |-
@@ -113,7 +113,7 @@
             - guest_os_ansible_distribution == "VMware Photon OS"
             - package_state in ['installed', 'latest', 'present']
 
-        - name: "{{ package_manage_op }} packages on VMware Photon OS"
+        - name: "{{ package_manage_op }} packages on {{ guest_os_ansible_distribution }}"
           ansible.builtin.command: "{{ package_manage_cmd }}"
           delegate_to: "{{ vm_guest_ip }}"
           register: package_manage_result


### PR DESCRIPTION
Stop and enable services might cause failures on Ubuntu OS. This fix is to separate service operations for enabling cloud-init GOSC. Firstly, stop cloud-init services, then modify cloud-init configs, and after that enable cloud-init services.