### PR TITLE
[Linux] Check python version to install python3-rpm package

### DIFF
--- a/common/get_guest_system_info.yml
+++ b/common/get_guest_system_info.yml
@@ -29,6 +29,7 @@
       - 'ansible_pkg_mgr'
       - 'ansible_system'
       - 'ansible_hostname'
+      - 'ansible_python_version'
 
 - name: "Set facts of guest OS system info"
   ansible.builtin.set_fact:
@@ -48,6 +49,7 @@
     guest_os_product_type: "{{ guest_system_info.ansible_os_product_type | default('') }}"
     guest_os_hostname: "{{ guest_system_info.ansible_hostname | default('') }}"
     guest_os_installation_type: "{{ guest_system_info.ansible_os_installation_type | default('') }}"
+    guest_os_python_version: "{{ guest_system_info.ansible_python_version | default('') }}"
 
 - name: "Update guest OS distribution facts for {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -26,7 +26,9 @@
   vars:
     package_list: ["python3-rpm"]
     package_state: "latest"
-  when: guest_os_ansible_pkg_mgr is search('yum|dnf')
+  when:
+    - guest_os_python_version is version('3.0.0', '>=')
+    - guest_os_ansible_pkg_mgr is search('yum|dnf')
 
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"


### PR DESCRIPTION
python3-rpm is required by guest OS with Python3 as default python interpreter. This fix added a checking about python version.

```
Testbed information:
+------------------------------------------------------------------------------------------+
| Product | Version | Build    | Hostname or IP | Server Model                             |
+------------------------------------------------------------------------------------------+
| vCenter | 7.0.3   | 22357613 |                |                                          |
+------------------------------------------------------------------------------------------+
| ESXi    | 7.0.3   | 22348816 |                | VMware, Inc. VMware20,1                  |
|         |         |          |                | Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz |
+------------------------------------------------------------------------------------------+

VM information:
+--------------------------------------------------------------------------------------+
| Name                      | test_rhel7                                               |
+--------------------------------------------------------------------------------------+
| Guest OS Distribution     | RedHat 7.9 x86_64                                        |
+--------------------------------------------------------------------------------------+
| GUI Installed             | True                                                     |
+--------------------------------------------------------------------------------------+
| CloudInit Version         |                                                          |
+--------------------------------------------------------------------------------------+
| Hardware Version          | vmx-19                                                   |
+--------------------------------------------------------------------------------------+
| VMTools Version           | 11.0.5 (build-15389592)                                  |
+--------------------------------------------------------------------------------------+
| Config Guest Id           | rhel7_64Guest                                            |
+--------------------------------------------------------------------------------------+
| Guest Short Name          |                                                          |
+--------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | rhel7_64Guest                                            |
+--------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Enterprise Linux 7 (64-bit)                      |
+--------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                               |
+--------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | bitness='64'                                             |
|                           | distroName='Red Hat Enterprise Linux Server'             |
|                           | distroVersion='7.9'                                      |
|                           | familyName='Linux'                                       |
|                           | kernelVersion='3.10.0-1160.el7.x86_64'                   |
|                           | prettyName='Red Hat Enterprise Linux Server 7.9 (Maipo)' |
+--------------------------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:01:52)
+---------------------------------------------+
| ID | Name              | Status | Exec Time |
+---------------------------------------------+
|  1 | check_os_fullname | Passed | 00:01:38  |
+---------------------------------------------+
```