### PR TITLE
Update deploy_vm test case full name in log plugin

### DIFF
--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -780,6 +780,21 @@ class CallbackModule(CallbackBase):
         test_idx = 0
         for test_id in self.test_runs:
             test_result = self.test_runs[test_id]
+            if test_result.name == 'deploy_vm':
+                # Update deploy_vm test case name
+                if self.testing_vars.get('vm_deploy_method', '').lower() == 'ova':
+                    if self.testing_testcase_file and 'windows' in self.testing_testcase_file:
+                        test_result.name = 'deploy_vm_ovf'
+                    else:
+                        test_result.name = 'deploy_vm_ova'
+
+                elif (self.testing_vars.get('boot_disk_controller') and
+                      self.testing_vars.get('firmware') and
+                      self.testing_vars.get('network_adapter_type')):
+                    test_result.name = "deploy_vm_{}_{}_{}".format(self.testing_vars['firmware'].lower(),
+                                                                   self.testing_vars['boot_disk_controller'].lower(),
+                                                                   self.testing_vars['network_adapter_type'].lower())
+
             test_idx += 1
             test_exec_time = time.strftime('%H:%M:%S', time.gmtime(test_result.duration))
             if test_result.status == 'Passed':

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -780,7 +780,8 @@ class CallbackModule(CallbackBase):
         test_idx = 0
         for test_id in self.test_runs:
             test_result = self.test_runs[test_id]
-            if test_result.name == 'deploy_vm':
+            if (str(self.testing_vars.get('new_vm', False)).lower() == 'true' and
+                test_result.name == 'deploy_vm'):
                 # Update deploy_vm test case name
                 if self.testing_vars.get('vm_deploy_method', '').lower() == 'ova':
                     if self.testing_testcase_file and 'windows' in self.testing_testcase_file:


### PR DESCRIPTION
If test failed before setting deploy_vm test case name, changes in this fix will update the test case name as possible as the plugin can.