### PR TITLE
[Linux] Mount CDROM device with state=ephemeral for adding local DVD repo

### DIFF
--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -27,29 +27,28 @@
     guest_cdrom_mount_fact: ""
     guest_cdrom_mount_path: "/mnt/cdrom"
 
-# Eject all connected CDROMs
-- include_tasks: ../utils/eject_cdrom_in_guest.yml
+- name: "Eject all connected CDROM devices"
+  include_tasks: ../utils/eject_cdrom_in_guest.yml
 
-# Connect CD/DVD drive 1 to OS ISO
-- include_tasks: ../../common/vm_connect_cdrom_to_iso.yml
+- name: "Connect CD/DVD drive 1 to guest OS ISO image"
+  include_tasks: ../../common/vm_connect_cdrom_to_iso.yml
   vars:
     vm_cdrom_iso_file: "{{ os_installation_iso_list[0] }}"
 
-# Disable all existing repos
-- include_tasks: ../utils/disable_repo.yml
+- name: "Disable all existing repositories"
+  include_tasks: ../utils/disable_repo.yml
   when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', "openSUSE Leap"]
 
-# Get the fact of system devices
-- include_tasks: ../../common/get_system_info.yml
+- name: "Get the fact of system devices"
+  include_tasks: ../../common/get_system_info.yml
   vars:
     filter: "ansible_devices"
 
-- name: "Get the fact of all OS devices"
+- name: "Set the fact of all OS devices"
   ansible.builtin.set_fact:
     guest_os_ansible_devices: "{{ guest_system_info.ansible_devices }}"
   when: guest_system_info.ansible_devices is defined
 
-# Get the CDROM device which connecting to ISO image
 - name: "Check VM has CDROM device"
   ansible.builtin.assert:
     that:
@@ -57,58 +56,54 @@
     fail_msg: "VM {{ vm_name }} has no CDROM device"
     success_msg: "VM {{ vm_name }} has CDROM device"
 
-- name: "Get the CDROM device connecting to ISO image"
+- name: "Set the fact of CDROM device connecting to ISO image"
   ansible.builtin.set_fact:
     guest_cdrom_device_fact: "{{ guest_os_ansible_devices[guest_cdrom_device_name] }}"
 
 - name: "Print CDROM device fact"
   ansible.builtin.debug: var=guest_cdrom_device_fact
 
-# Get the fact of filesytem mounts
-- include_tasks: ../../common/get_system_info.yml
+- name: "Get all filesystem mount points in guest OS"
+  include_tasks: ../../common/get_system_info.yml
   vars:
     filter: "ansible_mounts"
 
-- name: "Get the fact about all OS mounts"
+- name: "Set the fact of all guest OS mount points"
   ansible.builtin.set_fact:
     guest_os_ansible_mounts: "{{ guest_system_info.ansible_mounts }}"
   when: guest_system_info.ansible_mounts is defined
 
-- name: "Get the fact of CDROM device mount"
+- name: "Set the fact of CDROM device mount points"
   ansible.builtin.set_fact:
     guest_cdrom_mount_fact: "{{ guest_os_ansible_mounts | selectattr('device', 'equalto', '/dev/' + guest_cdrom_device_name) }}"
 
 - name: "Print CDROM device mount fact"
   ansible.builtin.debug: var=guest_cdrom_mount_fact
 
-# Get the mount path if CDROM has been mounted
-# Unmount CDROM if it has already been mounted
 - name: "Umount CDROM device if it has been mounted"
   ansible.posix.mount:
     path: "{{ item.mount }}"
     state: absent
   delegate_to: "{{ vm_guest_ip }}"
-  become: true
   with_items: "{{ guest_cdrom_mount_fact }}"
   when: guest_cdrom_mount_fact | length >= 1
 
-# Mount CDROM to /mnt/cdrom
 - name: "Mount CDROM device to {{ guest_cdrom_mount_path }}"
   ansible.posix.mount:
     path: "{{ guest_cdrom_mount_path }}"
     src: "/dev/{{ guest_cdrom_device_name }}"
     fstype: iso9660
-    state: mounted
+    state: ephemeral
   register: guest_cdrom_mount_result
   become: true
   delegate_to: "{{ vm_guest_ip }}"
 
-- name: "Set repo name"
+- name: "Set the local DVD repository name"
   ansible.builtin.set_fact:
     dvd_repo_name: "{{ guest_os_ansible_distribution }}-{{ guest_os_ansible_distribution_ver }}-dvd"
 
-# Add repo from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux/openSUSE Leap
-- name: "Add repo from CDROM for {{ guest_os_ansible_distribution }}"
+# Add repository from CDROM for RHEL/SLES/SLED/Rocky/AlmaLinux/openSUSE Leap
+- name: "Add repositories from CDROM for {{ guest_os_ansible_distribution }}"
   when: guest_os_ansible_distribution in ['RedHat', 'SLES', 'SLED', 'Rocky', 'AlmaLinux', 'openSUSE Leap']
   block:
     # Find the dir having repodata
@@ -117,7 +112,7 @@
       register: find_repodata_result
       delegate_to: "{{ vm_guest_ip }}"
 
-    - name: "Check CDROM has repodata"
+    - name: "Check the CDROM device has repodata"
       ansible.builtin.assert:
         that:
           - find_repodata_result.stdout_lines is defined
@@ -125,7 +120,8 @@
         fail_msg: "Not found repodata under {{ guest_cdrom_mount_path }}"
         success_msg: "Found repodata: {{ ','.join(find_repodata_result.stdout_lines) }}"
 
-    - include_tasks: add_repo_from_baseurl.yml
+    - name: "Add package repositories from the CDROM device"
+      include_tasks: add_repo_from_baseurl.yml
       vars:
         repo_name: "{{ dvd_repo_name }}-{{ repodata_path | dirname | basename }}"
         repo_baseurl: "{{ repodata_path | dirname }}"


### PR DESCRIPTION
Ansible mount module will write an entry to /etc/fstab when state=mounted. See https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html

And when state=absent, the entry should be removed from /etc/fstsab, but it seems not working all the time. This fix is to change state=ephemeral for mounting CDROM, so that it won't write the mount entry to /etc/fstab. So that after a reboot, it will not break the system due to not finding the fstab entry device.