### PR TITLE
[Windows] get VM guest info again after VMware Tools install

### DIFF
--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -8,8 +8,8 @@
 - name: "Initialize variables for new VM settings"
   ansible.builtin.set_fact:
     boot_disk_controller: "{{ boot_disk_controller | lower if (boot_disk_controller is defined and boot_disk_controller) else 'lsilogicsas' }}"
-    secureboot_enabled: "{{ secureboot_enabled | bool if (secureboot_enabled is defined and secureboot_enabled) else false }}"
-    network_adapter_type: "{{ 'e1000e' if (windows_has_inbox_driver is undefined or not windows_has_inbox_driver) else network_adapter_type }}"
+    secureboot_enabled: "{{ secureboot_enabled | default(false) | bool }}"
+    network_adapter_type: "{{ network_adapter_type | lower if (network_adapter_type is defined and network_adapter_type) else 'e1000e' }}"
     firmware: "{{ firmware | lower if (firmware is defined and firmware) else 'efi' }}"
     boot_disk_size_gb: "{{ [64, boot_disk_size_gb | default(64) | int] | max }}"
 

--- a/windows/deploy_vm/deploy_vm_from_iso.yml
+++ b/windows/deploy_vm/deploy_vm_from_iso.yml
@@ -8,7 +8,7 @@
 - name: "Initialize variables for new VM settings"
   ansible.builtin.set_fact:
     boot_disk_controller: "{{ boot_disk_controller | lower if (boot_disk_controller is defined and boot_disk_controller) else 'lsilogicsas' }}"
-    secureboot_enabled: "{{ secureboot_enabled | default(false) | bool }}"
+    secureboot_enabled: "{{ secureboot_enabled is defined and secureboot_enabled | lower == 'true' }}"
     network_adapter_type: "{{ network_adapter_type | lower if (network_adapter_type is defined and network_adapter_type) else 'e1000e' }}"
     firmware: "{{ firmware | lower if (firmware is defined and firmware) else 'efi' }}"
     boot_disk_size_gb: "{{ [64, boot_disk_size_gb | default(64) | int] | max }}"

--- a/windows/setup/win_guest_reconfig.yml
+++ b/windows/setup/win_guest_reconfig.yml
@@ -22,6 +22,9 @@
   include_tasks: ../utils/win_disable_store_auto_update.yml
   when: guest_os_product_type == "client"
 
+- name: "Disable UAC"
+  include_tasks: ../utils/win_disable_uac.yml
+
 - name: "Restart guest OS"
   include_tasks: ../utils/win_shutdown_restart.yml
   vars:

--- a/windows/utils/win_disable_uac.yml
+++ b/windows/utils/win_disable_uac.yml
@@ -1,0 +1,50 @@
+# Copyright 2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Disable the User Account Control (UAC) in Windows guest OS,
+# restarting guest OS is required.
+# Return:
+#   win_uac_disable_set: if set to 'true', UAC registry value is set to '0',
+#     and restarting guest OS is required, if set to 'false', then the UAC
+#     registry value is as expected, no need to set it and restart guest OS.
+#
+- name: "Set fact of the registry path for UAC"
+  ansible.builtin.set_fact:
+    win_uac_disable_set: false
+    win_uac_reg_path: "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+
+- name: "Get UAC registry current value"
+  include_tasks: win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: |-
+      if (Test-Path '{{ win_uac_reg_path }}') {
+        (Get-ItemProperty {{ win_uac_reg_path }}).EnableLUA
+      } else {
+        Write-Host 1
+      }
+    win_execute_cmd_ignore_error: true
+
+- name: "Set fact of the result of getting UAC registry value"
+  ansible.builtin.set_fact:
+    win_uac_reg_result: "{{ win_powershell_cmd_output }}"
+
+- name: "UAC registry value is not expected"
+  when: >
+    not (win_uac_reg_result.stdout_lines is defined and
+    win_uac_reg_result.stdout_lines | length == 1 and
+    win_uac_reg_result.stdout_lines[0] | int == 0)
+  block:
+    - name: "Disable UAC in guest OS"
+      include_tasks: win_execute_cmd.yml
+      vars:
+        win_powershell_cmd: "New-ItemProperty -Path {{ win_uac_reg_path }} -Name EnableLUA -PropertyType DWord -Value 0 -Force"
+    - name: "Set fact of require restarting guest OS"
+      ansible.builtin.set_fact:
+        win_uac_disable_set: true
+
+- name: "Print this task result"
+  ansible.builtin.debug:
+    msg: >
+      {%- if win_uac_disable_set -%}"Disable UAC by setting registry value to '0', please restart guest OS."
+      {%- else -%}"UAC registry value is already set to '0', not execute disable operation in guest OS."
+      {%- endif -%}

--- a/windows/utils/win_get_service_status.yml
+++ b/windows/utils/win_get_service_status.yml
@@ -7,17 +7,19 @@
 # Return:
 #   service_status: the service status
 #
-- name: Check required parameter
+- name: "Check required parameter"
   ansible.builtin.fail:
     msg: "win_service_name must be defined before get service status"
   when: win_service_name is undefined or not win_service_name
 
-- include_tasks: win_execute_cmd.yml
+- name: "Get service status"
+  include_tasks: win_execute_cmd.yml
   vars:
-    win_powershell_cmd: "get-service -Name {{ win_service_name }} | foreach {$_.Status}"
+    win_powershell_cmd: "Get-Service -Name {{ win_service_name }} | foreach {$_.Status}"
 
-- name: Set fact of the service status
+- name: "Set fact of the service status"
   ansible.builtin.set_fact:
     service_status: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
-- ansible.builtin.debug:
-    msg: "Get service '{{ win_service_name }}' status: {{ service_status }}"
+
+- name: "Display service status"
+  ansible.builtin.debug: var=service_status

--- a/windows/utils/win_get_service_status.yml
+++ b/windows/utils/win_get_service_status.yml
@@ -7,6 +7,10 @@
 # Return:
 #   service_status: the service status
 #
+- name: "Initialize the service status"
+  ansible.builtin.set_fact:
+    service_status: ''
+
 - name: "Check required parameter"
   ansible.builtin.fail:
     msg: "win_service_name must be defined before get service status"
@@ -20,6 +24,9 @@
 - name: "Set fact of the service status"
   ansible.builtin.set_fact:
     service_status: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length == 1
 
 - name: "Display service status"
   ansible.builtin.debug: var=service_status

--- a/windows/utils/win_get_vmtools_service_list.yml
+++ b/windows/utils/win_get_vmtools_service_list.yml
@@ -10,10 +10,12 @@
 # Return:
 #   vmtools_service_dict: VMware Tools services and service status dict.
 #
-- name: "Initialize VMware Tools services and status result"
+- name: "Initialize VMware Tools services status result and expected services list"
   ansible.builtin.set_fact:
     vmtools_service_dict: {}
+    win_get_vmtools_service_expect: "{{ win_get_vmtools_service_expect | default([]) }}"
 
+# Retry specified times to get services and status
 - name: "Retry to get VMware Tools services and status"
   ansible.windows.win_shell: "Get-Service | where-object {$_.displayname -match 'VMware'} | select Name, Status | ft -hide"
   register: get_vmtools_ser_result
@@ -25,7 +27,7 @@
   until:
     - get_vmtools_ser_result.stdout is defined
     - get_vmtools_ser_result.stdout
-    - (win_get_vmtools_service_expect | default([]) | reject('in', get_vmtools_ser_result.stdout)) | length == 0
+    - (win_get_vmtools_service_expect | reject('in', get_vmtools_ser_result.stdout)) | length == 0
 
 - name: "Set fact of VMware Tools services and status dict"
   ansible.builtin.set_fact:
@@ -37,3 +39,12 @@
 
 - name: "Display VMware Tools services and status"
   ansible.builtin.debug: var=vmtools_service_dict
+
+- name: "Check get all the services expected"
+  ansible.builtin.assert:
+    that:
+      - services_missing == []
+    fail_msg: "Services '{{ services_missing }}' are not found in guest OS, please check manually."
+  vars:
+    services_missing: "{{ win_get_vmtools_service_expect | difference(vmtools_service_dict.keys()) }}"
+  when: win_get_vmtools_service_expect | length != 0

--- a/windows/utils/win_get_vmtools_service_list.yml
+++ b/windows/utils/win_get_vmtools_service_list.yml
@@ -1,32 +1,41 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get VMware tools related services in Windows guest OS
+# Get VMware Tools installed services in Windows guest OS
+# Parameters:
+#   win_get_vmtools_service_retries: the retry time to get services list,
+#     default value is 1.
+#   win_get_vmtools_service_expect: the expected services list to get,
+#     default value is [].
 # Return:
-#   vmtools_service_dict: service and service status dict
+#   vmtools_service_dict: VMware Tools services and service status dict.
 #
-- name: Initialize the service and service status result
+- name: "Initialize VMware Tools services and status result"
   ansible.builtin.set_fact:
-    vmtools_service_list: []
     vmtools_service_dict: {}
 
-# Get VMware tools installed service list in Windows guest OS
-- include_tasks: win_execute_cmd.yml
-  vars:
-    win_powershell_cmd: "get-service | where-object {$_.displayname -match 'VMware'} | select Name, Status | ft -hide"
+- name: "Retry to get VMware Tools services and status"
+  ansible.windows.win_shell: "Get-Service | where-object {$_.displayname -match 'VMware'} | select Name, Status | ft -hide"
+  register: get_vmtools_ser_result
+  ignore_errors: true
+  delegate_to: "{{ vm_guest_ip }}"
+  ignore_unreachable: true
+  retries: "{{ win_get_vmtools_service_retries | default(1) }}"
+  delay: 5
+  until:
+    - get_vmtools_ser_result.stdout is defined
+    - get_vmtools_ser_result.stdout
+    - (win_get_vmtools_service_expect | default([]) | reject('in', get_vmtools_ser_result.stdout)) | length == 0
 
-- name: Set fact of service list
-  ansible.builtin.set_fact:
-    vmtools_service_list: "{{ win_powershell_cmd_output.stdout_lines }}"
+- name: "Got VMware Tools services list"
+  block:
+    - name: "Set fact of VMware Tools services and status dict"
+      ansible.builtin.set_fact:
+        vmtools_service_dict: "{{ vmtools_service_dict | combine({item.split()[0]: item.split()[1]}) }}"
+      with_items: "{{ get_vmtools_ser_result.stdout_lines | select }}"
   when:
-    - win_powershell_cmd_output is defined
-    - win_powershell_cmd_output.stdout_lines is defined
-    - win_powershell_cmd_output.stdout_lines | length != 0
+    - get_vmtools_ser_result.stdout_lines is defined
+    - get_vmtools_ser_result.stdout_lines | length != 0
 
-- name: Set fact of the service and service status dict
-  ansible.builtin.set_fact:
-    vmtools_service_dict: "{{ vmtools_service_dict | combine({item.split()[0]: item.split()[1]}) }}"
-  when: item
-  with_items: "{{ vmtools_service_list }}"
-- ansible.builtin.debug:
-    msg: "Get VMware tools installed service dict: {{ vmtools_service_dict | to_yaml }}"
+- name: "Display VMware Tools services and status"
+  ansible.builtin.debug: var=vmtools_service_dict

--- a/windows/utils/win_get_vmtools_service_list.yml
+++ b/windows/utils/win_get_vmtools_service_list.yml
@@ -17,7 +17,7 @@
 
 # Retry specified times to get services and status
 - name: "Retry to get VMware Tools services and status"
-  ansible.windows.win_shell: "Get-Service | where-object {$_.displayname -match 'VMware'} | select Name, Status | ft -hide"
+  ansible.windows.win_shell: "Get-Service | Where-Object {$_.displayname -match 'VMware'} | select Name, Status | ft -hide"
   register: get_vmtools_ser_result
   ignore_errors: true
   delegate_to: "{{ vm_guest_ip }}"

--- a/windows/utils/win_get_vmtools_service_list.yml
+++ b/windows/utils/win_get_vmtools_service_list.yml
@@ -27,12 +27,10 @@
     - get_vmtools_ser_result.stdout
     - (win_get_vmtools_service_expect | default([]) | reject('in', get_vmtools_ser_result.stdout)) | length == 0
 
-- name: "Got VMware Tools services list"
-  block:
-    - name: "Set fact of VMware Tools services and status dict"
-      ansible.builtin.set_fact:
-        vmtools_service_dict: "{{ vmtools_service_dict | combine({item.split()[0]: item.split()[1]}) }}"
-      with_items: "{{ get_vmtools_ser_result.stdout_lines | select }}"
+- name: "Set fact of VMware Tools services and status dict"
+  ansible.builtin.set_fact:
+    vmtools_service_dict: "{{ vmtools_service_dict | combine({item.split()[0]: item.split()[1]}) }}"
+  with_items: "{{ get_vmtools_ser_result.stdout_lines | select }}"
   when:
     - get_vmtools_ser_result.stdout_lines is defined
     - get_vmtools_ser_result.stdout_lines | length != 0

--- a/windows/utils/win_shutdown_restart.yml
+++ b/windows/utils/win_shutdown_restart.yml
@@ -9,6 +9,7 @@
 #     Default value is 600 seconds.
 #
 - name: "Shutdown guest OS inside OS"
+  when: set_win_power_state == "shutdown"
   block:
     - name: "Execute shutdown OS command"
       ansible.builtin.raw: 'stop-computer -Force'
@@ -16,9 +17,9 @@
     - name: "Set fact of the expected status"
       ansible.builtin.set_fact:
         expected_power_state: "poweredOff"
-  when: set_win_power_state == "shutdown"
 
 - name: "Restart guest OS inside OS"
+  when: set_win_power_state == "restart"
   block:
     - name: "Restart OS using win_reboot module"
       ansible.windows.win_reboot:
@@ -31,16 +32,36 @@
     - name: "Set fact of the expected status"
       ansible.builtin.set_fact:
         expected_power_state: "poweredOn"
-  when: set_win_power_state == "restart"
 
 - name: "Wait 15 seconds to before checking power status"
   ansible.builtin.pause:
     seconds: 15
 
-- include_tasks: ../../common/vm_wait_power_state.yml
+- name: "Check VM power state '{{ expected_power_state }}'"
+  include_tasks: ../../common/vm_wait_power_state.yml
   vars:
     expected_power_status: "{{ expected_power_state }}"
 
-- name: "Check winrm connectable after OS restart"
-  include_tasks: win_check_winrm.yml
+- name: "Check OS restarted"
   when: set_win_power_state == "restart"
+  block:
+    - name: "Check winrm connectable after OS restart"
+      include_tasks: win_check_winrm.yml
+    # Check user logon in console session
+    - name: "Query user in guest OS after OS restart"
+      ansible.windows.win_shell: "query user console"
+      register: query_user_result
+      ignore_errors: true
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_unreachable: true
+      retries: 5
+      delay: 3
+      until:
+        - query_user_result.stdout_lines is defined
+        - query_user_result.stdout_lines | length != 0
+    - name: "Check query user result"
+      ansible.builtin.assert:
+        that:
+          - query_user_result.stdout_lines is defined
+          - query_user_result.stdout_lines | length != 0
+        fail_msg: "Not get logon user in console session after 15 seconds: {{  query_user_result }}"

--- a/windows/utils/win_shutdown_restart.yml
+++ b/windows/utils/win_shutdown_restart.yml
@@ -64,4 +64,4 @@
         that:
           - query_user_result.stdout_lines is defined
           - query_user_result.stdout_lines | length != 0
-        fail_msg: "Not get logon user in console session after 15 seconds: {{  query_user_result }}"
+        fail_msg: "Not get logon user in console session after 15 seconds: {{ query_user_result }}"

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -30,7 +30,7 @@
   async: 600
   poll: 0
   environment:
-    ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT: 15
+    ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT: 30
 - name: "Pause 2 minutes before checking task status"
   ansible.builtin.pause:
     minutes: 2

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -23,9 +23,9 @@
   ansible.windows.win_shell: "{{ vmtools_install_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   ignore_errors: true
-  become: "{{ 'Windows Server 2012 R2' in guest_os_ansible_distribution }}"
+  become: true
   become_method: runas
-  become_user: "{{ 'Administrator' if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else omit }}"
+  become_user: 'Administrator'
   register: wintools_install_result
   async: 600
   poll: 0

--- a/windows/wintools_complete_install_verify/install_vmtools.yml
+++ b/windows/wintools_complete_install_verify/install_vmtools.yml
@@ -23,9 +23,9 @@
   ansible.windows.win_shell: "{{ vmtools_install_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   ignore_errors: true
-  become: true
+  become: "{{ 'Windows Server 2012 R2' in guest_os_ansible_distribution }}"
   become_method: runas
-  become_user: 'Administrator'
+  become_user: "{{ 'Administrator' if ('Windows Server 2012 R2' in guest_os_ansible_distribution) else omit }}"
   register: wintools_install_result
   async: 600
   poll: 0

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -56,9 +56,16 @@
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
 
 - name: "Get usernames of VMware Tools processes in guest OS"
-  include_tasks: ../utils/win_execute_cmd.yml
+  include_tasks:
+    file: ../utils/win_execute_cmd.yml
+    apply:
+      when: >
+        (win_powershell_cmd_output.stdout_lines is undefined) or
+        (win_powershell_cmd_output.stdout_lines | length != 2) or
+        (win_powershell_cmd_output.stdout_lines | sort != win_vmtoolsd_username_list | sort)
   vars:
     win_powershell_cmd: "(Get-Process vmtoolsd -IncludeUserName).UserName"
+  with_list: "{{ range(1, 11) | list }}"
 
 - name: "Check usernames of VMware Tools processes"
   ansible.builtin.assert:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -3,7 +3,12 @@
 ---
 - name: "Set fact of expected VMware Tools services and process usernames list"
   ansible.builtin.set_fact:
-    win_tools_services: ['VGAuthService', 'VMTools', 'vmvss']
+    win_tools_services: |-
+      {%- if vmtools_version is defined and vmtools_version is version('10.3.0', '>=') -%}
+      ['VGAuthService', 'VMTools', 'vmvss']
+      {%- else -%}
+      ['VMTools']
+      {% endif %}
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
 
 # Refresh VM guest info
@@ -20,19 +25,11 @@
     win_get_vmtools_service_retries: 6
     win_get_vmtools_service_expect: "{{ win_tools_services }}"
 
-- name: "Check VMware Tools services"
+- name: "Check VMware Tools service is running"
   ansible.builtin.assert:
     that:
-      - win_tools_services_missing == []
       - vmtools_service_dict['VMTools'] == "Running"
-    fail_msg: >
-      Services '{{ win_tools_services_missing }}' are not found, or 'VMTools' service
-      is not 'Running': {{ vmtools_service_dict['VMTools'] }} after VMware Tools install.
-  vars:
-    win_tools_services_missing: "{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }}"
-  when:
-    - vmtools_version is defined
-    - vmtools_version is version('10.3.0', '>=')
+    fail_msg: "'VMTools' service is not 'Running' after VMware Tools install: {{ vmtools_service_dict['VMTools'] }}"
 
 # Get VMware drivers
 - name: "Get VMware drivers list"

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -34,6 +34,9 @@
 - name: "Print VMware Tools version and build number"
   ansible.builtin.debug: var=vmtools_info_from_vmtoolsd
 
+- name: "Update VM guest info after installing VMware Tools"
+  include_tasks: ../../common/vm_get_guest_info.yml
+
 - name: "Get VMware drivers list"
   include_tasks: ../utils/win_get_vmtools_driver_list.yml
 

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -1,14 +1,8 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Set fact of expected VMware Tools services and process usernames list"
+- name: "Set fact of expected VMware Tools processes usernames"
   ansible.builtin.set_fact:
-    win_tools_services: |-
-      {%- if vmtools_version is defined and vmtools_version is version('10.3.0', '>=') -%}
-      ['VGAuthService', 'VMTools', 'vmvss']
-      {%- else -%}
-      ['VMTools']
-      {% endif %}
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
 
 # Refresh VM guest info
@@ -18,6 +12,15 @@
 # Get VMware Tools version
 - name: "Get VMware Tools version and build number"
   include_tasks: ../utils/win_get_vmtools_version_build.yml
+
+- name: "Set fact of expected VMware Tools services"
+  ansible.builtin.set_fact:
+    win_tools_services: |-
+      {%- if vmtools_version is defined and vmtools_version is version('10.3.0', '>=') -%}
+      ['VGAuthService', 'VMTools', 'vmvss']
+      {%- else -%}
+      ['VMTools']
+      {% endif %}
 
 - name: "Get VMware Tools services list"
   include_tasks: ../utils/win_get_vmtools_service_list.yml

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -1,47 +1,34 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check VMware Tools service is running and display the installed VMware Tools
-# version, get VMware Tools installation log file.
-#
+# Refresh VM guest info
+- name: "Update VM guest info after installing VMware Tools"
+  include_tasks: ../../common/vm_get_guest_info.yml
+
+# Get VMware Tools version
+- name: "Get VMware Tools version and build number"
+  include_tasks: ../utils/win_get_vmtools_version_build.yml
+
+# Get VMware Tools services
 - name: "Set fact of VMware Tools services list"
   ansible.builtin.set_fact:
     win_tools_services: ['VGAuthService', 'VMTools', 'vmvss']
 
-- name: "Get VMware Tools install log file path"
-  include_tasks: ../utils/win_get_path.yml
-  vars:
-    win_get_path_specified: '$env:temp\vminst.log'
-- name: "Fetch VMware Tools install log file"
-  include_tasks: ../utils/win_get_file.yml
-  vars:
-    win_get_file_src_path: "{{ win_get_path_absolute }}"
-    win_get_file_dst_path: "{{ current_test_log_folder }}"
-
-- name: "Get VMware Tools service status"
+- name: "Get 'VMTools' service status"
   include_tasks: ../utils/win_get_service_status.yml
   vars:
     win_service_name: "VMTools"
-- name: "Verify VMware Tools service status is running"
+
+- name: "Verify 'VMTools' service status is running"
   ansible.builtin.assert:
     that:
       - service_status == "Running"
     fail_msg: "VMTools service status: {{ service_status }}, which is not 'Running'."
     success_msg: "VMTools service status is 'Running'."
 
-- name: "Get VMware Tools version and build number"
-  include_tasks: ../utils/win_get_vmtools_version_build.yml
-- name: "Print VMware Tools version and build number"
-  ansible.builtin.debug: var=vmtools_info_from_vmtoolsd
-
-- name: "Update VM guest info after installing VMware Tools"
-  include_tasks: ../../common/vm_get_guest_info.yml
-
-- name: "Get VMware drivers list"
-  include_tasks: ../utils/win_get_vmtools_driver_list.yml
-
 - name: "Get VMware Tools services list"
   include_tasks: ../utils/win_get_vmtools_service_list.yml
+
 # Not all services are running, e.g., vmvss
 - name: "Display VMware Tools services status"
   ansible.builtin.debug:
@@ -59,13 +46,20 @@
     - vmtools_version is defined
     - vmtools_version is version('10.3.0', '>=')
 
+# Get VMware drivers
+- name: "Get VMware drivers list"
+  include_tasks: ../utils/win_get_vmtools_driver_list.yml
+
+# Get VMware Tools processes
 - name: "Set fact of expected usernames of VMware Tools processes"
   ansible.builtin.set_fact:
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
+
 - name: "Get usernames of VMware Tools processes in guest OS"
   include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "(Get-Process vmtoolsd -IncludeUserName).UserName"
+
 - name: "Check usernames of VMware Tools processes"
   ansible.builtin.assert:
     that:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -5,6 +5,21 @@
 - name: "Update VM guest info after installing VMware Tools"
   include_tasks: ../../common/vm_get_guest_info.yml
 
+# Check user logon
+- name: "Query user in guest OS"
+  ansible.windows.win_shell: "query user {{ vm_username }}"
+  register: query_user_result
+  ignore_errors: true
+  delegate_to: "{{ vm_guest_ip }}"
+  ignore_unreachable: true
+  retries: 5
+  delay: 3
+  until:
+    - query_user_result.stdout_lines is defined
+    - query_user_result.stdout_lines | length != 0
+- name: "Display query user result"
+  ansible.builtin.debug: var=query_user_result
+
 # Get VMware Tools version
 - name: "Get VMware Tools version and build number"
   include_tasks: ../utils/win_get_vmtools_version_build.yml

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -56,16 +56,9 @@
     win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
 
 - name: "Get usernames of VMware Tools processes in guest OS"
-  include_tasks:
-    file: ../utils/win_execute_cmd.yml
-    apply:
-      when: >
-        (win_powershell_cmd_output.stdout_lines is undefined) or
-        (win_powershell_cmd_output.stdout_lines | length != 2) or
-        (win_powershell_cmd_output.stdout_lines | sort != win_vmtoolsd_username_list | sort)
+  include_tasks: ../utils/win_execute_cmd.yml
   vars:
     win_powershell_cmd: "(Get-Process vmtoolsd -IncludeUserName).UserName"
-  with_list: "{{ range(1, 11) | list }}"
 
 - name: "Check usernames of VMware Tools processes"
   ansible.builtin.assert:

--- a/windows/wintools_complete_install_verify/verify_vmtools.yml
+++ b/windows/wintools_complete_install_verify/verify_vmtools.yml
@@ -1,60 +1,33 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+- name: "Set fact of expected VMware Tools services and process usernames list"
+  ansible.builtin.set_fact:
+    win_tools_services: ['VGAuthService', 'VMTools', 'vmvss']
+    win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
+
 # Refresh VM guest info
 - name: "Update VM guest info after installing VMware Tools"
   include_tasks: ../../common/vm_get_guest_info.yml
-
-# Check user logon
-- name: "Query user in guest OS"
-  ansible.windows.win_shell: "query user {{ vm_username }}"
-  register: query_user_result
-  ignore_errors: true
-  delegate_to: "{{ vm_guest_ip }}"
-  ignore_unreachable: true
-  retries: 5
-  delay: 3
-  until:
-    - query_user_result.stdout_lines is defined
-    - query_user_result.stdout_lines | length != 0
-- name: "Display query user result"
-  ansible.builtin.debug: var=query_user_result
 
 # Get VMware Tools version
 - name: "Get VMware Tools version and build number"
   include_tasks: ../utils/win_get_vmtools_version_build.yml
 
-# Get VMware Tools services
-- name: "Set fact of VMware Tools services list"
-  ansible.builtin.set_fact:
-    win_tools_services: ['VGAuthService', 'VMTools', 'vmvss']
-
-- name: "Get 'VMTools' service status"
-  include_tasks: ../utils/win_get_service_status.yml
-  vars:
-    win_service_name: "VMTools"
-
-- name: "Verify 'VMTools' service status is running"
-  ansible.builtin.assert:
-    that:
-      - service_status == "Running"
-    fail_msg: "VMTools service status: {{ service_status }}, which is not 'Running'."
-    success_msg: "VMTools service status is 'Running'."
-
 - name: "Get VMware Tools services list"
   include_tasks: ../utils/win_get_vmtools_service_list.yml
-
-# Not all services are running, e.g., vmvss
-- name: "Display VMware Tools services status"
-  ansible.builtin.debug:
-    msg: "Service '{{ item.key }}' status is: {{ item.value }}"
-  with_dict: "{{ vmtools_service_dict }}"
+  vars:
+    win_get_vmtools_service_retries: 6
+    win_get_vmtools_service_expect: "{{ win_tools_services }}"
 
 - name: "Check VMware Tools services"
   ansible.builtin.assert:
     that:
       - win_tools_services_missing == []
-    fail_msg: "Check VMware Tools services '{{ win_tools_services }}' in guest OS, not find services '{{ win_tools_services_missing }}' after VMware Tools install."
+      - vmtools_service_dict['VMTools'] == "Running"
+    fail_msg: >
+      Services '{{ win_tools_services_missing }}' are not found, or 'VMTools' service
+      is not 'Running': {{ vmtools_service_dict['VMTools'] }} after VMware Tools install.
   vars:
     win_tools_services_missing: "{{ win_tools_services | difference(vmtools_service_dict.keys() | default([])) }}"
   when:
@@ -64,11 +37,6 @@
 # Get VMware drivers
 - name: "Get VMware drivers list"
   include_tasks: ../utils/win_get_vmtools_driver_list.yml
-
-# Get VMware Tools processes
-- name: "Set fact of expected usernames of VMware Tools processes"
-  ansible.builtin.set_fact:
-    win_vmtoolsd_username_list: ["NT AUTHORITY\\SYSTEM", "{{ guest_os_hostname }}\\{{ vm_username }}"]
 
 - name: "Get usernames of VMware Tools processes in guest OS"
   include_tasks: ../utils/win_execute_cmd.yml

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -89,3 +89,13 @@
           include_tasks: ../../common/test_rescue.yml
           vars:
             exit_testing_when_fail: true
+      always:
+        - name: "Get VMware Tools install log file path"
+          include_tasks: ../utils/win_get_path.yml
+          vars:
+            win_get_path_specified: '$env:temp\vminst.log'
+        - name: "Fetch VMware Tools install log file"
+          include_tasks: ../utils/win_get_file.yml
+          vars:
+            win_get_file_src_path: "{{ win_get_path_absolute }}"
+            win_get_file_dst_path: "{{ current_test_log_folder }}"

--- a/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
+++ b/windows/wintools_complete_install_verify/wintools_complete_install_verify.yml
@@ -94,8 +94,13 @@
           include_tasks: ../utils/win_get_path.yml
           vars:
             win_get_path_specified: '$env:temp\vminst.log'
+        - name: "Check if VMware Tools install log file exists"
+          include_tasks: ../utils/win_check_file_exist.yml
+          vars:
+            win_check_file_exist_file: "{{ win_get_path_absolute }}"
         - name: "Fetch VMware Tools install log file"
           include_tasks: ../utils/win_get_file.yml
           vars:
             win_get_file_src_path: "{{ win_get_path_absolute }}"
             win_get_file_dst_path: "{{ current_test_log_folder }}"
+          when: win_check_file_exist_result

--- a/windows/wsl_distro_install_uninstall/wsl_test_prepare.yml
+++ b/windows/wsl_distro_install_uninstall/wsl_test_prepare.yml
@@ -5,13 +5,9 @@
   ansible.builtin.set_fact:
     vm_nested_virt_status: false
     vm_has_restarted: false
-    win_uac_reg: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system"
 
-# Disable the User Account Control(UAC), need restart the OS.
 - name: "Disable UAC"
-  include_tasks: ../utils/win_execute_cmd.yml
-  vars:
-    win_powershell_cmd: "New-ItemProperty -Path {{ win_uac_reg }} -Name EnableLUA -PropertyType DWord -Value 0 -Force"
+  include_tasks: ../utils/win_disable_uac.yml
 
 # Get CPU Hardware virtualization status
 - name: "Get VM Hardware virtualization status"


### PR DESCRIPTION
1. Add retry getting VMware Tools services after VMware Tools install to try to get all the expected services. 
2. Add a utility tasks 'win_disable_usc.yml', and execute that in test setup stage.