### PR TITLE
[Windows] fix the undefined error when checking the failure_msg for windows online update installation

### DIFF
--- a/windows/utils/win_install_online_updates.yml
+++ b/windows/utils/win_install_online_updates.yml
@@ -95,7 +95,7 @@
 
         - name: "Set fact of failure messages of not installed updates"
           ansible.builtin.set_fact:
-            win_updates_failure_msgs: "{{ win_updates_not_installed | map(attribute='failure_msg') }}"
+            win_updates_failure_msgs: "{{ win_updates_not_installed | map(attribute='failure_msg') | select('defined') }}"
         - name: "Set fact of the lengths of failure messages and not installed updates lists"
           ansible.builtin.set_fact:
             win_updates_failure_msgs_len: "{{ win_updates_failure_msgs | length }}"


### PR DESCRIPTION
When installing the windows online updates, the returned result may not contain the attribute "failure_msg" for the not installed updates. 