### PR TITLE
[Windows] Enable timesync with ESXi host before verifying SAML token

### DIFF
--- a/windows/host_verify_saml_token/host_verify_saml_token.yml
+++ b/windows/host_verify_saml_token/host_verify_saml_token.yml
@@ -38,6 +38,11 @@
         - name: "Check VMware Tools capability exists for host verified SAML token"
           include_tasks: ../../common/vm_check_vmtools_capability.yml
 
+        - name: "Enable guest OS timesync with ESXi server"
+          include_tasks: ../utils/win_execute_cmd.yml
+          vars:
+            win_powershell_cmd: "& 'C:\\Program Files\\VMware\\VMware Tools\\VMwareToolboxCmd.exe' timesync enable"
+
         - name: "Initialize facts about domain user information"
           ansible.builtin.set_fact:
             vcenter_admin_user_name: "{{ vcenter_username.split('@')[0] }}"


### PR DESCRIPTION
The host_verify_saml_token failed due to expired saml token. This fix enabled timesync with ESXi host server in Windows guest OS.

```
VM information:
+-------------------------------------------------------------------------------------------+
| Name                      | test_vm                                                       |
+-------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Microsoft Windows 10 Enterprise 10.0.19045.0 64-bit           |
+-------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                                        |
+-------------------------------------------------------------------------------------------+
| VMTools Version           | 13.0.0 (build-24383907)                                       |
+-------------------------------------------------------------------------------------------+
| Config Guest Id           | windows9_64Guest                                              |
+-------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | windows9_64Guest                                              |
+-------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Microsoft Windows 10 (64-bit)                                 |
+-------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | windowsGuest                                                  |
+-------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                            |
|                           | bitness='64'                                                  |
|                           | buildNumber='19045'                                           |
|                           | distroName='Windows'                                          |
|                           | distroVersion='10.0'                                          |
|                           | familyName='Windows'                                          |
|                           | kernelVersion='19045.2006'                                    |
|                           | prettyName='Windows 10 Enterprise, 64-bit (Build 19045.2006)' |
+-------------------------------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:06:32)
+--------------------------------------------------+
| ID | Name                   | Status | Exec Time |
+--------------------------------------------------+
|  1 | host_verify_saml_token | Passed | 00:06:18  |
+--------------------------------------------------+
```