### PR TITLE
[FreeBSD]power_operation_scripts failed on FreeBSD 13.x and 14.x with OVT installed from source

### DIFF
--- a/linux/open_vm_tools/add_enable_service.yml
+++ b/linux/open_vm_tools/add_enable_service.yml
@@ -71,7 +71,7 @@
           delegate_to: "{{ vm_guest_ip }}"
           ignore_errors: true
 
-        - name: "Update tools.conf path when install tools from source code"
+        - name: "Update tools.conf path to /etc/vmware-tools/tools.conf if exists"
           ansible.builtin.replace:
             path: "{{ service_file }}"
             regexp: '/usr/local/share/vmware-tools/tools.conf'

--- a/linux/open_vm_tools/add_enable_service.yml
+++ b/linux/open_vm_tools/add_enable_service.yml
@@ -56,30 +56,18 @@
         service_enabled: true
         service_state: "started"
 
-- name: "Enable FreeBSD service {{ service_name }}"
+- name: "Update tools.conf path and enable FreeBSD service {{ service_name }}"
   when:
     - guest_os_family == 'FreeBSD'
     - service_name == 'vmware-guestd'
   block:
-    - name: "Update tools.conf path for FreeBSD when tools is installed from source code"
+    - name: "Update tools.conf path to /etc/vmware-tools/tools.conf when tools is installed from source code"
+      ansible.builtin.replace:
+        path: "{{ service_file }}"
+        regexp: '/usr/local/share/vmware-tools/tools.conf'
+        replace: '/etc/vmware-tools/tools.conf'
+      delegate_to: "{{ vm_guest_ip }}"
       when: linux_ovt_install_type == 'source'
-      block:
-        - name: "Check file /etc/vmware-tools/tools.conf exists"
-          ansible.builtin.stat:
-            path: "/etc/vmware-tools/tools.conf"
-          register: tools_config_file_stat_result
-          delegate_to: "{{ vm_guest_ip }}"
-          ignore_errors: true
-
-        - name: "Update tools.conf path to /etc/vmware-tools/tools.conf if exists"
-          ansible.builtin.replace:
-            path: "{{ service_file }}"
-            regexp: '/usr/local/share/vmware-tools/tools.conf'
-            replace: '/etc/vmware-tools/tools.conf'
-          delegate_to: "{{ vm_guest_ip }}"
-          when:
-            - tools_config_file_stat_result.stat.exists is defined
-            - tools_config_file_stat_result.stat.exists
 
     - name: "Enable FreeBSD service {{ service_name }}"
       include_tasks: ../utils/replace_or_add_line_in_file.yml

--- a/linux/open_vm_tools/add_enable_service.yml
+++ b/linux/open_vm_tools/add_enable_service.yml
@@ -61,6 +61,26 @@
     - guest_os_family == 'FreeBSD'
     - service_name == 'vmware-guestd'
   block:
+    - name: "Update tools.conf file for FreeBSD when tools is installed from source code"
+      when: linux_ovt_install_type == 'source'
+      block:
+        - name: "Check file /etc/vmware-tools/tools.conf exists"
+          ansible.builtin.stat:
+            path: "/etc/vmware-tools/tools.conf"
+          register: tools_config_file_stat_result
+          delegate_to: "{{ vm_guest_ip }}"
+          ignore_errors: true
+
+        - name: "Update tools.conf path when install tools from source code"
+          ansible.builtin.replace:
+            path: "{{ service_file }}"
+            regexp: '/usr/local/share/vmware-tools/tools.conf'
+            replace: '/etc/vmware-tools/tools.conf'
+          delegate_to: "{{ vm_guest_ip }}"
+          when:
+            - tools_config_file_stat_result.stat.exists is defined
+            - tools_config_file_stat_result.stat.exists
+
     - name: "Enable FreeBSD service {{ service_name }}"
       include_tasks: ../utils/replace_or_add_line_in_file.yml
       vars:

--- a/linux/open_vm_tools/add_enable_service.yml
+++ b/linux/open_vm_tools/add_enable_service.yml
@@ -61,7 +61,7 @@
     - guest_os_family == 'FreeBSD'
     - service_name == 'vmware-guestd'
   block:
-    - name: "Update tools.conf file for FreeBSD when tools is installed from source code"
+    - name: "Update tools.conf path for FreeBSD when tools is installed from source code"
       when: linux_ovt_install_type == 'source'
       block:
         - name: "Check file /etc/vmware-tools/tools.conf exists"

--- a/linux/open_vm_tools/add_enable_service.yml
+++ b/linux/open_vm_tools/add_enable_service.yml
@@ -64,10 +64,12 @@
     - name: "Update tools.conf path to /etc/vmware-tools/tools.conf when tools is installed from source code"
       ansible.builtin.replace:
         path: "{{ service_file }}"
-        regexp: '/usr/local/share/vmware-tools/tools.conf'
-        replace: '/etc/vmware-tools/tools.conf'
+        regexp: '-c .*tools.conf'
+        replace: '-c /etc/vmware-tools/tools.conf'
       delegate_to: "{{ vm_guest_ip }}"
-      when: linux_ovt_install_type == 'source'
+      when:
+        - service_file_local_path is defined
+        - service_file_local_path
 
     - name: "Enable FreeBSD service {{ service_name }}"
       include_tasks: ../utils/replace_or_add_line_in_file.yml

--- a/linux/open_vm_tools/templates/vmware-guestd.tmpl
+++ b/linux/open_vm_tools/templates/vmware-guestd.tmpl
@@ -28,6 +28,6 @@ command="{{ ovt_install_prefix }}/bin/vmtoolsd"
 pidfile="/var/run/${name}.pid"
 start_precmd="${checkvm_cmd}"
 stop_precmd="${checkvm_cmd}"
-command_args="--background ${pidfile} -c {{ ovt_install_prefix }}/share/vmware-tools/tools.conf -p {{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc"
+command_args="--background ${pidfile} -c /etc/vmware-tools/tools.conf -p {{ ovt_install_prefix }}/lib/open-vm-tools/plugins/vmsvc"
 
 run_rc_command "$1"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -115,54 +115,26 @@
 - name: "Check the log file"
   when: power_script_op != "suspend"
   block:
-    - name: "Check the log file in {{ guest_os_ansible_distribution }}"
-      when: guest_os_ansible_distribution != 'FreeBSD'
-      block:
-        - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
-          ansible.builtin.shell: "grep {{ script_file_path }} *.log"
-          args:
-            chdir: "/var/log/vmware-tools"
-          delegate_to: "{{ vm_guest_ip }}"
-          register: result_search_str
-          until:
-            - result_search_str.rc is defined
-            - result_search_str.rc == 0
-          retries: 30
-          delay: 5
-          ignore_errors: true
+    - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
+      ansible.builtin.shell: "grep {{ script_file_path }} *.log"
+      args:
+        chdir: "/var/log/vmware-tools"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: result_search_str
+      until:
+        - result_search_str.rc is defined
+        - result_search_str.rc == 0
+      retries: 30
+      delay: 5
+      ignore_errors: true
 
-        - name: "Check the serching result"
-          ansible.builtin.assert:
-            that:
-              - result_search_str.rc is defined
-              - result_search_str.rc == 0
-            fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
-            success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
-   
-    - name: "Check the log file in {{ guest_os_ansible_distribution }}"
-      when: guest_os_ansible_distribution == 'FreeBSD'
-      block:
-        - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
-          ansible.builtin.shell: "grep {{ script_file_path }} *vmsvc*.log ./vmware-tools/*.log"
-          args:
-            chdir: "/var/log"
-          delegate_to: "{{ vm_guest_ip }}"
-          register: result_search_str
-          until:
-            - result_search_str.failed_when_result is defined
-            - not result_search_str.failed_when_result
-          retries: 30
-          delay: 5
-          ignore_errors: true
-          failed_when: result_search_str.stdout is undefined or result_search_str.stdout is not search(script_file_path)
-
-        - name: "Check the serching result"
-          ansible.builtin.assert:
-            that:
-              - result_search_str.failed_when_result is defined
-              - not result_search_str.failed_when_result
-            fail_msg: "Failed to find the {{ script_file_path }} in /var/log or /var/log/vmware-tools for {{ power_script_type }} {{ power_script_op }}."
-            success_msg: "Successfully found the {{ script_file_path }} in /var/log or /var/log/vmware-tools for {{ power_script_type }} {{ power_script_op }}."
+    - name: "Check the serching result"
+      ansible.builtin.assert:
+        that:
+          - result_search_str.rc is defined
+          - result_search_str.rc == 0
+        fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
+        success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
 
 - name: "Cleanup current {{ power_script_op }} script configuration"
   ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} script {{ power_script_op }} disable"

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -115,7 +115,7 @@
 - name: "Check the log file"
   when: power_script_op != "suspend"
   block:
-    - name: "Search the log file {{ script_file_path }}"
+    - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
       ansible.builtin.shell: "grep {{ script_file_path }} *.log"
       args:
         chdir: "/var/log/vmware-tools"
@@ -127,6 +127,22 @@
       retries: 30
       delay: 5
       ignore_errors: true
+      when: guest_os_ansible_distribution != 'FreeBSD'
+
+    - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
+      ansible.builtin.shell: "grep {{ script_file_path }} *vmsvc*.log ./vmware-tools/*.log"
+      args:
+        chdir: "/var/log"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: result_search_str
+      until:
+        - result_search_str.rc is defined
+        - result_search_str.rc == 0
+      retries: 30
+      delay: 5
+      ignore_errors: true
+      failed_when: result_search_str.stdout is undefined or result_search_str.stdout is not search(script_file_path)
+      when: guest_os_ansible_distribution == 'FreeBSD'
 
     - name: "Check the serching result"
       ansible.builtin.assert:

--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -115,42 +115,54 @@
 - name: "Check the log file"
   when: power_script_op != "suspend"
   block:
-    - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
-      ansible.builtin.shell: "grep {{ script_file_path }} *.log"
-      args:
-        chdir: "/var/log/vmware-tools"
-      delegate_to: "{{ vm_guest_ip }}"
-      register: result_search_str
-      until:
-        - result_search_str.rc is defined
-        - result_search_str.rc == 0
-      retries: 30
-      delay: 5
-      ignore_errors: true
+    - name: "Check the log file in {{ guest_os_ansible_distribution }}"
       when: guest_os_ansible_distribution != 'FreeBSD'
+      block:
+        - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
+          ansible.builtin.shell: "grep {{ script_file_path }} *.log"
+          args:
+            chdir: "/var/log/vmware-tools"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: result_search_str
+          until:
+            - result_search_str.rc is defined
+            - result_search_str.rc == 0
+          retries: 30
+          delay: 5
+          ignore_errors: true
 
-    - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
-      ansible.builtin.shell: "grep {{ script_file_path }} *vmsvc*.log ./vmware-tools/*.log"
-      args:
-        chdir: "/var/log"
-      delegate_to: "{{ vm_guest_ip }}"
-      register: result_search_str
-      until:
-        - result_search_str.rc is defined
-        - result_search_str.rc == 0
-      retries: 30
-      delay: 5
-      ignore_errors: true
-      failed_when: result_search_str.stdout is undefined or result_search_str.stdout is not search(script_file_path)
+        - name: "Check the serching result"
+          ansible.builtin.assert:
+            that:
+              - result_search_str.rc is defined
+              - result_search_str.rc == 0
+            fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
+            success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
+   
+    - name: "Check the log file in {{ guest_os_ansible_distribution }}"
       when: guest_os_ansible_distribution == 'FreeBSD'
+      block:
+        - name: "Search the log file {{ script_file_path }} in {{ guest_os_ansible_distribution }}"
+          ansible.builtin.shell: "grep {{ script_file_path }} *vmsvc*.log ./vmware-tools/*.log"
+          args:
+            chdir: "/var/log"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: result_search_str
+          until:
+            - result_search_str.failed_when_result is defined
+            - not result_search_str.failed_when_result
+          retries: 30
+          delay: 5
+          ignore_errors: true
+          failed_when: result_search_str.stdout is undefined or result_search_str.stdout is not search(script_file_path)
 
-    - name: "Check the serching result"
-      ansible.builtin.assert:
-        that:
-          - result_search_str.rc is defined
-          - result_search_str.rc == 0
-        fail_msg: "Failed to find the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
-        success_msg: "Successfully found the {{ script_file_path }} in {{ vmtools_vmsvc_log_file }} for {{ power_script_type }} {{ power_script_op }}."
+        - name: "Check the serching result"
+          ansible.builtin.assert:
+            that:
+              - result_search_str.failed_when_result is defined
+              - not result_search_str.failed_when_result
+            fail_msg: "Failed to find the {{ script_file_path }} in /var/log or /var/log/vmware-tools for {{ power_script_type }} {{ power_script_op }}."
+            success_msg: "Successfully found the {{ script_file_path }} in /var/log or /var/log/vmware-tools for {{ power_script_type }} {{ power_script_op }}."
 
 - name: "Cleanup current {{ power_script_op }} script configuration"
   ansible.builtin.command: "{{ vmware_toolbox_cmd_path }} script {{ power_script_op }} disable"

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -21,8 +21,8 @@
 - name: "Set fact of VMware Tools config file for FreeBSD"
   ansible.builtin.set_fact:
     vmtools_config_file: |-
-      {%- if vmtools_install_type is defined and vmtools_install_type == 'source' -%}/etc/vmware-tools/tools.conf
-      {%- else -%}/usr/local/share/vmware-tools/tools.conf
+      {%- if vmtools_install_type == 'package' -%}/usr/local/share/vmware-tools/tools.conf
+      {%- else -%}/etc/vmware-tools/tools.conf
       {%- endif -%}
   when: guest_os_ansible_distribution == 'FreeBSD'
 

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -11,23 +11,20 @@
     vmtools_log_dir: "/tmp/vmware-tools"
   when: vmtools_log_dir is undefined or not vmtools_log_dir
 
-# VMware Tools config file on Linux or FreeBSD with open-vm-tools eariler than 10.1.x
+# VMware Tools config file on Linux
 - name: "Set fact of VMware Tools config file for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:
     vmtools_config_file: "/etc/vmware-tools/tools.conf"
-  when: >-
-    guest_os_ansible_distribution != 'FreeBSD' or
-    vmtools_version is version('10.1.0', '<')
+  when: guest_os_ansible_distribution != 'FreeBSD'
 
-# VMware Tools config file on FreeBSD with open-vm-tools 10.1.x or later
+# VMware Tools config file on FreeBSD
 - name: "Set fact of VMware Tools config file for FreeBSD"
   ansible.builtin.set_fact:
     vmtools_config_file: |-
-      {%- if linux_ovt_install_type is defined and linux_ovt_install_type == 'source' -%}/etc/vmware-tools/tools.conf
+      {%- if vmtools_install_type is defined and vmtools_install_type == 'source' -%}/etc/vmware-tools/tools.conf
       {%- else -%}/usr/local/share/vmware-tools/tools.conf
       {%- endif -%}
-  when:
-    - guest_os_ansible_distribution == 'FreeBSD'
+  when: guest_os_ansible_distribution == 'FreeBSD'
 
 - name: "Set facts of VMware Tools log files"
   ansible.builtin.set_fact:

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -22,10 +22,13 @@
 # VMware Tools config file on FreeBSD with open-vm-tools 10.1.x or later
 - name: "Set fact of VMware Tools config file for FreeBSD"
   ansible.builtin.set_fact:
-    vmtools_config_file: "/usr/local/share/vmware-tools/tools.conf"
+    vmtools_config_file: |-
+      {%- if vmtools_version is version('12.5.0', '>=') -%}/etc/vmware-tools/tools.conf
+      {%- elif vmtools_version is version('10.1.0', '>=') -%}/usr/local/share/vmware-tools/tools.conf
+      {%- else -%}unknown
+      {%- endif -%}
   when:
     - guest_os_ansible_distribution == 'FreeBSD'
-    - vmtools_version is version('10.1.0', '>=')
 
 - name: "Set facts of VMware Tools log files"
   ansible.builtin.set_fact:

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -23,9 +23,8 @@
 - name: "Set fact of VMware Tools config file for FreeBSD"
   ansible.builtin.set_fact:
     vmtools_config_file: |-
-      {%- if vmtools_version is version('12.4.5', '>=') -%}/etc/vmware-tools/tools.conf
-      {%- elif vmtools_version is version('10.1.0', '>=') -%}/usr/local/share/vmware-tools/tools.conf
-      {%- else -%}unknown
+      {%- if linux_ovt_install_type is defined and linux_ovt_install_type == 'source' -%}/etc/vmware-tools/tools.conf
+      {%- else -%}/usr/local/share/vmware-tools/tools.conf
       {%- endif -%}
   when:
     - guest_os_ansible_distribution == 'FreeBSD'

--- a/linux/utils/enable_vmtools_logging.yml
+++ b/linux/utils/enable_vmtools_logging.yml
@@ -23,7 +23,7 @@
 - name: "Set fact of VMware Tools config file for FreeBSD"
   ansible.builtin.set_fact:
     vmtools_config_file: |-
-      {%- if vmtools_version is version('12.5.0', '>=') -%}/etc/vmware-tools/tools.conf
+      {%- if vmtools_version is version('12.4.5', '>=') -%}/etc/vmware-tools/tools.conf
       {%- elif vmtools_version is version('10.1.0', '>=') -%}/usr/local/share/vmware-tools/tools.conf
       {%- else -%}unknown
       {%- endif -%}


### PR DESCRIPTION
Problem:
power_operation_scripts failed on FreeBSD 13.x and 14.x with OVT installed from source


Resolution:
1. FreeBSD VM has OVT packages installed, and then it will uninstall original OVT packages and install with OVT from source. In such scenario, our case will firstly download the original vmtools service file before uninstalling the OVT packages, and then reuse them after OVT source install. Then the original vmtools file should be updated with /etc/vmware-tools/tools.conf before using it. You may update it at https://github.com/vmware/ansible-vsphere-gos-validation/blob/main/linux/open_vm_tools/add_enable_service.yml#L63

2. FreeBSD VM doesn't have OVT packages installed, and then it will install OVT from source. In such scenario, our case will create the vmtools service file from a template https://github.com/vmware/ansible-vsphere-gos-validation/blob/main/linux/open_vm_tools/templates/vmware-guestd.tmpl#L31. In such case, you can directly update this template file with /etc/vmware-tools/tools.conf



Test result:
Test passed with bundled tools & 12.5.0 tools from source build in FreeBSD 13
