### PR TITLE
[Linux] Get cloud-init version from command line

### DIFF
--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -77,7 +77,7 @@
         - name: "Assert cloud-init GOSC flag 'disable_vmware_customization' is false"
           ansible.builtin.assert:
             that:
-              - "{{ enable_ci_gosc_result.stdout.split(':')[1].strip() | lower == 'false' }}"
+              - not (enable_ci_gosc_result.stdout.split(':')[1].strip() | bool)
             fail_msg: "Failed to enable cloud-init GOSC by setting 'disable_vmware_customization' to true"
 
         - name: "Enable cloud-init network config"

--- a/linux/utils/get_cloudinit_version.yml
+++ b/linux/utils/get_cloudinit_version.yml
@@ -7,18 +7,21 @@
   ansible.builtin.set_fact:
     cloudinit_version: ""
 
+# Some OS might print cloud-init version to stderr
 - name: "Get cloud-init version from package info"
-  include_tasks: get_installed_package_info.yml
-  vars:
-    package_name: "cloud-init"
+  ansible.builtin.shell: "/usr/bin/cloud-init --version 2>&1 | awk '{print $2}'"
+  delegate_to: "{{ vm_guest_ip }}"
+  ignore_errors: true
+  register: get_cloudinit_version
 
 - name: "Set fact of cloud-init version"
   ansible.builtin.set_fact:
-    cloudinit_version: "{{ package_info.Version }}"
+    cloudinit_version: "{{ get_cloudinit_version.stdout }}"
   when:
-    - package_info | length > 0
-    - package_info.Version is defined
-    - package_info.Version
+    - get_cloudinit_version.rc is defined
+    - get_cloudinit_version.rc == 0
+    - get_cloudinit_version.stdout is defined
+    - get_cloudinit_version.stdout
 
 - name: "Print the cloud-init version"
   ansible.builtin.debug: var=cloudinit_version


### PR DESCRIPTION
The cloud-init version get from Ansible package module is not a full version on RHEL family. This change directly gets the cloud-init version from cloud-init command
Take RHEL_9.4 as an example, before this change, cloud-init version get from Ansible module is 23.4; with this change, we can get the full version 23.4-7.el9_4.
```
Photon_5.0: 24.2
RHEL_9.x: 23.4-7.el9_4
RHEL_7.x: 19.4
RockyLinux_8.x: 23.4-7.el8_10.0.1
ProLinux_8.x: 21.1-15.0.1.el8
CentOS_10: 24.1.4-13.el10
Debian_10.x_64: 20.2
Photon_4.0: 24.2
Ubuntu_24.04: 24.1.3-0ubuntu3
Pardus_23.x: 22.4.2
```