### PR TITLE
[Linux] Add config option 'without-x' for installing open-vm-tools from source on Ubuntu 24.04

### DIFF
--- a/linux/open_vm_tools/install_ovt_from_source.yml
+++ b/linux/open_vm_tools/install_ovt_from_source.yml
@@ -11,14 +11,11 @@
     ovt_check_config_file_tmpl: "{{ guest_os_ansible_system }}_ovt_check_config.tmpl"
     ovt_check_config_file_path: "{{ current_test_log_folder }}/ovt_check_config.yml"
 
-- name: "Create config files for installing open-vm-tools from source"
+- name: "Create build config file for installing open-vm-tools from source"
   ansible.builtin.template:
-    src: "templates/{{ item[0] }}"
-    dest: "{{ item[1] }}"
+    src: "templates/{{ ovt_build_config_file_tmpl }}"
+    dest: "{{ ovt_build_config_file_path }}"
     mode: "0755"
-  with_list:
-    - ["{{ ovt_build_config_file_tmpl }}", "{{ ovt_build_config_file_path }}"]
-    - ["{{ ovt_check_config_file_tmpl }}", "{{ ovt_check_config_file_path }}"]
 
 - name: "Set facts of dependencies and configure options to install open-vm-tools from source"
   ansible.builtin.set_fact:
@@ -121,6 +118,12 @@
   until: ovt_install_job_result.finished
   retries: 60
   delay: 10
+
+- name: "Create check config file after installing open-vm-tools from source"
+  ansible.builtin.template:
+    src: "templates/{{ ovt_check_config_file_tmpl }}"
+    dest: "{{ ovt_check_config_file_path }}"
+    mode: "0755"
 
 - name: "Set facts of open-vm-tools files and plugins should be installed from source"
   ansible.builtin.set_fact:

--- a/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
@@ -66,4 +66,7 @@ dependencies:
   - xmlsec1-openssl-devel
   - xorg-x11-devel
 {% endif %}
-configure_options: []
+{% if guest_os_ansible_distribution == 'Ubuntu' and guest_os_ansible_distribution_ver == '24.04' %}
+configure_options:
+  - "--without-x"
+{% endif %}

--- a/linux/open_vm_tools/templates/linux_ovt_check_config.tmpl
+++ b/linux/open_vm_tools/templates/linux_ovt_check_config.tmpl
@@ -7,11 +7,13 @@ binaries:
   - "{{ ovt_install_prefix }}/bin/vmware-rpctool"
   - "{{ ovt_install_prefix }}/bin/vmware-toolbox-cmd"
   - "{{ ovt_install_prefix }}/bin/vmware-xferlogs"
-  - "{{ ovt_install_prefix }}/bin/vmware-user-suid-wrapper"
   - "{{ ovt_install_prefix }}/bin/VGAuthService"
   - "{{ ovt_install_prefix }}/bin/vmware-vgauth-smoketest"
   - "{{ ovt_install_prefix }}/bin/vmware-vgauth-cmd"
   - "{{ ovt_install_prefix }}/bin/vmware-alias-import"
+{% if (ovt_configure_options | select('match', '--without-x') | length) == 0 %}
+  - "{{ ovt_install_prefix }}/bin/vmware-user-suid-wrapper"
+{% endif %}
 scripts:
   - "/etc/vmware-tools/poweroff-vm-default"
   - "/etc/vmware-tools/poweron-vm-default"
@@ -79,12 +81,14 @@ plugins:
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libgdp.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libpowerOps.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libvmbackup.so"
-    - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libresolutionKMS.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libguestStore.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libguestInfo.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libcomponentMgr.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libdeployPkgPlugin.so"
+{% if (ovt_configure_options | select('match', '--without-x') | length) == 0 %}
+    - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc/libresolutionKMS.so"
 vmusr_plugins:
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmusr/libdesktopEvents.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmusr/libdndcp.so"
     - "{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmusr/libresolutionSet.so"
+{% endif %}

--- a/linux/utils/get_cloudinit_version.yml
+++ b/linux/utils/get_cloudinit_version.yml
@@ -5,23 +5,32 @@
 #
 - name: "Initialize the fact of cloud-init version"
   ansible.builtin.set_fact:
+    cloudinit_bin_path: "/usr/bin/cloud-init"
     cloudinit_version: ""
 
-# Some OS might print cloud-init version to stderr
-- name: "Get cloud-init version from package info"
-  ansible.builtin.shell: "/usr/bin/cloud-init --version 2>&1 | awk '{print $2}'"
-  delegate_to: "{{ vm_guest_ip }}"
-  ignore_errors: true
-  register: get_cloudinit_version
+- name: "Check {{ cloudinit_bin_path }} exists"
+  include_tasks: get_file_stat_info.yml
+  vars:
+    guest_file_path: "{{ cloudinit_bin_path }}"
 
-- name: "Set fact of cloud-init version"
-  ansible.builtin.set_fact:
-    cloudinit_version: "{{ get_cloudinit_version.stdout }}"
-  when:
-    - get_cloudinit_version.rc is defined
-    - get_cloudinit_version.rc == 0
-    - get_cloudinit_version.stdout is defined
-    - get_cloudinit_version.stdout
+- name: "Get cloud-init version"
+  when: guest_file_exists
+  block:
+    # Some OS might print cloud-init version to stderr
+    - name: "Get cloud-init version from package info"
+      ansible.builtin.shell: "{{ cloudinit_bin_path }} --version 2>&1"
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: true
+      register: get_cloudinit_version
+
+    - name: "Set fact of cloud-init version"
+      ansible.builtin.set_fact:
+        cloudinit_version: "{{ get_cloudinit_version.stdout | replace(cloudinit_bin_path, '') | trim }}"
+      when:
+        - get_cloudinit_version.rc is defined
+        - get_cloudinit_version.rc == 0
+        - get_cloudinit_version.stdout is defined
+        - get_cloudinit_version.stdout
 
 - name: "Print the cloud-init version"
   ansible.builtin.debug: var=cloudinit_version

--- a/linux/utils/get_os_edition.yml
+++ b/linux/utils/get_os_edition.yml
@@ -11,6 +11,7 @@
     guest_os_edition: ""
 
 - name: "Get Ubuntu edition"
+  when: guest_os_ansible_distribution == "Ubuntu"
   block:
     - name: "Get installed packages on {{ guest_os_ansible_distribution }}"
       include_tasks: get_installed_packages.yml
@@ -19,13 +20,13 @@
       ansible.builtin.set_fact:
         guest_os_edition: |-
           {%- if 'linux-image-virtual' in guest_installed_packages -%}CloudImage
-          {%- elif 'ubuntu-server' in guest_installed_packages -%}Server
-          {%- elif 'ubuntu-desktop' in guest_installed_packages -%}Desktop
-          {%- else -%}{%- endif -%}
+          {%- elif guest_installed_packages | select('search', 'ubuntu-server') | length > 0 -%}Server
+          {%- elif guest_installed_packages | select('search', 'ubuntu-desktop') | length > 0 -%}Desktop
+          {%- endif -%}
       when: guest_installed_packages | length > 0
-  when: guest_os_ansible_distribution == "Ubuntu"
 
 - name: "Get Pardus edition"
+  when: guest_os_ansible_distribution is match("Pardus.*")
   block:
     - name: "Get display manager on {{ guest_os_ansible_distribution }}"
       include_tasks: check_guest_os_gui.yml
@@ -38,7 +39,6 @@
           {%- elif guest_os_display_manager == 'gdm' -%}GNOME
           {%- else -%}Server
           {%- endif -%}
-  when: guest_os_ansible_distribution is match("Pardus.*")
 
 - name: "Get Fedora Edition"
   ansible.builtin.set_fact:


### PR DESCRIPTION
1. Ubuntu 24.04 has upgraded gtk and gtkmm version, which would led to MKS related function issue. This fix is to skip compiling about X plugins on Ubuntu 24.04. 
2. Ubuntu 24.04 desktop installed ubuntu-desktop-minimal not ubuntu-desktop. So I also updated the edition check by searching for packages like ubuntu-server or ubuntu-desktop.
3. When cloud-init is not installed, command `/usr/bin/cloud-init --version 2>&1` failed, but with the pipe ` | awk '{print $2}', its rc is 0. So this fix also checked the cloud-init binary exists or not before getting cloud-init version.

```
+--------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                           |
|                           | bitness='64'                                 |
|                           | distroAddlVersion='24.04 LTS (Noble Numbat)' |
|                           | distroName='Ubuntu'                          |
|                           | distroVersion='24.04'                        |
|                           | familyName='Linux'                           |
|                           | kernelVersion='6.8.0-40-generic'             |
|                           | prettyName='Ubuntu 24.04 LTS'                |
+--------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:19:08)
+--------------------------------------------------+
| ID | Name                   | Status | Exec Time |
+--------------------------------------------------+
|  1 | ovt_verify_src_install | Passed | 00:18:42  |
+--------------------------------------------------+
```

```
+-------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                          |
|                           | bitness='64'                                |
|                           | distroAddlVersion='12 (bookworm)'           |
|                           | distroName='Debian GNU/Linux'               |
|                           | distroVersion='12'                          |
|                           | familyName='Linux'                          |
|                           | kernelVersion='6.1.0-22-amd64'              |
|                           | prettyName='Debian GNU/Linux 12 (bookworm)' |
+-------------------------------------------------------------------------+


Test Results (Total: 3, Passed: 3, Elapsed Time: 01:29:43)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | deploy_vm_bios_ide_e1000e | Passed | 00:57:06  |
|  2 | check_inbox_driver        | Passed | 00:01:36  |
|  3 | ovt_verify_src_install    | Passed | 00:30:41  |
+-----------------------------------------------------+
```

```
+---------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                      |
|                           | bitness='64'                            |
|                           | cpeString='cpe:/o:opensuse:leap:15.6'   |
|                           | distroAddlVersion='15.6'                |
|                           | distroName='openSUSE Leap'              |
|                           | distroVersion='15.6'                    |
|                           | familyName='Linux'                      |
|                           | kernelVersion='6.4.0-150600.21-default' |
|                           | prettyName='openSUSE Leap 15.6'         |
+---------------------------------------------------------------------+


Test Results (Total: 3, Passed: 3, Elapsed Time: 01:01:33)
+-------------------------------------------------------------+
| ID | Name                              | Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:38:50  |
|  2 | check_inbox_driver                | Passed | 00:03:20  |
|  3 | ovt_verify_src_install            | Passed | 00:19:01  |
+-------------------------------------------------------------+

```