### PR TITLE
Fix VM datastore value when the datastore name has space

### DIFF
--- a/common/vm_get_vm_info.yml
+++ b/common/vm_get_vm_info.yml
@@ -18,7 +18,7 @@
     vm_files_path_ds: "{{ vm_config.config.files.logDirectory }}"
     vm_dir_name: "{{ vm_config.config.files.logDirectory.split(']')[-1].strip(' \\/') }}"
     vm_vmx_path: "{{ vm_config.config.files.vmPathName | regex_replace('\\[(.*)\\] ', '/vmfs/volumes/\\1/') }}"
-    datastore: "{{ vm_config.config.files.logDirectory.split(' ')[0].strip('['']') }}"
+    datastore: "{{ vm_config.config.files.logDirectory.split(']')[0].strip('[') }}"
     vm_guest_id: "{{ vm_config.config.guestId }}"
     vm_guest_os_version: "{{ vm_config.config.guestFullName }}"
     vm_hardware_version: "{{ vm_config.config.version }}"


### PR DESCRIPTION
When the datastore name has space like `datastore2 (1)`, the value of datastore set in `common/vm_get_vm_info.yml` remove the space and characters following it, like `datastore2`.
This fix is to correct VM's datastore value.

Datastore name has space
```
TASK [Display VM's basic information] ************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_get_vm_info.yml:28
ok: [localhost] => {
    "msg": [
        "VM datastore: datastore2 (1)",
        "VM files path: /vmfs/volumes/datastore2 (1)/LinuxMint-22-Xfce-EFI-Tools-HW20/",
        "VM files path: [datastore2 (1)] LinuxMint-22-Xfce-EFI-Tools-HW20/",
        "VM directory name: LinuxMint-22-Xfce-EFI-Tools-HW20",
        "VM vmx file path: /vmfs/volumes/datastore2 (1)/LinuxMint-22-Xfce-EFI-Tools-HW20/LinuxMint-22-Xfce-EFI-Tools-HW20.vmx",
        "VM guest ID: other6xLinux64Guest",
        "VM hardware version: vmx-20",
        "VM hardware version number: 20",
        "VM firmware: efi"
    ]
```

Datastore name has no space
```
TASK [Display VM's basic information] ************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/github/ansible-vsphere-gos-validation/common/vm_get_vm_info.yml:28
ok: [localhost] => {
    "msg": [
        "VM datastore: datastore3",
        "VM files path: /vmfs/volumes/datastore3/rhel-10-debug_cpu_latency/",
        "VM files path: [datastore3] rhel-10-debug_cpu_latency/",
        "VM directory name: rhel-10-debug_cpu_latency",
        "VM vmx file path: /vmfs/volumes/datastore3/rhel-10-debug_cpu_latency/rhel-10-debug_cpu_latency.vmx",
        "VM guest ID: rhel8_64Guest",
        "VM hardware version: vmx-22",
        "VM hardware version number: 22",
        "VM firmware: efi"
    ]
}
```