### PR TITLE
[Windows] windows_online_updates_install result is 'Not Applicable' when there are updates installed

### DIFF
--- a/windows/utils/win_check_winrm.yml
+++ b/windows/utils/win_check_winrm.yml
@@ -1,13 +1,14 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Check VM IP address is retrieved
+- name: "Check VM IP address is retrieved"
   ansible.builtin.assert:
     that:
-      - vm_guest_ip is defined and vm_guest_ip
-    fail_msg: "Cannot check guest winrm connection due to vm_guest_ip is '{{ vm_guest_ip | default('not defined') }}'"
+      - vm_guest_ip is defined
+      - vm_guest_ip
+    fail_msg: "Cannot check guest winrm connection due to 'vm_guest_ip' is '{{ vm_guest_ip | default('not defined') }}'"
 
-- name: Check if guest OS winrm is connectable
+- name: "Check if guest OS winrm is connectable"
   wait_for:
     host: "{{ vm_guest_ip }}"
     port: "{{ guest_os_winrm_port | default(5986) }}"
@@ -16,17 +17,17 @@
     timeout: "{{ win_check_winrm_timeout | default(600) }}"
   register: check_winrm_result
   ignore_errors: true
-- name: Display the check winrm result
+- name: "Display the check winrm result"
   ansible.builtin.debug: var=check_winrm_result
   when: enable_debug
 
-# When guest winrm not connectable, check if there are WinBSOD log in vmware.log
-- block:
-    - include_tasks: win_check_winbsod.yml
-    - name: Guest OS connection failure
-      ansible.builtin.fail:
-        msg: "Guest winrm is not connectable in {{ win_check_winrm_timeout | default(300) }} seconds."
+- name: "Guest OS winrm is not connectable"
   when:
-    - check_winrm_result is defined
-    - "'failed' in check_winrm_result"
+    - check_winrm_result.failed is defined
     - check_winrm_result.failed
+  block:
+    - name: "Check if there are 'WinBSOD' logs in vmware.log"
+      include_tasks: win_check_winbsod.yml
+    - name: "Guest OS winrm connection failure"
+      ansible.builtin.fail:
+        msg: "Guest OS winrm is not connectable in {{ win_check_winrm_timeout | default(600) }} seconds."

--- a/windows/utils/win_get_os_version.yml
+++ b/windows/utils/win_get_os_version.yml
@@ -14,8 +14,10 @@
   include_tasks: win_execute_cmd.yml
   vars:
     win_powershell_cmd: >-
+      $os_version_reg = "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Update\\TargetingInfo\\Installed";
+      if (Test-Path $os_version_reg) {
       (Get-ChildItem -Path
-      "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Update\\TargetingInfo\\Installed\\*.OS.*").Name
+      "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Update\\TargetingInfo\\Installed\\*.OS.*").Name }
     win_execute_cmd_ignore_error: true
 
 - name: "Set fact of registry key path for getting OS version"
@@ -34,7 +36,7 @@
       include_tasks: win_execute_cmd.yml
       vars:
         win_powershell_cmd: >-
-          Get-ItemPropertyValue -Path "{{ win_os_version_reg_path }}" -Name Version
+          (Get-ItemProperty -Path "{{ win_os_version_reg_path }}").Version
         win_execute_cmd_ignore_error: true
     - name: "Set fact of Windows OS version"
       ansible.builtin.set_fact:
@@ -52,10 +54,15 @@
       include_tasks: win_execute_cmd.yml
       vars:
         win_powershell_cmd: >-
-          $majorver = Get-ItemPropertyValue -Path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" -Name CurrentMajorVersionNumber;
-          $minorver = Get-ItemPropertyValue -Path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" -Name CurrentMinorVersionNumber;
-          $buildnum = (Get-ItemPropertyValue -Path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" -Name BuildLabEx) -match "\d{5}\.\d{4}";
-          Write-Host($majorver, $minorver, $matches[0] -join '.')
+          $os_version = Get-ItemProperty -Path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+          $majorver = $os_version.CurrentMajorVersionNumber;
+          $minorver = $os_version.CurrentMinorVersionNumber;
+          $currentver = $os_version.CurrentVersion;
+          $buildnum = ($os_version.BuildLabEx) -match "\d{5}\.\d{4}";
+          if ($majorver and $minorver) {
+            Write-Host($majorver, $minorver, $matches[0] -join '.')
+          } elseif ($currentver) {
+            Write-Host($currentver, $matches[0] -join '.') }
         win_execute_cmd_ignore_error: true
     - name: "Set fact of Windows OS version"
       ansible.builtin.set_fact:

--- a/windows/utils/win_get_os_version.yml
+++ b/windows/utils/win_get_os_version.yml
@@ -58,8 +58,8 @@
           $majorver = $os_version.CurrentMajorVersionNumber;
           $minorver = $os_version.CurrentMinorVersionNumber;
           $currentver = $os_version.CurrentVersion;
-          $buildnum = ($os_version.BuildLabEx) -match "\d{5}\.\d{4}";
-          if ($majorver and $minorver) {
+          $buildnum = ($os_version.BuildLabEx) -match "\d{4,}\.\d+";
+          if ($majorver) {
             Write-Host($majorver, $minorver, $matches[0] -join '.')
           } elseif ($currentver) {
             Write-Host($currentver, $matches[0] -join '.') }

--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -107,8 +107,7 @@
           block:
             - name: "Set fact of failure messages can not be ignored"
               ansible.builtin.set_fact:
-                win_updates_failure_msgs: >
-                  {{ win_updates_failure_msgs | difference(win_updates_failure_msgs | select('search', item)) }}
+                win_updates_failure_msgs: "{{ win_updates_failure_msgs | reject('search', item) }}"
               loop: "{{ win_updates_ignore_kws }}"
             - name: "Set fact of Windows online updates install status"
               ansible.builtin.set_fact:

--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -26,8 +26,8 @@
 #        For example, 'failure_msg' is "Operation was not performed because there are
 #        no applicable updates (WU_E_NOT_APPLICABLE 0x80240017)".
 #     Other cases, it will be set to 'false'.
-#   win_online_updates_installed: If set to 'true', there are Windows online updates
-#     installed in guest OS, or it will be 'false'.
+#   win_online_updates_installed: If set to 'true', there are at least one Windows online
+#    updates installed in guest OS, or it will be 'false'.
 #
 - name: "Set fact and initialize Windows online updates install parameters"
   ansible.builtin.set_fact:
@@ -96,14 +96,20 @@
         - name: "Set fact of failure messages of not installed updates"
           ansible.builtin.set_fact:
             win_updates_failure_msgs: "{{ win_updates_not_installed | map(attribute='failure_msg') }}"
+        - name: "Set fact of the lengths of failure messages and not installed updates lists"
+          ansible.builtin.set_fact:
+            win_updates_failure_msgs_len: "{{ win_updates_failure_msgs | length }}"
+            win_updates_not_installed_len: "{{ win_updates_not_installed | length }}"
 
-        - name: "No failure message for update"
+        - name: "No failure messages for not installed updates"
           ansible.builtin.debug:
-            msg: "No 'failure_msg' info for not installed updates, so will not ignore these not installed updates."
-          when: win_updates_failure_msgs | length != win_updates_not_installed | length
+            msg: >-
+              {{ win_updates_not_installed_len - win_updates_failure_msgs_len }} updates
+              are not installed and without failure messages, which can not be ignored.
+          when: win_updates_failure_msgs_len != win_updates_not_installed_len
 
         - name: "Get failure messages for all not installed updates"
-          when: win_updates_failure_msgs | length == win_updates_not_installed | length
+          when: win_updates_failure_msgs_len == win_updates_not_installed_len
           block:
             - name: "Set fact of failure messages can not be ignored"
               ansible.builtin.set_fact:

--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -96,14 +96,24 @@
         - name: "Set fact of failure messages of not installed updates"
           ansible.builtin.set_fact:
             win_updates_failure_msgs: "{{ win_updates_not_installed | map(attribute='failure_msg') }}"
-        - name: "Set fact of failure messages can not be ignored"
-          ansible.builtin.set_fact:
-            win_updates_failure_msgs: "{{ win_updates_failure_msgs | difference(win_updates_failure_msgs | select('search', item)) }}"
-          loop: "{{ win_updates_ignore_kws }}"
-        - name: "Set fact of Windows online updates install status"
-          ansible.builtin.set_fact:
-            win_online_updates_succeed: true
-          when: win_updates_failure_msgs | length == 0
+
+        - name: "No failure message for update"
+          ansible.builtin.debug:
+            msg: "No 'failure_msg' info for not installed updates, so will not ignore these not installed updates."
+          when: win_updates_failure_msgs | length != win_updates_not_installed | length
+
+        - name: "Get failure messages for all not installed updates"
+          when: win_updates_failure_msgs | length == win_updates_not_installed | length
+          block:
+            - name: "Set fact of failure messages can not be ignored"
+              ansible.builtin.set_fact:
+                win_updates_failure_msgs: >
+                  {{ win_updates_failure_msgs | difference(win_updates_failure_msgs | select('search', item)) }}
+              loop: "{{ win_updates_ignore_kws }}"
+            - name: "Set fact of Windows online updates install status"
+              ansible.builtin.set_fact:
+                win_online_updates_succeed: true
+              when: win_updates_failure_msgs | length == 0
 
 - name: "Display Windows online updates install status"
   ansible.builtin.debug:

--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -16,13 +16,25 @@
 #   win_updates_log_file (optional): The log file path for Windows Update in guest OS.
 #     Default is 'C:\win_updates_log.txt'.
 # Return:
-#   win_online_updates_installed: Indicates if there are Windows online updates
-#     installed in guest OS successfully.
+#   win_online_updates_succeed: Will be set to 'true' in below conditions:
+#     1. no Windows updates found,
+#     2. there are Windows updates found, and the installed updates count is equal to
+#        the found count,
+#     3. there are Windows updates found, and the installed updates count is not equal
+#        to the found count, but the failure messages of the not installed ones contain
+#        the keywords representing failure can be ignored.
+#        For example, 'failure_msg' is "Operation was not performed because there are
+#        no applicable updates (WU_E_NOT_APPLICABLE 0x80240017)".
+#     Other cases, it will be set to 'false'.
+#   win_online_updates_installed: If set to 'true', there are Windows online updates
+#     installed in guest OS, or it will be 'false'.
 #
 - name: "Set fact and initialize Windows online updates install parameters"
   ansible.builtin.set_fact:
     win_updates_log_file: "{{ win_updates_log_file | default('C:\\win_updates_log.txt') }}"
+    win_online_updates_succeed: false
     win_online_updates_installed: false
+    win_updates_ignore_kws: ["no applicable"]
 
 - name: "Install Windows online updates"
   ansible.windows.win_updates:
@@ -39,19 +51,62 @@
   ignore_errors: "{{ win_updates_ignore_errors | default(false) }}"
 
 - name: "Print Windows online updates install result"
-  debug: var=win_updates_install_result
+  ansible.builtin.debug: var=win_updates_install_result
   when: enable_debug
 
-- name: "Set fact of Windows online updates install status"
-  ansible.builtin.set_fact:
-    win_online_updates_installed: true
+- name: "Windows online updates install task succeeds"
   when:
     - win_updates_install_result.failed is defined
     - not win_updates_install_result.failed
     - win_updates_install_result.found_update_count is defined
-    - win_updates_install_result.found_update_count | int != 0
     - win_updates_install_result.installed_update_count is defined
-    - win_updates_install_result.installed_update_count | int != 0
+  block:
+    # No updates found, so no updates installed
+    - name: "Set fact of Windows online updates install succeeds"
+      ansible.builtin.set_fact:
+        win_online_updates_succeed: true
+      when: win_updates_install_result.found_update_count | int == 0
+
+    # Updates found, updates installed
+    - name: "Installed update count is equal to found update count"
+      ansible.builtin.set_fact:
+        win_online_updates_succeed: true
+        win_online_updates_installed: true
+      when:
+        - win_updates_install_result.found_update_count | int != 0
+        - win_updates_install_result.installed_update_count | int == win_updates_install_result.found_update_count | int
+
+    # Updates found, while some not installed
+    - name: "Installed update count is not equal to found update count"
+      when:
+        - win_updates_install_result.found_update_count | int != 0
+        - win_updates_install_result.found_update_count | int > win_updates_install_result.installed_update_count | int
+      block:
+        - name: "Set fact of Windows online updates install status"
+          ansible.builtin.set_fact:
+            win_online_updates_installed: true
+          when: win_updates_install_result.installed_update_count | int != 0
+
+        - name: "Set fact of not installed updates list"
+          ansible.builtin.set_fact:
+            win_updates_not_installed: "{{ win_updates_install_result.updates.values() | selectattr('installed', 'equalto', false) }}"
+        - name: "Display the not installed updates list"
+          ansible.builtin.debug: var=win_updates_not_installed
+
+        - name: "Set fact of failure messages of not installed updates"
+          ansible.builtin.set_fact:
+            win_updates_failure_msgs: "{{ win_updates_not_installed | map(attribute='failure_msg') }}"
+        - name: "Set fact of failure messages can not be ignored"
+          ansible.builtin.set_fact:
+            win_updates_failure_msgs: "{{ win_updates_failure_msgs | difference(win_updates_failure_msgs | select('search', item)) }}"
+          loop: "{{ win_updates_ignore_kws }}"
+        - name: "Set fact of Windows online updates install status"
+          ansible.builtin.set_fact:
+            win_online_updates_succeed: true
+          when: win_updates_failure_msgs | length == 0
 
 - name: "Display Windows online updates install status"
-  ansible.builtin.debug: var=win_online_updates_installed
+  ansible.builtin.debug:
+    msg:
+      - "Windows online updates install succeeds: {{ win_online_updates_succeed }}"
+      - "There are Windows online updates installed in guest OS : {{ win_online_updates_installed }}"

--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -17,7 +17,7 @@
 #     Default is 'C:\win_updates_log.txt'.
 # Return:
 #   win_online_updates_installed: Indicates if there are Windows online updates
-#     installed and the installed count is the same as the found count.
+#     installed in guest OS successfully.
 #
 - name: "Set fact and initialize Windows online updates install parameters"
   ansible.builtin.set_fact:
@@ -46,10 +46,12 @@
   ansible.builtin.set_fact:
     win_online_updates_installed: true
   when:
+    - win_updates_install_result.failed is defined
+    - not win_updates_install_result.failed
     - win_updates_install_result.found_update_count is defined
     - win_updates_install_result.found_update_count | int != 0
     - win_updates_install_result.installed_update_count is defined
-    - win_updates_install_result.found_update_count | int == win_updates_install_result.installed_update_count | int
+    - win_updates_install_result.installed_update_count | int != 0
 
 - name: "Display Windows online updates install status"
   ansible.builtin.debug: var=win_online_updates_installed

--- a/windows/windows_online_updates_install/install_windows_online_updates.yml
+++ b/windows/windows_online_updates_install/install_windows_online_updates.yml
@@ -52,7 +52,7 @@
     msg: >-
       Before installing Windows updates, guest OS build number is '{{ win_os_build_before_update }}',
       configured expected build number is '{{ windows_updated_build_num }}', while after trying to
-      install Windows updates in guest OS, no update installed.
+      install Windows updates in guest OS, no update found or installed.
   when:
     - win_check_is_updated
     - not win_online_updates_installed

--- a/windows/windows_online_updates_install/install_windows_online_updates.yml
+++ b/windows/windows_online_updates_install/install_windows_online_updates.yml
@@ -44,15 +44,28 @@
     skip_reason: "Not Applicable"
   when:
     - not win_check_is_updated
+    - win_online_updates_succeed
     - not win_online_updates_installed
 
-# Fail test case when no update installed while expect guest OS to be updated
-- name: "No Windows updates installed in guest OS"
+# Fail test case when not all updates installed and not expect guest OS to be updated
+- name: "Not all Windows updates installed in guest OS"
+  ansible.builtin.fail:
+    msg: >-
+      Test case failed due to not all Windows updates installed, while parameter 'windows_updated_build_num'
+      '{{ windows_updated_build_num | default('') }}' is not set to the build number
+      newer than the current build '{{ win_os_build_before_update }}', please check the
+      failure messages of not installed updates.
+  when:
+    - not win_check_is_updated
+    - not win_online_updates_succeed
+
+# Fail test case when no or not all updates installed while expect guest OS to be updated
+- name: "No or not all Windows updates installed in guest OS"
   ansible.builtin.fail:
     msg: >-
       Before installing Windows updates, guest OS build number is '{{ win_os_build_before_update }}',
       configured expected build number is '{{ windows_updated_build_num }}', while after trying to
-      install Windows updates in guest OS, no update found or installed.
+      install Windows updates in guest OS, no update or not all updates installed.
   when:
     - win_check_is_updated
-    - not win_online_updates_installed
+    - not win_online_updates_installed or not win_online_updates_succeed

--- a/windows/windows_online_updates_install/windows_online_updates_install.yml
+++ b/windows/windows_online_updates_install/windows_online_updates_install.yml
@@ -16,8 +16,6 @@
         - name: "Initialize Windows updates install variables"
           ansible.builtin.set_fact:
             win_updates_log_file: "C:\\win_updates_log.txt"
-            win_online_updates_succeed: false
-            win_online_updates_installed: false
             win_check_is_updated: false
 
         - name: "Check parameter 'windows_updated_build_num' value"

--- a/windows/windows_online_updates_install/windows_online_updates_install.yml
+++ b/windows/windows_online_updates_install/windows_online_updates_install.yml
@@ -16,6 +16,7 @@
         - name: "Initialize Windows updates install variables"
           ansible.builtin.set_fact:
             win_updates_log_file: "C:\\win_updates_log.txt"
+            win_online_updates_succeed: false
             win_online_updates_installed: false
             win_check_is_updated: false
 

--- a/windows/windows_update_install/install_online_updates.yml
+++ b/windows/windows_update_install/install_online_updates.yml
@@ -1,10 +1,6 @@
 # Copyright 2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Initialize Windows online updates install status"
-  ansible.builtin.set_fact:
-    win_online_updates_succeed: false
-
 - name: "Get guest OS version build"
   include_tasks: ../utils/win_get_os_version.yml
 - name: "Display the guest OS version build before installing Windows online updates"

--- a/windows/windows_update_install/install_online_updates.yml
+++ b/windows/windows_update_install/install_online_updates.yml
@@ -3,7 +3,7 @@
 ---
 - name: "Initialize Windows online updates install status"
   ansible.builtin.set_fact:
-    win_online_updates_installed: false
+    win_online_updates_succeed: false
 
 - name: "Get guest OS version build"
   include_tasks: ../utils/win_get_os_version.yml
@@ -52,7 +52,9 @@
 # For internal existing VM test scenario.
 # If guest OS has been updated, take a new base snapshot and remove the old one.
 - name: "Reset base snapshot if Windows online updates installed"
-  when: win_online_updates_installed
+  when:
+    - win_online_updates_succeed
+    - win_online_updates_installed
   block:
     - name: "Get guest OS version build"
       include_tasks: ../utils/win_get_os_version.yml


### PR DESCRIPTION
In the situation that "found updates count != installed updates count", while the reason is some updates are not applicable to the OS and the task result is not 'failed', so this is acceptable result.