### PR TITLE
[Windows] change VMware Tools ISO path to VM folder on ESXi host

### DIFF
--- a/windows/wintools_complete_install_verify/detach_vmtools_and_remove.yml
+++ b/windows/wintools_complete_install_verify/detach_vmtools_and_remove.yml
@@ -18,5 +18,5 @@
     file_in_datastore_ops: "absent"
     file_in_datastore_failed_ignore: true
   when:
-    - win_vmtools_iso_name is defined
-    - win_vmtools_iso_name
+    - vmtools_iso_ds_path is defined
+    - vmtools_iso_ds_path

--- a/windows/wintools_complete_install_verify/detach_vmtools_and_remove.yml
+++ b/windows/wintools_complete_install_verify/detach_vmtools_and_remove.yml
@@ -1,8 +1,8 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Change CDROM type from iso to client
-- include_tasks: ../../common/vm_configure_cdrom.yml
+- name: "Change CDROM type from ISO to client"
+  include_tasks: ../../common/vm_configure_cdrom.yml
   vars:
     cdrom_type: 'client'
     cdrom_controller_type: "{{ vm_cdrom_controller_type }}"
@@ -10,11 +10,13 @@
     cdrom_unit_num: "{{ vm_cdrom_unit_num }}"
     cdrom_state: present
 
-# Delete downloaded VMware tools iso on ESXi datastore
-- include_tasks: ../../common/esxi_check_delete_datastore_file.yml
+- name: "Delete downloaded VMware Tools ISO file on ESXi host"
+  include_tasks: ../../common/esxi_check_delete_datastore_file.yml
   vars:
     file_in_datastore: "{{ datastore }}"
-    file_in_datastore_path: "{{ win_vmtools_iso_download }}"
+    file_in_datastore_path: "{{ vmtools_iso_ds_path }}"
     file_in_datastore_ops: "absent"
     file_in_datastore_failed_ignore: true
-  when: win_vmtools_iso_download is defined and win_vmtools_iso_download
+  when:
+    - win_vmtools_iso_name is defined
+    - win_vmtools_iso_name

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -1,18 +1,24 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Download VMware tools from specified URL and transfer to ESXi host datastore
-- name: Set fact of VMware tools ISO file name
+# Download VMware Tools from specified URL and transfer to ESXi host
+- name: "Set fact of VMware Tools ISO file name"
   ansible.builtin.set_fact:
-    win_vmtools_iso_download: "{{ vmtools_url_path.split('/')[-1] }}"
-- name: Set fact of the VMware tools ISO path on ESXi host datatore
-  ansible.builtin.set_fact:
-    vmtools_iso_path: "[{{ datastore }}] {{ win_vmtools_iso_download }}"
+    win_vmtools_iso_name: "{{ vmtools_url_path.split('/')[-1] }}"
 
-- name: Download VMware tools ISO file
+- name: "Set facts of VMware Tools ISO file paths"
+  ansible.builtin.set_fact:
+    vmtools_iso_local_path: "{{ local_cache }}/{{ win_vmtools_iso_name }}"
+    vmtools_iso_ds_path: "{{ vm_dir_name }}/{{ win_vmtools_iso_name }}"
+
+- name: "Set fact of VMware Tools ISO datatore path on ESXi host"
+  ansible.builtin.set_fact:
+    vmtools_iso_path: "[{{ datastore }}] {{ vmtools_iso_ds_path }}"
+
+- name: "Download VMware Tools ISO file to local"
   get_url:
     url: "{{ vmtools_url_path }}"
-    dest: "{{ local_cache }}/{{ win_vmtools_iso_download }}"
+    dest: "{{ vmtools_iso_local_path }}"
     validate_certs: false
     use_proxy: "{{ use_localhost_proxy | default(false) }}"
   environment:
@@ -20,12 +26,13 @@
     HTTP_PROXY: "{{ http_proxy_localhost | default(omit) }}"
     FTP_PROXY: "{{ http_proxy_localhost | default(omit) }}"
 
-# Copy downloaded VMware tools ISO file to ESXi host
-- include_tasks: ../../common/esxi_upload_datastore_file.yml
+- name: "Copy downloaded VMware Tools ISO file to ESXi host"
+  include_tasks: ../../common/esxi_upload_datastore_file.yml
   vars:
-    src_file_path: "{{ local_cache }}/{{ win_vmtools_iso_download }}"
-    dest_file_path: "{{ win_vmtools_iso_download }}"
+    src_file_path: "{{ vmtools_iso_local_path }}"
+    dest_file_path: "{{ vmtools_iso_ds_path }}"
     upload_file_timeout: 900
 
-- ansible.builtin.debug:
-    msg: "VMware tools ISO file is uploaded to ESXi host: {{ vmtools_iso_path }}"
+- name: "Print VMware Tools ISO file path"
+  ansible.builtin.debug:
+    msg: "VMware Tools ISO file path on ESXi host: {{ vmtools_iso_path }}"

--- a/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
+++ b/windows/wintools_complete_install_verify/download_vmtools_and_transfer.yml
@@ -16,7 +16,7 @@
     vmtools_iso_path: "[{{ datastore }}] {{ vmtools_iso_ds_path }}"
 
 - name: "Download VMware Tools ISO file to local"
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ vmtools_url_path }}"
     dest: "{{ vmtools_iso_local_path }}"
     validate_certs: false
@@ -26,7 +26,7 @@
     HTTP_PROXY: "{{ http_proxy_localhost | default(omit) }}"
     FTP_PROXY: "{{ http_proxy_localhost | default(omit) }}"
 
-- name: "Copy downloaded VMware Tools ISO file to ESXi host"
+- name: "Upload downloaded VMware Tools ISO file to ESXi host"
   include_tasks: ../../common/esxi_upload_datastore_file.yml
   vars:
     src_file_path: "{{ vmtools_iso_local_path }}"


### PR DESCRIPTION
To avoid VMware Tools ISO file operation failure in multiple test runs on the same datastore on the same ESXi host.
Change VMware Tools ISO file path on ESXi host to each VM's folder.

```
VM information:
+------------------------------------------------------------------------------------------+
| Name                      | Ansible_winsrv_vbs_80u3_intel                                |
+------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Microsoft Windows Server 2025 Datacenter 10.0.26100.0 64-bit |
+------------------------------------------------------------------------------------------+
| IP                        |                                              |
+------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-21                                                       |
+------------------------------------------------------------------------------------------+
| VMTools Version           | 12.5.0 (build-24276846)                                      |
+------------------------------------------------------------------------------------------+
| Config Guest Id           | windows2022srvNext_64Guest                                   |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | windows2022srvNext_64Guest                                   |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Microsoft Windows Server 2025 (64-bit)                       |
+------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | windowsGuest                                                 |
+------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                           |
|                           | bitness='64'                                                 |
|                           | buildNumber='26100'                                          |
|                           | distroName='Windows'                                         |
|                           | distroVersion='10.0'                                         |
|                           | familyName='Windows'                                         |
|                           | kernelVersion='26100.2033'                                   |
|                           | prettyName='Windows Server 2025, 64-bit (Build 26100.2033)'  |
+------------------------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:10:45)
+------------------------------------------------------------+
| ID | Name                             | Status | Exec Time |
+------------------------------------------------------------+
|  1 | wintools_complete_install_verify | Passed | 00:10:30  |
+------------------------------------------------------------+
```