### PR TITLE
[Windows] add workaround for disk enable UUID not exist known issue on ESXi 7.0.3

### DIFF
--- a/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
+++ b/windows/check_quiesce_snapshot/check_vmx_disk_enable_uuid.yml
@@ -1,39 +1,40 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Set fact of the disk enable UUID key
+- name: "Set fact of the disk enable UUID key value pair"
   ansible.builtin.set_fact:
     vm_advanced_settings:
       - key: "disk.EnableUUID"
         value: "TRUE"
 
-# Get VM vmx config
-- include_tasks: ../../common/vm_get_extra_config.yml
+- name: "Get VM vmx config"
+  include_tasks: ../../common/vm_get_extra_config.yml
 
 # Known issue on Windows Server 2022 guest ID on ESXi 7.0U3c build, fixed in ESXi 7.0U3d
-- block:
-    - name: "Known issue - ignore missing disk.EnableUUID = TRUE"
-      ansible.builtin.debug:
-        msg: "'disk.EnableUUID = TRUE' is not in VM vmx file, ignore this known issue on ESXi 7.0U3c with guestID '{{ vm_guest_id }}'."
-      tags:
-        - known_issue
-      when: not vm_advanced_settings[0].key in vm_extra_config
+- name: "Check if there is known issue on ESXi {{ esxi_version }}"
   when:
-    - esxi_version is defined and esxi_version
     - esxi_version is version('7.0.3', '=')
-    - esxi_build is defined and esxi_build
     - esxi_build == "19193900"
-    - vm_guest_id is defined and vm_guest_id
     - vm_guest_id == "windows2019srvNext_64Guest"
+  block:
+    - name: "Save the VM extra config"
+      ansible.builtin.set_fact:
+        vm_extra_config_before: "{{ vm_extra_config }}"
+    - name: "Handle known issue"
+      when: not vm_advanced_settings[0].key in vm_extra_config_before
+      block:
+        - name: "Known issue - config 'disk.EnableUUID' not exist"
+          ansible.builtin.debug:
+            msg: "Config 'disk.EnableUUID' is not in VM vmx file, this is the known issue on ESXi 7.0U3c with guestID '{{ vm_guest_id }}'."
+          tags:
+            - known_issue
+        - name: "Workaround for the known issue to setting VM extra config"
+          include_tasks: ../utils/win_set_vm_extra_config.yml
 
-- name: Check if get expected config in vmx
+- name: "Check if get expected config in vmx"
   ansible.builtin.assert:
     that:
       - vm_advanced_settings[0].key in vm_extra_config
       - vm_extra_config[vm_advanced_settings[0].key] | lower == vm_advanced_settings[0].value | lower
     fail_msg: "'disk.EnableUUID = TRUE' is not in VM vmx file."
     success_msg: "'disk.EnableUUID = TRUE' is in VM vmx file."
-  when: >
-    (esxi_version is undefined or not (esxi_version is version('7.0.3', '='))) or
-    (esxi_version is version('7.0.3', '=') and (esxi_build is undefined or esxi_build != "19193900")) or
-    (vm_guest_id is undefined or vm_guest_id != "windows2019srvNext_64Guest")

--- a/windows/utils/win_set_vm_extra_config.yml
+++ b/windows/utils/win_set_vm_extra_config.yml
@@ -1,0 +1,21 @@
+# Copyright 2024 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+- name: "Shutdown guest OS before setting VM extra config"
+  include_tasks: win_shutdown_restart.yml
+  vars:
+    set_win_power_state: "shutdown"
+
+- name: "Set VM extra config"
+  include_tasks: ../../common/vm_set_extra_config.yml
+
+- name: "Power on VM after setting VM extra config"
+  include_tasks: ../../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: 'powered-on'
+
+- name: "Update in-memory inventory after VM power on"
+  include_tasks: win_update_inventory.yml
+
+- name: "Get VM extra config after setting"
+  include_tasks: ../../common/vm_get_extra_config.yml

--- a/windows/vhba_hot_add_remove/enable_vm_nvme_spec13.yml
+++ b/windows/vhba_hot_add_remove/enable_vm_nvme_spec13.yml
@@ -7,25 +7,8 @@
       - key: "nvme.specVersion"
         value: "103"
 
-# Shutdown guest OS
-- include_tasks: ../utils/win_shutdown_restart.yml
-  vars:
-    set_win_power_state: "shutdown"
-
-# Add extra config for VM
-- name: "Set 'nvme.specVersion' with '103' in VM's extra config"
-  include_tasks: ../../common/vm_set_extra_config.yml
-
-- name: "Power on VM"
-  include_tasks: ../../common/vm_set_power_state.yml
-  vars:
-    vm_power_state_set: 'powered-on'
-
-# After VM power on in above common task, get VM IP address again in case IP changed
-- include_tasks: ../utils/win_update_inventory.yml
-
-- name: "Get VM's extra config"
-  include_tasks: ../../common/vm_get_extra_config.yml
+- name: "Set VM extra config for enabling NVMe Spec 1.3"
+  include_tasks: ../utils/win_set_vm_extra_config.yml
 
 - name: "Check 'nvme.specVersion' is '103' in VM's extra config after VM power-on"
   ansible.builtin.assert:


### PR DESCRIPTION
"disk.EnableUUID = TRUE" config for Windows Server VM should exist in vmx for taking quiesce snapshot, this change add the workaround to add this config in vmx when hitting known issue. 