### PR TITLE
Enable guest IP hack with vmware_host_config_manager module

### DIFF
--- a/common/esxi_enable_guest_ip_hack.yml
+++ b/common/esxi_enable_guest_ip_hack.yml
@@ -11,12 +11,9 @@
       {{ esxi_advanced_system_settings['Net.GuestIPHack'] | default('') }}
 
 - name: "Enable guest IP hack on ESXi host"
+  include_tasks: esxi_set_advanced_system_settings.yml
+  vars:
+    esxi_host_config_options: {'Net.GuestIPHack': 1}
   when: >-
     esxi_advanced_system_settings['Net.GuestIPHack'] is undefined or
     esxi_advanced_system_settings['Net.GuestIPHack'] | string != "1"
-  block: 
-    # Enable guest IP hack on ESXi host
-    - name: "Enable GuestIPHack on ESXi host '{{ esxi_hostname }}'"
-      include_tasks: esxi_set_advanced_system_settings.yml
-      vars:
-        esxi_host_config_options: {'Net.GuestIPHack': 1}

--- a/common/esxi_enable_guest_ip_hack.yml
+++ b/common/esxi_enable_guest_ip_hack.yml
@@ -1,29 +1,22 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Enable guest IP hack on ESXi host
-- name: "Enable GuestIPHack on ESXi host '{{ esxi_hostname }}'"
-  ansible.builtin.command: "esxcli system settings advanced set -o /Net/GuestIPHack -i 1"
-  delegate_to: "{{ esxi_hostname }}"
-  register: esxcli_output
-- name: Display the esxcli command result
-  ansible.builtin.debug: var=esxcli_output
-  when: enable_debug is defined and enable_debug
+- name: "Get ESXi server advanced system settings"
+  include_tasks: esxi_get_advanced_system_settings.yml
 
-- name: "Get GuestIPHack option value on ESXi host"
-  ansible.builtin.shell: "esxcli system settings advanced list -o /Net/GuestIPHack | grep 'Int Value' | awk 'NR==1 {print $3}'"
-  delegate_to: "{{ esxi_hostname }}"
-  changed_when: false
-  register: esxcli_output2
-- name: Display the esxcli command result
-  ansible.builtin.debug: var=esxcli_output2
-  when: enable_debug is defined and enable_debug
+- name: "Display current state of guest IP hack on ESXi host"
+  ansible.builtin.debug:
+    msg: >-
+      Current value of 'Net.GuestIPHack' is
+      {{ esxi_advanced_system_settings['Net.GuestIPHack'] | default('') }}
 
-- name: "Check GuestIPHack enabled on ESXi host"
-  ansible.builtin.assert:
-    that:
-      - esxcli_output2.stdout_lines is defined
-      - esxcli_output2.stdout_lines | length > 0
-      - esxcli_output2.stdout_lines[0] == '1'
-    fail_msg: "Enable GuestIPHack on ESXi host failed, got value '{{ esxcli_output2.stdout_lines[0] }}', expected '1'."
-    success_msg: "Enable GuestIPHack on ESXi host succeed"
+- name: "Enable guest IP hack on ESXi host"
+  when: >-
+    esxi_advanced_system_settings['Net.GuestIPHack'] is undefined or
+    esxi_advanced_system_settings['Net.GuestIPHack'] | string != "1"
+  block: 
+    # Enable guest IP hack on ESXi host
+    - name: "Enable GuestIPHack on ESXi host '{{ esxi_hostname }}'"
+      include_tasks: esxi_set_advanced_system_settings.yml
+      vars:
+        esxi_host_config_options: {'Net.GuestIPHack': 1}


### PR DESCRIPTION
Replace esxcli command with Ansible module to enable guest IP hack on ESXi host.

```
TASK [Display current state of guest IP hack on ESXi host] *******************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/esxi_enable_guest_ip_hack.yml:7
ok: [localhost] => {
    "msg": "Current value of 'Net.GuestIPHack' is 0"
}

TASK [Enable GuestIPHack on ESXi host '192.168.1.2'] *****************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/esxi_enable_guest_ip_hack.yml:19
included: /home/qiz/workspace/ansible-vsphere-gos-validation/tests/unit_tests/../../common/esxi_set_advanced_system_settings.yml for localhost

TASK [Check 'esxi_host_config_options' parameter value is valid] *************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/esxi_set_advanced_system_settings.yml:8
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [Configure ESXi server with advanded system settings] *******************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/esxi_set_advanced_system_settings.yml:15
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "cluster_name": null,
            "esxi_hostname": "192.168.1.2",
            "hostname": "192.168.1.2",
            "options": {
                "Net.GuestIPHack": 1
            },
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "username": "root",
            "validate_certs": false
        }
    },
    "msg": "Net.GuestIPHack changed."
}

TASK [Display the result of configuring ESXi advanced system settings] *******************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/esxi_set_advanced_system_settings.yml:25
ok: [localhost] => {
    "set_advanced_settings_result": {
        "changed": true,
        "failed": false,
        "msg": "Net.GuestIPHack changed."
    }
}
META: ending play
```