### PR TITLE
[Linux] Update cloud-init services for version 24.3 or later

### DIFF
--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -27,6 +27,10 @@
 - name: "Update cloud-init configs"
   when: guest_cloud_cfg_exists | bool
   block:
+    - name: "Get cloud-init version"
+      include_tasks: get_cloudinit_version.yml
+      when: cloudinit_version is undefined or not cloudinit_version
+
     - name: "Set keyword for searching network config in cloud-init config files"
       ansible.builtin.set_fact:
         network_config_keyword: "network: *{config: *disabled}"
@@ -41,13 +45,24 @@
     - name: "Enable cloud-init GOSC for cloud-init workflow"
       when: enable_cloudinit_gosc
       block:
-        - name: "Set fact of cloud-init services"
+        - name: "Set fact of cloud-init services for version {{ cloudinit_version }}"
           ansible.builtin.set_fact:
             cloud_init_services:
               - cloud-init-local
               - cloud-init
               - cloud-config
               - cloud-final
+          when: cloudinit_version is version('24.3', '<')
+
+        - name: "Set fact of cloud-init services for version {{ cloudinit_version }}"
+          ansible.builtin.set_fact:
+            cloud_init_services:
+              - cloud-init-local
+              - cloud-init-network
+              - cloud-config
+              - cloud-final
+              - cloud-init-main
+          when: cloudinit_version is version('24.3', '>=')
 
         - name: "Stop cloud-init services"
           ansible.builtin.shell: "systemctl stop {{ service_name }}"


### PR DESCRIPTION
The cloud-init services are changed from version 24.3. Ubuntu 24.10 Beta has cloud-init 24.4, this fix is to resolve failed cloud-init GOSC testing on Ubuntu 24.10.