### PR TITLE
[Plugin] Set test case to Blocked when env setup and installing tools failed

### DIFF
--- a/linux/open_vm_tools/pre_ovt_install.yml
+++ b/linux/open_vm_tools/pre_ovt_install.yml
@@ -50,17 +50,6 @@
     fail_msg: "The value of 'linux_ovt_install_type' must be 'package' or 'source'"
     success_msg: "The open-vm-tools install type is {{ linux_ovt_install_type }}"
 
-- name: "Block test case because of missing linux_ovt_tarball_url for open-vm-tools source install"
-  include_tasks: ../../common/skip_test_case.yml
-  vars:
-    skip_msg: >-
-      Skip test case {{ ansible_play_name }} because 'linux_ovt_tarball_url' is not set, which is
-      required when open-vm-tools install type is {{ linux_ovt_install_type }}.
-    skip_reason: "Blocked"
-  when:
-    - linux_ovt_install_type == 'source'
-    - linux_ovt_tarball_url is undefined or not linux_ovt_tarball_url
-
 - name: "Skip test case when open-vm-tools install type is not applicable"
   include_tasks: ../../common/skip_test_case.yml
   vars:
@@ -71,6 +60,17 @@
   when: >-
     (ansible_play_name == 'ovt_verify_pkg_install' and linux_ovt_install_type != 'package') or
     (ansible_play_name == 'ovt_verify_src_install' and linux_ovt_install_type != 'source')
+
+- name: "Block test case because of missing linux_ovt_tarball_url for open-vm-tools source install"
+  include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: >-
+      Skip test case {{ ansible_play_name }} because 'linux_ovt_tarball_url' is not set, which is
+      required when open-vm-tools install type is {{ linux_ovt_install_type }}.
+    skip_reason: "Blocked"
+  when:
+    - linux_ovt_install_type == 'source'
+    - linux_ovt_tarball_url is undefined or not linux_ovt_tarball_url
 
 # At present, only Debian, Ubuntu, Pardus and FreeBSD are supported to
 # install open-vm-tools from source.

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -734,8 +734,8 @@ class CallbackModule(CallbackBase):
             # Test cases are blocked by env_setup failure
             testcase_blocked = True
 
+        blocker_pattern = r'deploy_vm|ovt_verify_.*_install|wintools_complete_install_verify'
         for test_id in self.test_runs:
-            blocker_pattern = r'deploy_vm|ovt_verify_.*_install|wintools_complete_install_verify'
             if (self.test_runs[test_id].status in ['Failed', 'Blocked'] and
                 re.search(blocker_pattern, self.test_runs[test_id].name)):
                 testcase_blocked = True

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -11,9 +11,10 @@ import sys
 import importlib
 import shutil
 import logging
+import yaml
+import re
 from collections import OrderedDict
 from textwrap import TextWrapper
-import yaml
 from ansible import context
 from ansible import constants as C
 from ansible.playbook.task_include import TaskInclude
@@ -727,15 +728,21 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_VERBOSE)
             return
 
-        # Block test cases when deploy_vm failed
-        deploy_vm_failed = False
+        # Block test cases when deploy_vm or installing tools failed
+        testcase_blocked = False
+        if self._play_name == 'env_setup':
+            # Test cases are blocked by env_setup failure
+            testcase_blocked = True
+
         for test_id in self.test_runs:
-            if 'deploy_vm' in self.test_runs[test_id].name:
-                deploy_vm_failed = (self.test_runs[test_id].status == 'Failed')
+            blocker_pattern = r'deploy_vm|ovt_verify_.*_install|wintools_complete_install_verify'
+            if (self.test_runs[test_id].status in ['Failed', 'Blocked'] and
+                re.search(blocker_pattern, self.test_runs[test_id].name)):
+                testcase_blocked = True
                 continue
 
-            # For test cases after deploy_vm, set their status to 'Blocked'
-            if deploy_vm_failed:
+            # For test cases after blocker, set their status to 'Blocked'
+            if testcase_blocked and self.test_runs[test_id].status == 'No Run':
                 self.test_runs[test_id].status = 'Blocked'
 
 


### PR DESCRIPTION
If test failed at env_setup, deploy_vm, or installing tools, set the following test cases results to Blocked.

Failed at env_setup:
```
Test Results (Total: 32, Blocked: 32, Elapsed Time: 00:00:03)
+-------------------------------------------------------------------+
| ID | Name                                 |   Status  | Exec Time |
+-------------------------------------------------------------------+
| 01 | deploy_vm                            | * Blocked | 00:00:00  |
| 02 | ovt_verify_pkg_install               | * Blocked | 00:00:00  |
| 03 | ovt_verify_src_install               | * Blocked | 00:00:00  |
| 04 | ovt_verify_status                    | * Blocked | 00:00:00  |
| 05 | vgauth_check_service                 | * Blocked | 00:00:00  |
| 06 | host_verify_saml_token               | * Blocked | 00:00:00  |
| 07 | check_ip_address                     | * Blocked | 00:00:00  |
| 08 | check_os_fullname                    | * Blocked | 00:00:00  |
| 09 | stat_balloon                         | * Blocked | 00:00:00  |
| 10 | stat_hosttime                        | * Blocked | 00:00:00  |
| 11 | device_list                          | * Blocked | 00:00:00  |
| 12 | power_operation_scripts              | * Blocked | 00:00:00  |
| 13 | check_quiesce_snapshot_custom_script | * Blocked | 00:00:00  |
| 14 | memory_hot_add_basic                 | * Blocked | 00:00:00  |
| 15 | cpu_hot_add_basic                    | * Blocked | 00:00:00  |
| 16 | cpu_multicores_per_socket            | * Blocked | 00:00:00  |
| 17 | check_efi_firmware                   | * Blocked | 00:00:00  |
| 18 | secureboot_enable_disable            | * Blocked | 00:00:00  |
| 19 | e1000e_network_device_ops            | * Blocked | 00:00:00  |
| 20 | vmxnet3_network_device_ops           | * Blocked | 00:00:00  |
| 21 | pvrdma_network_device_ops            | * Blocked | 00:00:00  |
| 22 | gosc_perl_dhcp                       | * Blocked | 00:00:00  |
| 23 | gosc_perl_staticip                   | * Blocked | 00:00:00  |
| 24 | gosc_cloudinit_dhcp                  | * Blocked | 00:00:00  |
| 25 | gosc_cloudinit_staticip              | * Blocked | 00:00:00  |
| 26 | paravirtual_vhba_device_ops          | * Blocked | 00:00:00  |
| 27 | lsilogic_vhba_device_ops             | * Blocked | 00:00:00  |
| 28 | lsilogicsas_vhba_device_ops          | * Blocked | 00:00:00  |
| 29 | sata_vhba_device_ops                 | * Blocked | 00:00:00  |
| 30 | nvme_vhba_device_ops                 | * Blocked | 00:00:00  |
| 31 | nvdimm_cold_add_remove               | * Blocked | 00:00:00  |
| 32 | ovt_verify_pkg_uninstall             | * Blocked | 00:00:00  |
+-------------------------------------------------------------------+
```

ovt_verify_src_install is blocked due to missing required variable. 
```
Test Results (Total: 32, Blocked: 30, Skipped: 2, Elapsed Time: 00:02:14)
+-------------------------------------------------------------------+
| ID | Name                                 |   Status  | Exec Time |
+-------------------------------------------------------------------+
| 01 | deploy_vm                            | * Skipped | 00:00:00  |
| 02 | ovt_verify_pkg_install               | * Skipped | 00:01:00  |
| 03 | ovt_verify_src_install               | * Blocked | 00:00:48  |
| 04 | ovt_verify_status                    | * Blocked | 00:00:00  |
| 05 | vgauth_check_service                 | * Blocked | 00:00:00  |
| 06 | host_verify_saml_token               | * Blocked | 00:00:00  |
| 07 | check_ip_address                     | * Blocked | 00:00:00  |
| 08 | check_os_fullname                    | * Blocked | 00:00:00  |
| 09 | stat_balloon                         | * Blocked | 00:00:00  |
| 10 | stat_hosttime                        | * Blocked | 00:00:00  |
| 11 | device_list                          | * Blocked | 00:00:00  |
| 12 | power_operation_scripts              | * Blocked | 00:00:00  |
| 13 | check_quiesce_snapshot_custom_script | * Blocked | 00:00:00  |
| 14 | memory_hot_add_basic                 | * Blocked | 00:00:00  |
| 15 | cpu_hot_add_basic                    | * Blocked | 00:00:00  |
| 16 | cpu_multicores_per_socket            | * Blocked | 00:00:00  |
| 17 | check_efi_firmware                   | * Blocked | 00:00:00  |
| 18 | secureboot_enable_disable            | * Blocked | 00:00:00  |
| 19 | e1000e_network_device_ops            | * Blocked | 00:00:00  |
| 20 | vmxnet3_network_device_ops           | * Blocked | 00:00:00  |
| 21 | pvrdma_network_device_ops            | * Blocked | 00:00:00  |
| 22 | gosc_perl_dhcp                       | * Blocked | 00:00:00  |
| 23 | gosc_perl_staticip                   | * Blocked | 00:00:00  |
| 24 | gosc_cloudinit_dhcp                  | * Blocked | 00:00:00  |
| 25 | gosc_cloudinit_staticip              | * Blocked | 00:00:00  |
| 26 | paravirtual_vhba_device_ops          | * Blocked | 00:00:00  |
| 27 | lsilogic_vhba_device_ops             | * Blocked | 00:00:00  |
| 28 | lsilogicsas_vhba_device_ops          | * Blocked | 00:00:00  |
| 29 | sata_vhba_device_ops                 | * Blocked | 00:00:00  |
| 30 | nvme_vhba_device_ops                 | * Blocked | 00:00:00  |
| 31 | nvdimm_cold_add_remove               | * Blocked | 00:00:00  |
| 32 | ovt_verify_pkg_uninstall             | * Blocked | 00:00:00  |
+-------------------------------------------------------------------+
```

Failed at wintools_complete_install_verify
```
Test Results (Total: 35, Failed: 1, Blocked: 33, Skipped: 1, Elapsed Time: 00:00:39)
+---------------------------------------------------------------+
| ID | Name                             |   Status  | Exec Time |
+---------------------------------------------------------------+
| 01 | deploy_vm                        | * Skipped | 00:00:00  |
| 02 | wintools_complete_install_verify | * Failed  | 00:00:00  |
| 03 | windows_update_install           | * Blocked | 00:00:00  |
| 04 | guest_os_inplace_upgrade         | * Blocked | 00:00:00  |
| 05 | secureboot_enable_disable        | * Blocked | 00:00:00  |
| 06 | check_efi_firmware               | * Blocked | 00:00:00  |
| 07 | check_ip_address                 | * Blocked | 00:00:00  |
| 08 | check_os_fullname                | * Blocked | 00:00:00  |
| 09 | mouse_driver_vmtools             | * Blocked | 00:00:00  |
| 10 | vgauth_check_service             | * Blocked | 00:00:00  |
| 11 | host_verify_saml_token           | * Blocked | 00:00:00  |
| 12 | stat_balloon                     | * Blocked | 00:00:00  |
| 13 | stat_hosttime                    | * Blocked | 00:00:00  |
| 14 | power_operation_scripts          | * Blocked | 00:00:00  |
| 15 | paravirtual_vhba_device_ops      | * Blocked | 00:00:00  |
| 16 | lsilogicsas_vhba_device_ops      | * Blocked | 00:00:00  |
| 17 | sata_vhba_device_ops             | * Blocked | 00:00:00  |
| 18 | nvme_vhba_device_ops             | * Blocked | 00:00:00  |
| 19 | nvme_vhba_device_ops_spec13      | * Blocked | 00:00:00  |
| 20 | nvme_disk_hot_extend_spec13      | * Blocked | 00:00:00  |
| 21 | nvdimm_cold_add_remove           | * Blocked | 00:00:00  |
| 22 | e1000e_network_device_ops        | * Blocked | 00:00:00  |
| 23 | vmxnet3_network_device_ops       | * Blocked | 00:00:00  |
| 24 | memory_hot_add_basic             | * Blocked | 00:00:00  |
| 25 | check_quiesce_snapshot           | * Blocked | 00:00:00  |
| 26 | cpu_multicores_per_socket        | * Blocked | 00:00:00  |
| 27 | gosc_sanity_staticip             | * Blocked | 00:00:00  |
| 28 | gosc_sanity_dhcp                 | * Blocked | 00:00:00  |
| 29 | wsl_distro_install_uninstall     | * Blocked | 00:00:00  |
| 30 | vbs_enable_disable               | * Blocked | 00:00:00  |
| 31 | eflow_deploy                     | * Blocked | 00:00:00  |
| 32 | mdag_enable_disable              | * Blocked | 00:00:00  |
| 33 | vtpm_cold_add_remove             | * Blocked | 00:00:00  |
| 34 | wintools_uninstall_verify        | * Blocked | 00:00:00  |
| 35 | cpu_hot_add_basic                | * Blocked | 00:00:00  |
+---------------------------------------------------------------+
```