### PR TITLE
[Windows] set fixed mount point for older OS versions in test case windows_update_install

### DIFF
--- a/windows/windows_update_install/prepare_msu_file.yml
+++ b/windows/windows_update_install/prepare_msu_file.yml
@@ -22,12 +22,13 @@
     msu_file_path: ""
     msu_nfs_path_list: []
 
-# For OS older than 17763 (Windows 1809 or Windows Server 2019), it has very high frequency of timeout for the command.
 - name: "Get unused driver letter"
   include_tasks: ../utils/win_get_unused_drive_letter.yml
   when: guest_os_build_num | int >= 17763
 
-- name: "Set the new driver letter for older OS"
+# For OS older than 17763 (Windows 1809 or Windows Server 2019), it has very high frequency of timeout
+# for executing command to get unused driver letter. Hence here specify one for them.
+- name: "Set the new driver letter for guest OS build number older than 17763"
   ansible.builtin.set_fact:
     drive_letter_new: "T"
   when: guest_os_build_num | int < 17763

--- a/windows/windows_update_install/prepare_msu_file.yml
+++ b/windows/windows_update_install/prepare_msu_file.yml
@@ -21,10 +21,16 @@
     msu_file_basename: ""
     msu_file_path: ""
     msu_nfs_path_list: []
-    drive_letter_new: "T"
 
-#- name: "Get unused driver letter"
-#  include_tasks: ../utils/win_get_unused_drive_letter.yml
+# For OS older than 17763 (Windows 1809 or Windows Server 2019), it has very high frequency of timeout for the command.
+- name: "Get unused driver letter"
+  include_tasks: ../utils/win_get_unused_drive_letter.yml
+  when: guest_os_build_num | int >= 17763
+
+- name: "Set the new driver letter for older OS"
+  ansible.builtin.set_fact:
+    drive_letter_new: "T"
+  when: guest_os_build_num | int < 17763
 
 - name: "Set the facts of the .msu file source and destination directory"
   ansible.builtin.set_fact:

--- a/windows/windows_update_install/prepare_msu_file.yml
+++ b/windows/windows_update_install/prepare_msu_file.yml
@@ -21,9 +21,10 @@
     msu_file_basename: ""
     msu_file_path: ""
     msu_nfs_path_list: []
+    drive_letter_new: "T"
 
-- name: "Get unused driver letter"
-  include_tasks: ../utils/win_get_unused_drive_letter.yml
+#- name: "Get unused driver letter"
+#  include_tasks: ../utils/win_get_unused_drive_letter.yml
 
 - name: "Set the facts of the .msu file source and destination directory"
   ansible.builtin.set_fact:

--- a/windows/windows_update_install/prepare_msu_file.yml
+++ b/windows/windows_update_install/prepare_msu_file.yml
@@ -26,9 +26,9 @@
   include_tasks: ../utils/win_get_unused_drive_letter.yml
   when: guest_os_build_num | int >= 17763
 
-# For OS older than 17763 (Windows 1809 or Windows Server 2019), it has very high frequency of timeout
-# for executing command to get unused driver letter. Hence here specify one for them.
-- name: "Set the new driver letter for guest OS build number older than 17763"
+# For OS build number older than 17763 (Windows 10 v1809 or Windows Server 2019), it has very high frequency of timeout
+# for executing command to get unused drive letter. Hence here specify one for them.
+- name: "Set the new drive letter for guest OS build number older than 17763"
   ansible.builtin.set_fact:
     drive_letter_new: "T"
   when: guest_os_build_num | int < 17763


### PR DESCRIPTION
 For OS older than 17763 (Windows 1809 or Windows Server 2019), it has very high frequency of timeout for the command.
Hence for these older OS, hard code the drive letter to mount the shared folder. 
