### PR TITLE
[Linux] Get cloud-init services list by searching services fact

### DIFF
--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -27,10 +27,6 @@
 - name: "Update cloud-init configs"
   when: guest_cloud_cfg_exists | bool
   block:
-    - name: "Get cloud-init version"
-      include_tasks: get_cloudinit_version.yml
-      when: cloudinit_version is undefined or not cloudinit_version
-
     - name: "Set keyword for searching network config in cloud-init config files"
       ansible.builtin.set_fact:
         network_config_keyword: "network: *{config: *disabled}"
@@ -45,24 +41,14 @@
     - name: "Enable cloud-init GOSC for cloud-init workflow"
       when: enable_cloudinit_gosc
       block:
-        - name: "Set fact of cloud-init services for version {{ cloudinit_version }}"
-          ansible.builtin.set_fact:
-            cloud_init_services:
-              - cloud-init-local
-              - cloud-init
-              - cloud-config
-              - cloud-final
-          when: cloudinit_version is version('24.3', '<')
+        - name: "Get facts of all services"
+          ansible.builtin.service_facts:
+          register: service_facts_result
+          delegate_to: "{{ vm_guest_ip }}"
 
-        - name: "Set fact of cloud-init services for version {{ cloudinit_version }}"
+        - name: "Get all cloud-init services on {{ vm_guest_os_distribution }}"
           ansible.builtin.set_fact:
-            cloud_init_services:
-              - cloud-init-local
-              - cloud-init-network
-              - cloud-config
-              - cloud-final
-              - cloud-init-main
-          when: cloudinit_version is version('24.3', '>=')
+            cloud_init_services: "{{ service_facts_result.ansible_facts.services.keys() | select('match', 'cloud-.*.service') }}"
 
         - name: "Stop cloud-init services"
           ansible.builtin.shell: "systemctl stop {{ service_name }}"

--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -46,6 +46,13 @@
           register: service_facts_result
           delegate_to: "{{ vm_guest_ip }}"
 
+        - name: "Check guest OS services are retrieved"
+          ansible.builtin.assert:
+            that:
+              - service_facts_result.ansible_facts.services is defined
+              - service_facts_result.ansible_facts.services | length > 0
+            fail_msg: "Failed to get guest OS services"
+
         - name: "Get all cloud-init services on {{ vm_guest_os_distribution }}"
           ansible.builtin.set_fact:
             cloud_init_services: "{{ service_facts_result.ansible_facts.services.keys() | select('match', 'cloud-.*.service') }}"


### PR DESCRIPTION
cloud-init-network.service and cloud-init-main.service were not found on Photon OS and Ubuntu with cloud-init 24.3.1 installed. So getting cloud-init services list is not accurate by cloud-init version. This fix will directly search for cloud-init services in ansible distribution services fact.

```
TASK [Get all cloud-init services on Ubuntu 22.04 Desktop x86_64] ************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/linux/utils/enable_disable_cloudinit_cfg.yml:49
ok: [localhost] => {
    "ansible_facts": {
        "cloud_init_services": [
            "cloud-init-local.service",
            "cloud-config.service",
            "cloud-final.service",
            "cloud-init-hotplugd.service",
            "cloud-init.service"
        ]
    },
    "changed": false
}

....
VM information:
+-------------------------------------------------------------------------------+
| Name                      | test_vm                                           |
+-------------------------------------------------------------------------------+
| Guest OS Distribution     | Ubuntu 22.04 Desktop x86_64                       |
+-------------------------------------------------------------------------------+
| IP                        | 10.70.182.98                                      |
+-------------------------------------------------------------------------------+
| GUI Installed             | True                                              |
+-------------------------------------------------------------------------------+
| CloudInit Version         | 24.3.1-0ubuntu0~22.04.1                           |
+-------------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                            |
+-------------------------------------------------------------------------------+
| VMTools Version           | 13.0.0 (build-24383907)                           |
+-------------------------------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                                     |
+-------------------------------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                                     |
+-------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)                             |
+-------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                        |
+-------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                |
|                           | bitness='64'                                      |
|                           | distroAddlVersion='22.04.5 LTS (Jammy Jellyfish)' |
|                           | distroName='Ubuntu'                               |
|                           | distroVersion='22.04'                             |
|                           | familyName='Linux'                                |
|                           | kernelVersion='6.8.0-49-generic'                  |
|                           | prettyName='Ubuntu 22.04.5 LTS'                   |
+-------------------------------------------------------------------------------+

Test Results (Total: 2, Passed: 2, Elapsed Time: 00:10:28)
+---------------------------------------------------+
| ID | Name                    | Status | Exec Time |
+---------------------------------------------------+
|  1 | gosc_cloudinit_dhcp     | Passed | 00:04:42  |
|  2 | gosc_cloudinit_staticip | Passed | 00:04:57  |
+---------------------------------------------------+
```