### PR TITLE
Add mainline kernel upgarde support for ubuntu

### DIFF
--- a/autoinstall/Ubuntu/Desktop/Subiquity/user-data.j2
+++ b/autoinstall/Ubuntu/Desktop/Subiquity/user-data.j2
@@ -32,6 +32,8 @@ autoinstall:
     - rdma-core
     - rdmacm-utils
     - ibverbs-utils
+    - nfs-common
+    - curl
   user-data:
     users:
       - name: root

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -42,14 +42,9 @@
 - name: "Prepare for Ubuntu installation"
   when: guest_id is match('ubuntu.*')
   block:
-    - name: "Check upgrade_kernel_version when upgrade_kernel_version is defined"
+    - name: "Check and get upgrade_kernel_version when upgrade_kernel_version is defined"
+      include_tasks: ubuntu/get_mainline_kernel.yml
       when: upgrade_kernel_version is defined and upgrade_kernel_version
-      block:
-        - name: "Set the base url for kernel version check"
-          ansible.builtin.set_fact:
-            mainline_kernel_url: "https://kernel.ubuntu.com/mainline"
-        - name: "Check the kernel version exists"
-          include_tasks: ubuntu/get_mainline_kernel.yml
     - name: "Prepare for Ubuntu installation"
       include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
 
@@ -312,7 +307,7 @@
         wait_service_status: "running"
 
 - name: "Upgrade kernel for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
-  include_tasks: upgrade_vm_kernel.yml
+  include_tasks: upgrade_linux_kernel.yml
   when: >
     ((upgrade_kernel_version is defined and upgrade_kernel_version and 
     guest_os_ansible_distribution == "Ubuntu") or

--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -40,8 +40,18 @@
   include_tasks: ../../common/get_iso_file_list.yml
 
 - name: "Prepare for Ubuntu installation"
-  include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
   when: guest_id is match('ubuntu.*')
+  block:
+    - name: "Check upgrade_kernel_version when upgrade_kernel_version is defined"
+      when: upgrade_kernel_version is defined and upgrade_kernel_version
+      block:
+        - name: "Set the base url for kernel version check"
+          ansible.builtin.set_fact:
+            mainline_kernel_url: "https://kernel.ubuntu.com/mainline"
+        - name: "Check the kernel version exists"
+          include_tasks: ubuntu/get_mainline_kernel.yml
+    - name: "Prepare for Ubuntu installation"
+      include_tasks: ubuntu/prepare_ubuntu_iso_install.yml
 
 - name: "Set default unattend install conf file"
   when: unattend_install_conf is undefined or not unattend_install_conf
@@ -301,60 +311,11 @@
         service_name: "{{ wait_service_name }}"
         wait_service_status: "running"
 
-- name: "Upgrade Oracle Linux 9.0 kernel from UEK R7 GA to latest UEK R7"
-  when:
-    - guest_os_ansible_distribution == "OracleLinux"
-    - guest_os_ansible_distribution_ver == "9.0"
-    - "'uek' in guest_os_ansible_kernel"
-  block:
-    - name: "Take a snapshot before upgrading UEK"
-      include_tasks: ../../common/vm_take_snapshot.yml
-      vars:
-        snapshot_name: "OL_9.0GA_UEK"
-
-    - name: "Get Oracle Linux 9.0 UEK R7 version before upgrading"
-      ansible.builtin.set_fact:
-        ol9_uekr7_is_upgraded: false
-        ol9_uekr7_before_upgrade: "{{ guest_os_ansible_kernel }}"
-
-    - name: "Add Oracle Linux online repos for upgrading kernel"
-      include_tasks: ../utils/add_official_online_repo.yml
-
-    - name: "Update Oracle Linux 9.0 to latest UEK R7"
-      ansible.builtin.shell: "yum update --nogpgcheck -y"
-      register: ol9_uekr7_upgrade_result
-      delegate_to: "{{ vm_guest_ip }}"
-
-    - name: "Set the fact of that Oracle Linux 9.0 UEK R7 is upgraded"
-      ansible.builtin.set_fact:
-        ol9_uekr7_is_upgraded: true
-      when:
-        - ol9_uekr7_upgrade_result is defined
-        - ol9_uekr7_upgrade_result.rc is defined
-        - ol9_uekr7_upgrade_result.rc == 0
-
-    - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded"
-      when: ol9_uekr7_is_upgraded
-      block:
-        - name: "Reboot Oracle Linux"
-          include_tasks: ../utils/reboot.yml
-
-        - name: "Update VM guest IPv4 address in in-memory inventory"
-          include_tasks: ../../common/update_inventory.yml
-
-        - name: "Refresh Linux system info"
-          include_tasks: ../utils/get_linux_system_info.yml
-
-        - name: "Get Oracle Linux 9.0 UEK R7 version after upgrading"
-          ansible.builtin.set_fact:
-            ol9_uekr7_after_upgrade: "{{ guest_os_ansible_kernel }}"
-
-        - name: "Check Oracle Linux 9.0 kernel UEK R7 is upgraded successfully"
-          ansible.builtin.assert:
-            that:
-              - ol9_uekr7_after_upgrade is version(ol9_uekr7_before_upgrade, '>')
-            fail_msg: >-
-              Oracle Linux 9.0 UEK R7 upgrading failed. Before upgrade, the UEK R7
-              version is '{{ ol9_uekr7_before_upgrade }}', after upgrade the UEK R7
-              version is '{{ ol9_uekr7_after_upgrade }}'.
-
+- name: "Upgrade kernel for {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
+  include_tasks: upgrade_vm_kernel.yml
+  when: >
+    ((upgrade_kernel_version is defined and upgrade_kernel_version and 
+    guest_os_ansible_distribution == "Ubuntu") or
+    (guest_os_ansible_distribution == "OracleLinux" and
+    guest_os_ansible_distribution_ver == "9.0" and
+    "'uek' in guest_os_ansible_kernel"))

--- a/linux/deploy_vm/templates/post_install_scripts/preseed_late_command.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/preseed_late_command.sh
@@ -6,7 +6,7 @@
 required_pkgs="open-vm-tools"
 {% if unattend_installer == 'Ubuntu-Ubiquity' %}
 # Ubuntu Desktop required packages
-required_pkgs="$required_pkgs open-vm-tools-desktop build-essential openssh-server vim locales cloud-init rdma-core rdmacm-utils ibverbs-utils"
+required_pkgs="$required_pkgs open-vm-tools-desktop build-essential openssh-server vim locales cloud-init rdma-core rdmacm-utils ibverbs-utils nfs-common curl"
 {% elif unattend_installer == 'Debian' %}
 # Debian required packages
 required_pkgs="$required_pkgs open-vm-tools-desktop cloud-init debconf-utils rdma-core rdmacm-utils ibverbs-utils"

--- a/linux/deploy_vm/ubuntu/get_mainline_kernel.yml
+++ b/linux/deploy_vm/ubuntu/get_mainline_kernel.yml
@@ -1,0 +1,41 @@
+# Copyright 2022-2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Check the kernel version exists"
+  ansible.builtin.uri:
+    url: "{{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64"
+    return_content: true
+  register: check_kernel_result
+  ignore_errors: yes
+  when: upgrade_kernel_version is match('[0-9]+.[0-9a-z.-]+')
+
+- name: "Get the latest kernel version"
+  when: >
+    (upgrade_kernel_version | lower == 'latest' or
+     upgrade_kernel_version is not match('[0-9]+.[0-9a-z.-]+') or
+     check_kernel_result.status is undefined or check_kernel_result.status != 200)
+  block:
+    - name: "Get the latest kernel with amd64"
+      ansible.builtin.shell: |
+        versions=`curl -s '{{ mainline_kernel_url }}/?C=N;O=D' | sed 's/>/\\n/g' |grep -Po '(?<=v)[0-9]+.[0-9a-z.-]+'|head -10`
+        for version in $versions; do
+          if wget --spider "{{ mainline_kernel_url }}/v$version/amd64"; then
+            echo "$version"
+            break
+          else
+            continue
+          fi
+        done
+      register: get_kernel_version_result
+    - name: "Check the kernel version result"
+      ansible.builtin.assert:
+        that:
+          - get_kernel_version_result is defined
+          - get_kernel_version_result.stdout_lines is defined
+          - get_kernel_version_result.stdout_lines | length >= 1
+          - get_kernel_version_result.stdout_lines[0] is match('[0-9]+.[0-9a-z.-]+')
+        fail_msg: "Failed to get the latest version: {{ get_kernel_version_result.stderr }}"
+        success_msg: "Get the latest version: get_kernel_version_result.stdout_lines[0]"
+    - name: "Set the kernel version"
+      ansible.builtin.set_fact:
+        upgrade_kernel_version: "{{ get_kernel_version_result.stdout_lines[0] }}"

--- a/linux/deploy_vm/ubuntu/get_mainline_kernel.yml
+++ b/linux/deploy_vm/ubuntu/get_mainline_kernel.yml
@@ -1,6 +1,10 @@
 # Copyright 2022-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+- name: "Set the base url for kernel version check"
+  ansible.builtin.set_fact:
+    mainline_kernel_url: "https://kernel.ubuntu.com/mainline"
+
 - name: "Check the kernel version exists"
   ansible.builtin.uri:
     url: "{{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64"

--- a/linux/deploy_vm/upgrade_linux_kernel.yml
+++ b/linux/deploy_vm/upgrade_linux_kernel.yml
@@ -23,8 +23,6 @@
 
 - name: "Update mainline kernel to {{ upgrade_kernel_version }} for Ubuntu"
   ansible.builtin.shell: |
-    packages="nfs-common curl"
-    for package in $packages; do dpkg -l | grep -qw $package || apt install -y $package; done
     wget -c -- $(curl -s {{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64/ | sed 's/"\|>\|</\n/g' | grep deb | uniq | while read line; do echo "{{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64/${line}";done)
     if [ $? -eq 0 ]; then dpkg -i linux*.deb; rm -rf linux*.deb; fi
     sed -i 's/#WaylandEnable=false/WaylandEnable=false/'  /etc/gdm3/custom.conf

--- a/linux/deploy_vm/upgrade_vm_kernel.yml
+++ b/linux/deploy_vm/upgrade_vm_kernel.yml
@@ -1,0 +1,74 @@
+# Copyright 2022-2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Take a snapshot before upgrading kernel"
+  include_tasks: ../../common/vm_take_snapshot.yml
+  vars:
+    snapshot_name: "kernel_before_upgrade"
+
+- name: "Get kernel version before upgrading"
+  ansible.builtin.set_fact:
+    kernel_is_upgraded: false
+    kernel_before_upgrade: "{{ guest_os_ansible_kernel }}"
+
+- name: "Upgrade Kernel for Oracle"
+  when: guest_os_ansible_distribution == "OracleLinux"
+  block:
+    - name: "Add Oracle Linux online repos for upgrading kernel"
+      include_tasks: ../utils/add_official_online_repo.yml
+    - name: "Update Oracle Linux 9.0 to latest UEK R7"
+      ansible.builtin.shell: "yum update --nogpgcheck -y"
+      register: kernel_upgrade_result
+      delegate_to: "{{ vm_guest_ip }}"
+
+- name: "Update mainline kernel to {{ upgrade_kernel_version }} for Ubuntu"
+  ansible.builtin.shell: |
+    packages="nfs-common curl"
+    for package in $packages; do dpkg -l | grep -qw $package || apt install -y $package; done
+    wget -c -- $(curl -s {{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64/ | sed 's/"\|>\|</\n/g' | grep deb | uniq | while read line; do echo "{{ mainline_kernel_url }}/v{{ upgrade_kernel_version }}/amd64/${line}";done)
+    if [ $? -eq 0 ]; then dpkg -i linux*.deb; rm -rf linux*.deb; fi
+    sed -i 's/#WaylandEnable=false/WaylandEnable=false/'  /etc/gdm3/custom.conf
+  register: kernel_upgrade_result
+  delegate_to: "{{ vm_guest_ip }}"
+  when: guest_os_ansible_distribution == "Ubuntu"
+
+- name: "Set the fact of that kernel is upgraded"
+  ansible.builtin.set_fact:
+    kernel_is_upgraded: true
+  when:
+    - kernel_upgrade_result is defined
+    - kernel_upgrade_result.rc is defined
+    - kernel_upgrade_result.rc == 0
+
+- name: "Check kernel is upgraded"
+  when: kernel_is_upgraded
+  block:
+    - name: "Reboot Linux Guest"
+      include_tasks: ../utils/reboot.yml
+
+    - name: "Update VM guest IPv4 address in in-memory inventory"
+      include_tasks: ../../common/update_inventory.yml
+
+    - name: "Refresh Linux system info"
+      include_tasks: ../utils/get_linux_system_info.yml
+
+    - name: "Get kernel version after upgrading"
+      ansible.builtin.set_fact:
+        kernel_after_upgrade: "{{ guest_os_ansible_kernel }}"
+
+    - name: "Check kernel is upgraded successfully"
+      ansible.builtin.assert:
+        that:
+          - kernel_after_upgrade is version(kernel_before_upgrade, '>')
+        fail_msg: >-
+          Kernel upgrading failed. Before upgrade, the kernel
+          version is '{{ kernel_before_upgrade }}', after upgrade the kernel
+          version is '{{ kernel_after_upgrade }}'.
+
+    - name: "Check gcc version in ubuntu {{ kernel_after_upgrade }}"
+      ansible.builtin.shell: |
+        gcc_ver=$(cat /proc/version | grep -Po 'gcc-\d+')
+        if ! dpkg-query -W -f='${Status}' "$gcc_ver"  | grep "ok installed"; then apt install -y "$gcc_ver"; fi 
+      register: check_gcc_result
+      delegate_to: "{{ vm_guest_ip }}"
+      when: guest_os_ansible_distribution == "Ubuntu"

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -415,6 +415,11 @@ flatcar_python3_download_url: "https://downloads.activestate.com/ActivePython/re
 #
 # http_proxy_vm: "http://myproxy.company.com:8080"
 
+# For Linux Mainline Kernel Upgrade only in Ubuntu:
+# e.g., 'latest', '6.10', '6.11-rc1'.
+#
+# upgrade_kernel_version: latest
+
 # FusionOS:
 # By default, VM's IPv4 address is assigned by DHCP server. To install FusionOS
 # with static IP, set 'ethernet0_ipv4_addr', 'ethernet0_gateway' and 'ethernet0_netmask'


### PR DESCRIPTION
- Add upgrade_kernel_version into var/test.yml for testing kernel upgrade only in ubuntu
- Testing done with ubuntu 24.04 and mainline kernel 6.11-rc2
```
ok: [localhost] => {
    "ansible_facts": {
        "upgrade_kernel_version": "6.11-rc2"
    },
    "changed": false
}
...
ok: [localhost] => {
    "ansible_facts": {
        "kernel_before_upgrade": "6.8.0-39-generic",
        "kernel_is_upgraded": false
    },
    "changed": false
}
...
ok: [localhost] => {
    "ansible_facts": {
        "kernel_after_upgrade": "6.11.0-061100rc2-generic"
    },
    "changed": false
}
```