### PR TITLE
Update gdm setting for Fedora

### DIFF
--- a/autoinstall/Fedora/36/Workstation/ks.cfg
+++ b/autoinstall/Fedora/36/Workstation/ks.cfg
@@ -74,7 +74,10 @@ echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 # Enable autologin
 sed -i '/\[daemon\]/a AutomaticLogin={{ new_user }}' /etc/gdm/custom.conf
 sed -i '/\[daemon\]/a AutomaticLoginEnable=True' /etc/gdm/custom.conf
-sed -i 's/#WaylandEnable=false/WaylandEnable=false/'  /etc/gdm/custom.conf
+gnome_ver=`gnome-shell --version | grep -Po '[0-9]+(?=.)'`
+if [[ $gnome_ver =~ 4(4|5|6) ]]; then
+    sed -i 's/#WaylandEnable=false/WaylandEnable=false/'  /etc/gdm/custom.conf
+fi
 {% endif %}
 echo '{{ autoinstall_complete_msg }}' >/dev/ttyS0
 %end

--- a/autoinstall/Fedora/36/Workstation/ks.cfg
+++ b/autoinstall/Fedora/36/Workstation/ks.cfg
@@ -74,7 +74,7 @@ echo '{{ new_user }} ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/{{ new_user }}
 # Enable autologin
 sed -i '/\[daemon\]/a AutomaticLogin={{ new_user }}' /etc/gdm/custom.conf
 sed -i '/\[daemon\]/a AutomaticLoginEnable=True' /etc/gdm/custom.conf
-gnome_ver=`gnome-shell --version | grep -Po '[0-9]+(?=.)'`
+gnome_ver=`gnome-shell --version | grep -Po '[0-9]+' | head -1`
 if [[ $gnome_ver =~ 4(4|5|6) ]]; then
     sed -i 's/#WaylandEnable=false/WaylandEnable=false/'  /etc/gdm/custom.conf
 fi


### PR DESCRIPTION
- Update gdm setting for Fedora to resolve the issue of black screen after autoinstall: only Fedora 38, 39 and 40 need to start with the workaround WaylandEnable=false. Fedora 36, 37 and 41 can start with default setting.
- Internal testing passed for all these releases.