### PR TITLE
Fix unsupported parameters issue

### DIFF
--- a/common/esxi_check_delete_datastore_file.yml
+++ b/common/esxi_check_delete_datastore_file.yml
@@ -28,7 +28,7 @@
 - name: "Datastore file operation"
   community.vmware.vsphere_file:
     validate_certs: "{{ validate_certs | default(false) }}"
-    host: "{{ vsphere_host_name }}"
+    hostname: "{{ vsphere_host_name }}"
     username: "{{ vsphere_host_user }}"
     password: "{{ vsphere_host_user_password }}"
     datacenter: "{{ vsphere_host_datacenter }}"


### PR DESCRIPTION
```
2024-08-22 02:42:10,022 | Failed at Play [01_deploy_vm] ******************************

2024-08-22 02:42:10,022 | TASK [01_deploy_vm][Datastore file operation] **************
task path: /home/worker/workspace/Ansible_Windows_11_MAIN_NVME_E1000E_EFI_SecureBoot-15/ansible-vsphere-gos-validation/common/esxi_check_delete_datastore_file.yml:28
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "datacenter": "ansible_test",
            "datastore": "gosv-images",
            "host": "10.83.107.244",
            "hostname": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "OS/Other/Windows/Windows11/v24H2/26100.1150/Windows11_InsiderPreview_EnterpriseVL_x64_en-us_26100.1150.iso",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "state": "file",
            "timeout": 600,
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "msg": "Unsupported parameters for (community.vmware.vsphere_file) module: host. Supported parameters include: datacenter, datastore, hostname, password, path, port, proxy_host, proxy_port, state, timeout, username, validate_certs (admin, dest, pass, pwd, user)."
}
error message:
Unsupported parameters for (community.vmware.vsphere_file) module: host. Supported parameters include: datacenter, datastore, hostname, password, path, port, proxy_host, proxy_port, state, timeout, username, validate_certs (admin, dest, pass, pwd, user).
```