### PR TITLE
[Linux] Fix power_operation_scripts failures

### DIFF
--- a/linux/power_operation_scripts/power_operation_scripts.yml
+++ b/linux/power_operation_scripts/power_operation_scripts.yml
@@ -30,7 +30,7 @@
 
         - name: "Set fact of power operations"
           ansible.builtin.set_fact:
-            power_script_ops: ['shutdown']
+            power_script_ops: ['power', 'shutdown', 'suspend', 'resume']
 
         - name: "Get path of vmware-toolbox-cmd"
           include_tasks: ../utils/get_vmware_toolbox_cmd_path.yml

--- a/linux/power_operation_scripts/power_operation_scripts.yml
+++ b/linux/power_operation_scripts/power_operation_scripts.yml
@@ -30,7 +30,7 @@
 
         - name: "Set fact of power operations"
           ansible.builtin.set_fact:
-            power_script_ops: ['power', 'shutdown', 'suspend', 'resume']
+            power_script_ops: ['shutdown', 'resume']
 
         - name: "Get path of vmware-toolbox-cmd"
           include_tasks: ../utils/get_vmware_toolbox_cmd_path.yml

--- a/linux/power_operation_scripts/power_operation_scripts.yml
+++ b/linux/power_operation_scripts/power_operation_scripts.yml
@@ -30,7 +30,7 @@
 
         - name: "Set fact of power operations"
           ansible.builtin.set_fact:
-            power_script_ops: ['shutdown', 'resume']
+            power_script_ops: ['shutdown']
 
         - name: "Get path of vmware-toolbox-cmd"
           include_tasks: ../utils/get_vmware_toolbox_cmd_path.yml

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -89,7 +89,7 @@
     - power_script_type == "custom"
     - power_script_op != "suspend"
   block:
-    - name: "Get the status of file {{ script_tag_path }}"
+    - name: "Get the status of file {{ script_tag_path }} for {{ power_script_type }} {{ power_script_op }} "
       ansible.builtin.stat:
         path: "{{ script_tag_path }}"
       delegate_to: "{{ vm_guest_ip }}"
@@ -97,7 +97,7 @@
       until:
         - tag_path_exist_result.stat.exists is defined
         - tag_path_exist_result.stat.exists
-      retries: 20
+      retries: 100
       delay: 5
 
     - name: "Check the serching result"
@@ -111,7 +111,7 @@
 - name: "Check the log file"
   when: power_script_op != "suspend"
   block:
-    - name: "Search the log file"
+    - name: "Search the log file {{ script_file_path }}"
       ansible.builtin.shell: "grep {{ script_file_path }} /var/log/vmware-tools/*.log"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -112,7 +112,9 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.command: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
+      ansible.builtin.shell: "grep {{ script_file_path | basename }} *.log"
+      args:
+        chdir: "/var/log/vmware-tools"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str
       until:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -52,7 +52,7 @@
   ansible.builtin.pause:
     seconds: 10
 
-- name: "Shutdown and then Power on guest OS for {{ power_script_type }} {{ power_script_op }}"
+- name: "Shutdown and then power on guest OS for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['power', 'shutdown']
   block:
     - name: "Shutdown VM for {{ power_script_type }} {{ power_script_op }}"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -118,7 +118,7 @@
       until:
         - result_search_str.rc is defined
         - result_search_str.rc == 0
-      retries: 100
+      retries: 300
       delay: 5
       ignore_errors: true
 

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -78,9 +78,14 @@
 - name: "Update inventory"
   include_tasks: ../../common/update_inventory.yml
 
-- name: "Pause 20 seconds for the script to finish executing"
+- name: "Wait for VMware Tools running"
+  include_tasks: ../../common/vm_wait_vmtools_status.yml
+  vars:
+    vm_wait_vmtools_running: true
+
+- name: "Pause 15 seconds for the script to finish executing"
   ansible.builtin.pause:
-    seconds: 20
+    seconds: 15
 
 - name: "Check the script file running as expected"
   ansible.builtin.stat:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -112,7 +112,7 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file"
-      ansible.builtin.shell: "grep '{{ script_file_path }}' /var/log/vmware-tools/*.log"
+      ansible.builtin.shell: "grep {{ script_file_path }} /var/log/vmware-tools/*.log"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str
       until:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -48,7 +48,7 @@
     fail_msg: "Failed to find the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
 
-- name: "Pause 10 seconds to wait configure take affected"
+- name: "Pause 10 seconds to wait configure take effect"
   ansible.builtin.pause:
     seconds: 10
 
@@ -60,7 +60,7 @@
       vars:
         vm_power_state_set: "shutdown-guest"
 
-    - name: "Poweron VM for {{ power_script_type }} {{ power_script_op }}"
+    - name: "Power on VM for {{ power_script_type }} {{ power_script_op }}"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
@@ -81,11 +81,6 @@
 
 - name: "Update inventory"
   include_tasks: ../../common/update_inventory.yml
-
-- name: "Wait for VMware Tools running"
-  include_tasks: ../../common/vm_wait_vmtools_status.yml
-  vars:
-    vm_wait_vmtools_running: true
 
 - name: "Get content of file tools.conf after {{ power_script_type }} {{ power_script_op }}"
   ansible.builtin.command: "cat {{ vmtools_config_file }}"
@@ -109,7 +104,7 @@
       retries: 30
       delay: 5
 
-    - name: "Check the serching result"
+    - name: "Check the searching result"
       ansible.builtin.assert:
         that:
           - tag_path_exist_result.stat.exists is defined
@@ -121,7 +116,7 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.shell: "grep {{ script_file_path | basename }} *.log"
+      ansible.builtin.shell: "grep {{ script_file_path }} *.log"
       args:
         chdir: "/var/log/vmware-tools"
       delegate_to: "{{ vm_guest_ip }}"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -51,13 +51,18 @@
     fail_msg: "Failed to find the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
 
-- name: "Reboot guest OS for {{ power_script_type }} {{ power_script_op }}"
+- name: "Shutdown and then Poweron guest OS for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['power', 'shutdown']
   block:
-    - name: "Reboot VM for {{ power_script_type }} {{ power_script_op }}"
+    - name: "Shutdown VM for {{ power_script_type }} {{ power_script_op }}"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
-        vm_power_state_set: "reboot-guest"
+        vm_power_state_set: "shutdown-guest"
+
+    - name: "Poweron VM for {{ power_script_type }} {{ power_script_op }}"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: "powered-on"
 
 - name: "Suspend and resume VM for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['suspend', 'resume']

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -134,7 +134,7 @@
           - result_search_str.rc is defined
           - result_search_str.rc == 0
         fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
-        success_msg: "Successfully found the {{ script_file_path }} in {{ result_search_str.stdout }} for {{ power_script_type }} {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
 
 - name: "Cleanup current {{ power_script_op }} script configuration"
   ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} script {{ power_script_op }} disable"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -106,7 +106,7 @@
       until:
         - tag_path_exist_result.stat.exists is defined
         - tag_path_exist_result.stat.exists
-      retries: 300
+      retries: 30
       delay: 5
 
     - name: "Check the serching result"
@@ -121,15 +121,13 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.shell: "grep {{ script_file_path | basename }} *.log"
-      args:
-        chdir: "/var/log/vmware-tools"
+      ansible.builtin.command: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str
       until:
         - result_search_str.rc is defined
         - result_search_str.rc == 0
-      retries: 300
+      retries: 30
       delay: 5
       ignore_errors: true
 

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -49,7 +49,7 @@
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
 
 - name: "Shutdown and then power on guest OS"
-  when: power_script_op in ['power', 'shutdown']
+  when: power_script_op in ['power']
   block:
     - name: "Shutdown VM"
       include_tasks: ../../common/vm_set_power_state.yml
@@ -60,6 +60,14 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
+
+- name: "Reboot guest OS"
+  when: power_script_op in ['shutdown']
+  block:
+    - name: "Shutdown VM"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: "reboot-guest"
 
 - name: "Suspend and resume VM"
   when: power_script_op in ['suspend', 'resume']

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -112,7 +112,7 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.shell: "grep {{ script_file_path }} /var/log/vmware-tools/*.log"
+      ansible.builtin.command: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str
       until:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -64,7 +64,7 @@
 - name: "Reboot guest OS"
   when: power_script_op in ['shutdown']
   block:
-    - name: "Shutdown VM"
+    - name: "Reboot VM"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "reboot-guest"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -49,7 +49,7 @@
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
 
 - name: "Shutdown and then power on guest OS"
-  when: power_script_op in ['power']
+  when: power_script_op in ['power', 'shutdown']
   block:
     - name: "Shutdown VM"
       include_tasks: ../../common/vm_set_power_state.yml
@@ -60,14 +60,6 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
-
-- name: "Reboot guest OS"
-  when: power_script_op in ['shutdown']
-  block:
-    - name: "Reboot VM"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: "reboot-guest"
 
 - name: "Suspend and resume VM"
   when: power_script_op in ['suspend', 'resume']

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -118,8 +118,8 @@
       until:
         - result_search_str.rc is defined
         - result_search_str.rc == 0
-      retries: 10
-      delay: 5
+      retries: 20
+      delay: 10
       ignore_errors: true
 
     - name: "Check the serching result"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -118,8 +118,8 @@
       until:
         - result_search_str.rc is defined
         - result_search_str.rc == 0
-      retries: 20
-      delay: 10
+      retries: 100
+      delay: 5
       ignore_errors: true
 
     - name: "Check the serching result"
@@ -128,7 +128,7 @@
           - result_search_str.rc is defined
           - result_search_str.rc == 0
         fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_op }}."
-        success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_file_path }} in {{ result_search_str.stdout }} for {{ power_script_op }}."
 
 - name: "Cleanup current {{ power_script_op }} script configuration"
   ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} script {{ power_script_op }} disable"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -97,7 +97,7 @@
       until:
         - tag_path_exist_result.stat.exists is defined
         - tag_path_exist_result.stat.exists
-      retries: 100
+      retries: 300
       delay: 5
 
     - name: "Check the serching result"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -121,7 +121,9 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.command: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
+      ansible.builtin.shell: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
+      args:
+        chdir: "/var/log/vmware-tools"
       delegate_to: "{{ vm_guest_ip }}"
       register: result_search_str
       until:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -75,6 +75,10 @@
         vm_power_state_set: "powered-on"
         force: true
 
+    - name: "Pause 10 seconds"
+      ansible.builtin.pause:
+        seconds: 10
+
 - name: "Update inventory"
   include_tasks: ../../common/update_inventory.yml
 

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -39,9 +39,6 @@
   register: tools_conf_content_result
   delegate_to: "{{ vm_guest_ip }}"
 
-- name: "Print content of file tools.conf"
-  ansible.builtin.debug: var=tools_conf_content_result
-
 - name: "Check the configuration is expected in tools.conf"
   ansible.builtin.assert:
     that:
@@ -50,6 +47,10 @@
       - tools_conf_content_result.stdout.find(script_file_in_conf_file) != -1
     fail_msg: "Failed to find the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
+
+- name: "Pause 10 seconds to wait configure take affected"
+  ansible.builtin.pause:
+    seconds: 10
 
 - name: "Shutdown and then Poweron guest OS for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['power', 'shutdown']
@@ -90,9 +91,6 @@
   ansible.builtin.command: "cat {{ vmtools_config_file }}"
   register: tools_conf_content_result
   delegate_to: "{{ vm_guest_ip }}"
-
-- name: "Print content of file tools.conf after {{ power_script_type }} {{ power_script_op }}"
-  ansible.builtin.debug: var=tools_conf_content_result
 
 - name: "Check the script file running as expected"
   when:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -52,7 +52,7 @@
   ansible.builtin.pause:
     seconds: 10
 
-- name: "Shutdown and then Poweron guest OS for {{ power_script_type }} {{ power_script_op }}"
+- name: "Shutdown and then Power on guest OS for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['power', 'shutdown']
   block:
     - name: "Shutdown VM for {{ power_script_type }} {{ power_script_op }}"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -105,8 +105,8 @@
         that:
           - tag_path_exist_result.stat.exists is defined
           - tag_path_exist_result.stat.exists
-        fail_msg: "Failed to find {{ script_tag_path }} for {{ power_script_op }}."
-        success_msg: "Successfully found the {{ script_tag_path }} for {{ power_script_op }}."
+        fail_msg: "Failed to find {{ script_tag_path }} for {{ power_script_type }} {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_tag_path }} for {{ power_script_type }} {{ power_script_op }}."
 
 - name: "Check the log file"
   when: power_script_op != "suspend"
@@ -127,8 +127,8 @@
         that:
           - result_search_str.rc is defined
           - result_search_str.rc == 0
-        fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_op }}."
-        success_msg: "Successfully found the {{ script_file_path }} in {{ result_search_str.stdout }} for {{ power_script_op }}."
+        fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_file_path }} in {{ result_search_str.stdout }} for {{ power_script_type }} {{ power_script_op }}."
 
 - name: "Cleanup current {{ power_script_op }} script configuration"
   ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} script {{ power_script_op }} disable"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -121,7 +121,7 @@
   when: power_script_op != "suspend"
   block:
     - name: "Search the log file {{ script_file_path }}"
-      ansible.builtin.shell: "grep {{ script_file_path | basename }} /var/log/vmware-tools/*.log"
+      ansible.builtin.shell: "grep {{ script_file_path | basename }} *.log"
       args:
         chdir: "/var/log/vmware-tools"
       delegate_to: "{{ vm_guest_ip }}"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -75,12 +75,12 @@
         vm_power_state_set: "powered-on"
         force: true
 
-    - name: "Pause 10 seconds"
-      ansible.builtin.pause:
-        seconds: 10
-
 - name: "Update inventory"
   include_tasks: ../../common/update_inventory.yml
+
+- name: "Pause 20 seconds for the script to finish executing"
+  ansible.builtin.pause:
+    seconds: 20
 
 - name: "Check the script file running as expected"
   ansible.builtin.stat:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -39,6 +39,9 @@
   register: tools_conf_content_result
   delegate_to: "{{ vm_guest_ip }}"
 
+- name: "Print content of file tools.conf"
+  ansible.builtin.debug: var=tools_conf_content_result
+
 - name: "Check the configuration is expected in tools.conf"
   ansible.builtin.assert:
     that:
@@ -48,28 +51,23 @@
     fail_msg: "Failed to find the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
     success_msg: "Successfully found the {{ script_file_in_conf_file }} in tool.conf for {{ power_script_op }} script."
 
-- name: "Shutdown and then power on guest OS"
+- name: "Reboot guest OS for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['power', 'shutdown']
   block:
-    - name: "Shutdown VM"
+    - name: "Reboot VM for {{ power_script_type }} {{ power_script_op }}"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
-        vm_power_state_set: "shutdown-guest"
+        vm_power_state_set: "reboot-guest"
 
-    - name: "Power on VM"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: "powered-on"
-
-- name: "Suspend and resume VM"
+- name: "Suspend and resume VM for {{ power_script_type }} {{ power_script_op }}"
   when: power_script_op in ['suspend', 'resume']
   block:
-    - name: "Suspend the VM"
+    - name: "Suspend the VM for {{ power_script_type }} {{ power_script_op }}"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'suspended'
 
-    - name: "Resume VM"
+    - name: "Resume VM for {{ power_script_type }} {{ power_script_op }}"
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
@@ -83,13 +81,21 @@
   vars:
     vm_wait_vmtools_running: true
 
+- name: "Get content of file tools.conf after {{ power_script_type }} {{ power_script_op }}"
+  ansible.builtin.command: "cat {{ vmtools_config_file }}"
+  register: tools_conf_content_result
+  delegate_to: "{{ vm_guest_ip }}"
+
+- name: "Print content of file tools.conf after {{ power_script_type }} {{ power_script_op }}"
+  ansible.builtin.debug: var=tools_conf_content_result
+
 - name: "Check the script file running as expected"
   when:
     - script_tag_path is defined and script_tag_path
     - power_script_type == "custom"
     - power_script_op != "suspend"
   block:
-    - name: "Get the status of file {{ script_tag_path }} for {{ power_script_type }} {{ power_script_op }} "
+    - name: "Get the status of file {{ script_tag_path }} for {{ power_script_type }} {{ power_script_op }}"
       ansible.builtin.stat:
         path: "{{ script_tag_path }}"
       delegate_to: "{{ vm_guest_ip }}"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -83,20 +83,30 @@
   vars:
     vm_wait_vmtools_running: true
 
-- name: "Pause 15 seconds for the script to finish executing"
-  ansible.builtin.pause:
-    seconds: 15
-
 - name: "Check the script file running as expected"
-  ansible.builtin.stat:
-    path: "{{ script_tag_path }}"
-  delegate_to: "{{ vm_guest_ip }}"
-  register: tag_path_exist_result
-  failed_when: tag_path_exist_result.stat.exists is undefined or not tag_path_exist_result.stat.exists
   when:
     - script_tag_path is defined and script_tag_path
     - power_script_type == "custom"
     - power_script_op != "suspend"
+  block:
+    - name: "Get the status of file {{ script_tag_path }}"
+      ansible.builtin.stat:
+        path: "{{ script_tag_path }}"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: tag_path_exist_result
+      until:
+        - tag_path_exist_result.stat.exists is defined
+        - tag_path_exist_result.stat.exists
+      retries: 20
+      delay: 5
+
+    - name: "Check the serching result"
+      ansible.builtin.assert:
+        that:
+          - tag_path_exist_result.stat.exists is defined
+          - tag_path_exist_result.stat.exists
+        fail_msg: "Failed to find {{ script_tag_path }} for {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_tag_path }} for {{ power_script_op }}."
 
 - name: "Check the log file"
   when: power_script_op != "suspend"
@@ -104,8 +114,13 @@
     - name: "Search the log file"
       ansible.builtin.shell: "grep '{{ script_file_path }}' /var/log/vmware-tools/*.log"
       delegate_to: "{{ vm_guest_ip }}"
-      ignore_errors: true
       register: result_search_str
+      until:
+        - result_search_str.rc is defined
+        - result_search_str.rc == 0
+      retries: 10
+      delay: 5
+      ignore_errors: true
 
     - name: "Check the serching result"
       ansible.builtin.assert:


### PR DESCRIPTION
Problem
-------------
power_operation_scripts hit intermittent failure for many guestOS such as Ubuntu and rhcos.



Root Cause:
-------------
Need to wait several seconds for wait configuration sync after modify etc/vmware-tools/tools.conf 



Test result:
Passed for Ubuntu 24.04 Live Server  and  Desktop, RHCOS.