### PR TITLE
[Linux] Check VM guest info with compatible hardware versions and VMware Tools

### DIFF
--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -38,29 +38,20 @@
             - guest_os_ansible_distribution == 'Flatcar'
             - guest_os_ansible_distribution_ver is version('3760.2.0', '>=')
 
-        - name: "Get hardware version for checking guest info on ESXi {{ esxi_version }}"
-          when: esxi_version is version('8.0.3', '!=')
-          block:
-            - name: "Get ESXi hardware versions"
-              include_tasks: ../../common/esxi_get_hardware_versions.yml
-    
-            - name: "Set fact of latest hardware version for checking guest info on ESXi {{ esxi_version }}"
-              ansible.builtin.set_fact:
-                guest_info_latest_hwv:  "{{ esxi_latest_hardware_version }}"
+        - name: "Get ESXi hardware versions"
+          include_tasks: ../../common/esxi_get_hardware_versions.yml
 
-        - name: "Set hardware version for checking guest info on ESXi {{ esxi_version }}"
+        - name: "Set facts of hardware versions for checking VM guest info"
           ansible.builtin.set_fact:
-            guest_info_latest_hwv: 22
-          when: esxi_version is version('8.0.3', '==')
+            vm_base_hardware_version: "{{ vm_hardware_version_num }}"
+            vm_current_hw_version: "{{ vm_hardware_version_num }}"
+            guest_info_latest_hwv: "{{ 22 if esxi_version is version('8.0.3', '==') else esxi_latest_hardware_version }}"
+            compatible_hardware_versions: "{{ esxi_hardware_versions | select('>=', vm_hardware_version_num | int) }}"
 
         - name: "Get supported guest ids on ESXi {{ esxi_version }}"
           include_tasks: ../../common/esxi_get_guest_ids.yml
           vars:
             esxi_hardware_version: "{{ guest_info_latest_hwv }}"
-
-        - name: "Display guest OS distribution"
-          ansible.builtin.debug:
-            msg: "{{ vm_guest_os_distribution }}"
 
         - name: "Initialize facts about VM expected guest info"
           ansible.builtin.set_fact:
@@ -79,7 +70,7 @@
         - name: "Set fact of guest OS short-name config"
           ansible.builtin.set_fact:
             guest_short_name: "{{ get_shortname_result.stdout | default('') }}"
-        
+
         - name: "Match guest id for {{ vm_guest_os_distribution }}"
           include_tasks: match_guest_id.yml
 
@@ -95,11 +86,37 @@
               {%- if vm_guest_id is match('freebsd.*') -%}otherGuestFamily
               {%- else -%}linuxGuest{%- endif -%}
 
-        - name: "Validate guest id, full name and family in guest info"
+        - name: "Validate guest id, full name and family in guest info for compatible hardware versions"
           include_tasks: validate_os_fullname.yml
+          with_items: "{{ compatible_hardware_versions }}"
+          loop_control:
+            loop_var: compatible_hw_version
+
       rescue:
         - name: "Test rescue"
           include_tasks: ../../common/test_rescue.yml
       always:
         - name: "Collect VMware Tools logs"
           include_tasks: ../utils/collect_vmtools_logs.yml
+
+        - name: "Revert to base snapshot to downgrade VM hardware version and update VM info"
+          when:
+            - vm_base_hardware_version | default('')
+            - vm_current_hw_version | default('')
+            - vm_current_hw_version | int > vm_base_hardware_version | int
+          block:
+            - name: "Revert to base snapshot"
+              include_tasks: ../../common/vm_revert_snapshot.yml
+              vars:
+                snapshot_name: "{{ base_snapshot_name }}"
+
+            # FreeBSD VM's base snapshot is in powered off state
+            - name: "Power on FreeBSD VM and get VM guest IP"
+              include_tasks: ../../common/update_inventory.yml
+              when: guest_os_ansible_distribution == "FreeBSD"
+
+            - name: "Update VM info"
+              include_tasks: ../../common/vm_get_vm_info.yml
+
+            - name: "Update VM guest info"
+              include_tasks: ../../common/vm_get_guest_info.yml

--- a/linux/check_os_fullname/check_os_fullname.yml
+++ b/linux/check_os_fullname/check_os_fullname.yml
@@ -41,17 +41,22 @@
         - name: "Get ESXi hardware versions"
           include_tasks: ../../common/esxi_get_hardware_versions.yml
 
+        # guestinfo_latest_hw_version is the hardware version containing latest guest ids on the ESXi server
+        # vm_base_hw_version is the hardware version of VM at base snapshot
+        # vm_current_hw_version is the hardware version of VM at present and will be updated after upgrading
+        # hardware version
+        # vm_compatible_hw_versions is a list of hardware versions which VM is compatible with
         - name: "Set facts of hardware versions for checking VM guest info"
           ansible.builtin.set_fact:
-            vm_base_hardware_version: "{{ vm_hardware_version_num }}"
+            guestinfo_latest_hw_version: "{{ 22 if esxi_version is version('8.0.3', '==') else esxi_latest_hardware_version }}"
+            vm_base_hw_version: "{{ vm_hardware_version_num }}"
             vm_current_hw_version: "{{ vm_hardware_version_num }}"
-            guest_info_latest_hwv: "{{ 22 if esxi_version is version('8.0.3', '==') else esxi_latest_hardware_version }}"
-            compatible_hardware_versions: "{{ esxi_hardware_versions | select('>=', vm_hardware_version_num | int) }}"
+            vm_compatible_hw_versions: "{{ esxi_hardware_versions | select('>=', vm_hardware_version_num | int) }}"
 
         - name: "Get supported guest ids on ESXi {{ esxi_version }}"
           include_tasks: ../../common/esxi_get_guest_ids.yml
           vars:
-            esxi_hardware_version: "{{ guest_info_latest_hwv }}"
+            esxi_hardware_version: "{{ guestinfo_latest_hw_version }}"
 
         - name: "Initialize facts about VM expected guest info"
           ansible.builtin.set_fact:
@@ -88,9 +93,9 @@
 
         - name: "Validate guest id, full name and family in guest info for compatible hardware versions"
           include_tasks: validate_os_fullname.yml
-          with_items: "{{ compatible_hardware_versions }}"
+          with_items: "{{ vm_compatible_hw_versions }}"
           loop_control:
-            loop_var: compatible_hw_version
+            loop_var: vm_compatible_hw_version
 
       rescue:
         - name: "Test rescue"
@@ -101,9 +106,9 @@
 
         - name: "Revert to base snapshot to downgrade VM hardware version and update VM info"
           when:
-            - vm_base_hardware_version | default('')
+            - vm_base_hw_version | default('')
             - vm_current_hw_version | default('')
-            - vm_current_hw_version | int > vm_base_hardware_version | int
+            - vm_current_hw_version | int > vm_base_hw_version | int
           block:
             - name: "Revert to base snapshot"
               include_tasks: ../../common/vm_revert_snapshot.yml

--- a/linux/check_os_fullname/check_unmapped_guest_id.yml
+++ b/linux/check_os_fullname/check_unmapped_guest_id.yml
@@ -76,6 +76,8 @@
     - guest_os_ansible_distribution_major_ver | int >= 9
     - vmtools_version is version('12.4.0', '>=')
     - vmtools_version is version('12.5.0', '<')
+    - esxi_version is version('8.0.3', '<=')
+    - esxi_version is version('7.0.3', '>=')
     - guestinfo_guest_id == 'asianux9_64Guest'
 
 # When guest id is empty, the guest full name which at least includes Linux kernel version, OS pretty name
@@ -91,7 +93,7 @@
        esxi_version is version('7.0.0', '<=')) or
       (guest_os_ansible_kernel is version('6.0', '>=') and
        vmtools_version is version('12.0.0', '>=') and
-       esxi_version is version('7.0.3', '<='))
+       esxi_version is version('7.0.3', '=='))
 
 - name: "Ignore unmapped guest id"
   when: ignore_unmapped_guest_id

--- a/linux/check_os_fullname/check_unmapped_guest_id.yml
+++ b/linux/check_os_fullname/check_unmapped_guest_id.yml
@@ -4,9 +4,24 @@
 # Check whether unmapped guest id can be ignored
 # Unmapped guest id could be empty guest id or same as VM configured guest id
 #
-- name: "Initialize the fact of ignoreing unmapped guest id to false"
+- name: "Initialize facts for ignoreing unmapped guest info"
   ansible.builtin.set_fact:
     ignore_unmapped_guest_id: false
+    guestinfo_equalto_vm_config: >-
+      {{
+        guestinfo_guest_id == vm_guest_id and
+        guestinfo_guest_family == vm_guest_family and
+        guestinfo_guest_full_name | regex_replace(' or later( versions)?', '') == vm_guest_os_version | regex_replace(' or later( versions)?', '')
+      }}
+    guestinfo_shows_os_release: >-
+      {{
+        not guestinfo_guest_id and
+        guest_os_ansible_kernel in guestinfo_guest_full_name and
+        ((guest_os_release.PRETTY_NAME is defined and guest_os_release.PRETTY_NAME and
+          guest_os_release.PRETTY_NAME in guestinfo_guest_full_name) or
+          (guest_os_release.NAME is defined and guest_os_release.NAME and
+          guest_os_release.NAME in guestinfo_guest_full_name))
+      }}
 
 - name: "Check VMware Tools {{ vmtools_version }} open-vm-tools package vendor is Rocky Linux or not"
   when:
@@ -26,14 +41,14 @@
     # VMware Tools version is 11.3.5 or earlier, and open-vm-tools package vendor is Rocky Linux
     - name: "Set fact to ignore unmapped guest id for Rocky Linux with VMware Tools {{ vmtools_version }}"
       ansible.builtin.set_fact:
-        ignore_unmapped_guest_id: true
+        ignore_unmapped_guest_id: "{{ guestinfo_equalto_vm_config }}"
       when: ovt_vendor_is_rocky
 
 # Guest ids of AlmaLinux and Rocky Linux are mapped to VM configured guest id when
 # VMware Tools version is 12.0.0 or later, and ESXi version is 7.0.3 or earlier
 - name: "Set fact to ignore unmapped guest id for {{ vm_guest_os_distribution }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
-    ignore_unmapped_guest_id: true
+    ignore_unmapped_guest_id: "{{ guestinfo_equalto_vm_config }}"
   when:
     - guest_os_ansible_distribution in ['AlmaLinux', 'Rocky']
     - vmtools_version is version('12.0.0', '>=')
@@ -43,7 +58,7 @@
 # VMware Tools version is 12.5.0 or later, and ESXi version is 8.0.3 or earlier
 - name: "Set fact to ignore unmapped guest id for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
-    ignore_unmapped_guest_id: true
+    ignore_unmapped_guest_id: "{{ guestinfo_equalto_vm_config }}"
   when:
     - vmtools_version is version('12.5.0', '>=')
     - esxi_version is version('8.0.3', '<=')
@@ -53,9 +68,22 @@
                                         'Pardus GNU/Linux',
                                         'Kylin Linux Advanced Server']
 
-- name: "Set fact to ignore unmapped guest id for other Linux {{ guest_os_ansible_kernel }} on ESXi {{ esxi_version }}"
+- name: "Set fact to ignore unmapped guest id for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
     ignore_unmapped_guest_id: true
+  when:
+    - guest_os_ansible_distribution == 'MIRACLE'
+    - guest_os_ansible_distribution_major_ver | int >= 9
+    - vmtools_version is version('12.4.0', '>=')
+    - vmtools_version is version('12.5.0', '<')
+    - guestinfo_guest_id == 'asianux9_64Guest'
+
+# When guest id is empty, the guest full name which at least includes Linux kernel version, OS pretty name
+# For VM with newer VMware Tools, the unmapped guest full name also includes OS name, version id and build id
+# Here we only check linux kernel version, OS pretty name or distro name are in guest full name.
+- name: "Set fact to ignore unmapped guest id for other Linux {{ guest_os_ansible_kernel }} on ESXi {{ esxi_version }}"
+  ansible.builtin.set_fact:
+    ignore_unmapped_guest_id: "{{ guestinfo_equalto_vm_config or guestinfo_shows_os_release }}"
   when:
     - guest_is_otherlinux
     - (guest_os_ansible_kernel is version('5.0', '>=') and
@@ -68,47 +96,15 @@
 - name: "Ignore unmapped guest id"
   when: ignore_unmapped_guest_id
   block:
-    # When guest id is empty, the guest full name which at least includes Linux kernel version, OS pretty name
-    # For VM with newer VMware Tools, the unmapped guest full name also includes OS name, version id and build id
-    # Here we only check linux kernel version, OS pretty name or distro name are in guest full name.
-    - name: "Ignore emtpy guest id for {{ vm_guest_os_distribution }} on ESXi {{ esxi_version }}"
-      when:
-        - not guestinfo_guest_id
-        - guest_os_ansible_kernel in guestinfo_guest_full_name
-        - ((guest_os_release.PRETTY_NAME is defined and guest_os_release.PRETTY_NAME and
-          guest_os_release.PRETTY_NAME in guestinfo_guest_full_name) or
-          (guest_os_release.NAME is defined and guest_os_release.NAME and
-          guest_os_release.NAME in guestinfo_guest_full_name))
-      block:
-        - name: "Ignore empty guest id"
-          ansible.builtin.debug:
-            msg: >-
-              The guest id of {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} is '{{ guestinfo_guest_id }}'
-              on ESXi {{ esxi_version }}, and guest full name is '{{ guestinfo_guest_full_name }}',  which shows
-              guest OS detailed information. This is as expected on ESXi {{ esxi_version }}.
-              Test Passed.
-          tags:
-            - known_issue
+    - name: "Ignore unmapped guest id for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.debug:
+        msg: >-
+          The guest id of {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} is '{{ guestinfo_guest_id }}'
+          on ESXi {{ esxi_version }}, and guest full name is '{{ guestinfo_guest_full_name }}', which is as expected.
+          Test Passed.
+      tags:
+        - known_issue
 
-        - name: "Test passed for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
-          ansible.builtin.meta: end_host
-
-    - name: "Ignore VM configured guest id for {{ vm_guest_os_distribution }} on ESXi {{ esxi_version }}"
-      when:
-        - guestinfo_guest_id
-        - guestinfo_guest_id == vm_guest_id
-        - guestinfo_guest_full_name == vm_guest_os_version
-        - guestinfo_guest_family == vm_guest_family
-      block:
-        - name: "Ignore VM configured guest id"
-          ansible.builtin.debug:
-            msg: >-
-              The guest id of {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} is '{{ guestinfo_guest_id }}'
-              on ESXi {{ esxi_version }}, and guest full name is '{{ guestinfo_guest_full_name }}',  which is same as VM settings.
-              This is as expected on ESXi {{ esxi_version }}.
-              Test Passed.
-          tags:
-            - known_issue
-
-        - name: "Test passed for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
-          ansible.builtin.meta: end_host
+    - name: "Skip checking guest info for {{ vm_guest_os_distribution }} with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.set_fact:
+        skip_guest_info_checking: true

--- a/linux/check_os_fullname/get_other_linux_guest_ids.yml
+++ b/linux/check_os_fullname/get_other_linux_guest_ids.yml
@@ -7,6 +7,7 @@
   ansible.builtin.set_fact:
     guest_id_major_version: "{{ guest_os_ansible_kernel | regex_search('^\\d+') }}"
     guest_is_otherlinux: true
+    guest_id_pattern: "other\\d+xLinux"
 
 - name: "Fail the test due to unknown Linux kernel major version"
   ansible.builtin.fail:
@@ -15,10 +16,4 @@
 
 - name: "Get supported other Linux guest ids for 64-bit guest OS"
   ansible.builtin.set_fact:
-    supported_guest_ids: "{{ esxi_guest_ids | select('match', 'other\\d+xLinux64Guest') | reject('match', 'other2[46]xLinux64Guest') }}"
-  when: guest_id_bit == '64'
-
-- name: "Get supported other Linux guest ids for 32-bit guest OS"
-  ansible.builtin.set_fact:
-    supported_guest_ids: "{{ esxi_guest_ids | select('match', 'other\\d+xLinux$') | reject('match', 'other2[46]xLinux') }}"
-  when: guest_id_bit != '64'
+    supported_guest_ids: "{{ esxi_guest_ids_for_bit | select('match', guest_id_pattern) | reject('match', 'other2[46]xLinux') }}"

--- a/linux/check_os_fullname/map_guest_id_to_fullname.yml
+++ b/linux/check_os_fullname/map_guest_id_to_fullname.yml
@@ -5,7 +5,7 @@
 #
 - name: "Initialize fact of the guest full name mapped by guest id"
   ansible.builtin.set_fact:
-    mapped_guest_fulname: ""
+    mapped_guest_fullname: ""
 
 - name: "Get guest id options for hardware version {{ guest_info_latest_hwv }}"
   include_tasks: ../../common/esxi_get_guest_config_options.yml
@@ -26,4 +26,4 @@
 
 - name: "Set fact of the guest full name mapped by guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
-    mapped_guest_fulname: "{{ guest_config_options.guest_fullname }}"
+    mapped_guest_fullname: "{{ guest_config_options.guest_fullname }}"

--- a/linux/check_os_fullname/map_guest_id_to_fullname.yml
+++ b/linux/check_os_fullname/map_guest_id_to_fullname.yml
@@ -3,10 +3,10 @@
 ---
 # Map guest id to guest full name
 #
-- name: "Get guest id options for hardware version {{ guest_info_latest_hwv }}"
+- name: "Get guest id options for hardware version {{ guestinfo_latest_hw_version }}"
   include_tasks: ../../common/esxi_get_guest_config_options.yml
   vars:
-    esxi_hardware_version: "{{ guest_info_latest_hwv }}"
+    esxi_hardware_version: "{{ guestinfo_latest_hw_version }}"
     guest_id: "{{ expected_guest_id }}"
 
 - name: "Check guest full name is defined for guest id {{ expected_guest_id }}"
@@ -18,7 +18,7 @@
       - guest_config_options.guest_fullname
     fail_msg: >-
       Failed to find guest full name for guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}
-      with latest guest info hardware version {{ guest_info_latest_hwv }}
+      with latest guest info hardware version {{ guestinfo_latest_hw_version }}
 
 - name: "Set fact of the guest full name mapped by guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:

--- a/linux/check_os_fullname/map_guest_id_to_fullname.yml
+++ b/linux/check_os_fullname/map_guest_id_to_fullname.yml
@@ -3,10 +3,6 @@
 ---
 # Map guest id to guest full name
 #
-- name: "Initialize fact of the guest full name mapped by guest id"
-  ansible.builtin.set_fact:
-    mapped_guest_fullname: ""
-
 - name: "Get guest id options for hardware version {{ guest_info_latest_hwv }}"
   include_tasks: ../../common/esxi_get_guest_config_options.yml
   vars:
@@ -26,4 +22,4 @@
 
 - name: "Set fact of the guest full name mapped by guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
-    mapped_guest_fullname: "{{ guest_config_options.guest_fullname }}"
+    expected_guest_fullname: "{{ guest_config_options.guest_fullname }}"

--- a/linux/check_os_fullname/map_guest_id_to_fullname.yml
+++ b/linux/check_os_fullname/map_guest_id_to_fullname.yml
@@ -3,7 +3,11 @@
 ---
 # Map guest id to guest full name
 #
-- name: "Get guest id options"
+- name: "Initialize fact of the guest full name mapped by guest id"
+  ansible.builtin.set_fact:
+    mapped_guest_fulname: ""
+
+- name: "Get guest id options for hardware version {{ guest_info_latest_hwv }}"
   include_tasks: ../../common/esxi_get_guest_config_options.yml
   vars:
     esxi_hardware_version: "{{ guest_info_latest_hwv }}"
@@ -20,6 +24,6 @@
       Failed to find guest full name for guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}
       with latest guest info hardware version {{ guest_info_latest_hwv }}
 
-- name: "Set expected guest full name for {{ vm_guest_os_distribution }}"
+- name: "Set fact of the guest full name mapped by guest id {{ expected_guest_id }} on ESXi {{ esxi_version }}"
   ansible.builtin.set_fact:
-    expected_guest_fullname: "{{ guest_config_options.guest_fullname }}"
+    mapped_guest_fulname: "{{ guest_config_options.guest_fullname }}"

--- a/linux/check_os_fullname/match_guest_id.yml
+++ b/linux/check_os_fullname/match_guest_id.yml
@@ -8,6 +8,9 @@
     guest_id_pattern: ""
     guest_id_bit: ""
     guest_id_major_version: ""
+    guest_is_otherlinux: false
+    esxi_guest_ids_for_bit: []
+    supported_guest_ids: []
 
 - name: "Set guest id pattern and bit from short-name in tools.conf"
   when: guest_short_name
@@ -24,38 +27,70 @@
 - name: "Set guest id pattern and bit from guest OS release"
   when: not guest_short_name
   block:
-    - name: "Initialize facts to map guest id for {{ vm_guest_os_distribution }}"
+    - name: "Set fact of guest id bit"
       ansible.builtin.set_fact:
-        guest_os_release_name: "{{ guest_os_release.NAME | replace(' ', '') | regex_replace(' *(server|os) *$', '', ignorecase=True) }}"
-        guest_os_release_id: |-
-          {%- if guest_os_release.ID | lower == 'sled' -%}sles
-          {%- elif guest_os_release.ID | lower is match('opensuse.*') -%}opensuse
-          {%- else -%}{{ guest_os_release.ID }}
-          {%- endif -%}
-        guest_id_major_version: "{{ guest_os_release.VERSION | regex_search('\\d+') }}"
-
-    - name: "Match MIRACLE LINUX guest id to asianux on ESXi {{ esxi_veresion }} with VMware Tools version {{ vmtools_version }}"
-      ansible.builtin.set_fact:
-        guest_os_release_id: "asianux|{{ guest_os_release_id }}"
-      when: 
-        - guest_os_ansible_distribution == 'MIRACLE'
-        - vmtools_version is version('12.3.5', '>')
-        - esxi_version is version('8.0.3', '<=')
-     
-    - name: "Set facts of guest id pattern and bit from guest OS release"
-      ansible.builtin.set_fact:
-        guest_id_pattern: "(?i)({{ guest_os_release_id }}|({{ guest_os_release_name }}))\\w*\\d*"
         guest_id_bit: "{{ '64' if guest_os_bit == '64-bit' else '' }}"
 
-- name: "Set fact of supported 64-bit guest ids matching '{{ guest_id_pattern  }}'"
+    # AlmaLinux and Rocky Linux will be recognized as other Linux by VMware Tool earlier than 12.0.0
+    # MIRACLE LINUX will be recognized as other Linux by VMware Tool earlier thatn 12.4.0
+    # ProLinux, FusionOS, Pardus and Kylin Linux will be recognized as other Linux
+    # by VMware Tool earlier than 12.5.0
+    - name: "Set fact that current guest OS should be recognized as other Linux"
+      ansible.builtin.set_fact:
+        guest_is_otherlinux: true
+      when: >-
+        (guest_os_ansible_distribution in ['Almalinux', 'Rocky'] and
+         vmtools_version is version('12.0.0', '<')) or
+        (guest_os_ansible_distribution == 'MIRACLE' and
+         vmtools_version is version('12.4.0', '<')) or
+        (guest_os_ansible_distribution in ['ProLinux', 'FusionOS',
+                                           'Pardus GNU/Linux',
+                                           'Kylin Linux Advanced Server'] and
+         vmtools_version is version('12.5.0', '<'))
+
+    - name: "Set guest id pattern for {{ guest_os_ansible_distribution }}"
+      when: not guest_is_otherlinux
+      block:
+        - name: "Initialize facts to map guest id for {{ vm_guest_os_distribution }}"
+          ansible.builtin.set_fact:
+            guest_os_release_name: "{{ guest_os_release.NAME | replace(' ', '') |
+                                       regex_replace(' *(server|os) *$', '', ignorecase=True) }}"
+            guest_os_release_id: |-
+              {%- if guest_os_release.ID | lower == 'sled' -%}sles
+              {%- elif guest_os_release.ID | lower is match('opensuse.*') -%}opensuse
+              {%- else -%}{{ guest_os_release.ID }}
+              {%- endif -%}
+            guest_id_major_version: "{{ guest_os_release.VERSION | regex_search('\\d+') }}"
+
+        - name: "Match MIRACLE LINUX guest id to 'asianux' with VMware Tools version {{ vmtools_version }}"
+          ansible.builtin.set_fact:
+            guest_os_release_id: "asianux"
+            guest_os_release_name: "Asianux"
+          when:
+            - guest_os_ansible_distribution == 'MIRACLE'
+            - vmtools_version is version('12.4.0', '>=')
+            - vmtools_version is version('12.5.0', '<')
+
+        - name: "Set facts of guest id pattern and bit from guest OS release"
+          ansible.builtin.set_fact:
+            guest_id_pattern: "(?i)({{ guest_os_release_id }}|({{ guest_os_release_name }}))\\w*\\d*"
+
+- name: "Set fact of ESXi supported 64-bit guest ids"
   ansible.builtin.set_fact:
-    supported_guest_ids: "{{ esxi_guest_ids | select('match', guest_id_pattern ~ '_?64Guest') }}"
+    esxi_guest_ids_for_bit: "{{ esxi_guest_ids | select('match', '.*64Guest') }}"
   when: guest_id_bit == '64'
 
-- name: "Set fact of supported 32-bit guest ids matching '{{ guest_id_pattern }}'"
+- name: "Set fact of ESXi supported 32-bit guest ids"
   ansible.builtin.set_fact:
-    supported_guest_ids: "{{ esxi_guest_ids | reject('match', '.*64Guest') | select('match', guest_id_pattern ~ 'Guest') }}"
+    esxi_guest_ids_for_bit: "{{ esxi_guest_ids | reject('match', '.*64Guest') }}"
   when: guest_id_bit != '64'
+
+- name: "Set fact of supported {{ guest_id_bit }}-bit guest ids matching '{{ guest_id_pattern  }}'"
+  ansible.builtin.set_fact:
+    supported_guest_ids: "{{ esxi_guest_ids_for_bit | select('match', guest_id_pattern) }}"
+  when:
+    - guest_id_pattern
+    - not guest_is_otherlinux
 
 # Not found supported guest ids for guest OS distribution, then look for supported other Linux guest ids
 - name: "Get supported other Linux guest ids"
@@ -64,11 +99,14 @@
     - supported_guest_ids | length == 0
     - guest_os_ansible_distribution != "FreeBSD"
 
+- name: "Display supported guest ids for {{ vm_guest_os_distribution }}"
+  ansible.builtin.debug: var=supported_guest_ids
+
 - name: "Set fact of expected guest id for {{ vm_guest_os_distribution }}"
   ansible.builtin.set_fact:
     expected_guest_id: "{{ supported_guest_ids[0] }}"
   when: supported_guest_ids | length == 1
-  
+
 - name: "Look for closest guest id for {{ vm_guest_os_distribution }}"
   when: supported_guest_ids | length > 1
   block:

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -7,9 +7,8 @@
   ansible.builtin.debug:
     msg: "Start to validate VM guest info for hardware version {{ compatible_hw_version }}"
 
-- name: "Set facts of expected guest full name and whether to skip guest info checking"
+- name: "Set facts whether to upgrade VM hardware version and skip guest info checking"
   ansible.builtin.set_fact:
-    expected_guest_fullname: "{{ mapped_guest_fullname }}"
     skip_guest_info_checking: false
     upgrade_vm_hardware_version: >-
       {{

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -1,49 +1,124 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
+# Validate VM guest info for a compatible hardware version
+#
+- name: "Start to validate VM guest info"
+  ansible.builtin.debug:
+    msg: "Start to validate VM guest info for hardware version {{ compatible_hw_version }}"
+
+- name: "Set facts of expected guest full name and whether to skip guest info checking"
+  ansible.builtin.set_fact:
+    expected_guest_fullname: "{{ mapped_guest_fulname }}"
+    skip_guest_info_checking: false
+    upgrade_vm_hardware_version: >-
+      {{
+        compatible_hw_version is defined and
+        compatible_hw_version is match('\d+') and
+        compatible_hw_version | int > vm_current_hw_version | int
+      }}
+
+- name: "Upgrade VM hardware version"
+  when: upgrade_vm_hardware_version | bool
+  block:
+    - name: "Shutdown VM"
+      include_tasks: ../utils/shutdown.yml
+
+    - name: "Upgrade VM hardware version from {{ vm_current_hw_version }} to {{ compatible_hw_version }}"
+      include_tasks: ../../common/vm_upgrade_hardware_version.yml
+      vars:
+        hw_version: "{{ compatible_hw_version }}"
+
+    - name: "Set fact for VM current hardware version"
+      ansible.builtin.set_fact:
+        vm_current_hw_version: "{{ vm_hardware_version_num }}"
+
+    - name: "Power on VM"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: 'powered-on'
+
+    - name: "Get VM guest IP"
+      include_tasks: ../../common/update_inventory.yml
+
+# If the VM's hardware version is not the latest hardware version, other Linux and FreeBSD guest full names
+# might has 'or later'. In such case, expected guest full name should be same as the one in lower hardware version.
+- name: "Get guest full name for guest id {{ expected_guest_id }} when hardware version is {{ vm_hardware_version_num }}"
+  when:
+    - expected_guest_id is match('other\\dxLinux|freebsd')
+    - vm_current_hw_version | int < guest_info_latest_hwv | int
+  block:
+    - name: "Get guest id options for hardware version {{ vm_hardware_version_num }}"
+      include_tasks: ../../common/esxi_get_guest_config_options.yml
+      vars:
+        esxi_hardware_version: "{{ vm_current_hw_version }}"
+        guest_id: "{{ expected_guest_id }}"
+
+    - name: "Set expected guest full name for {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        expected_guest_fullname: "{{ guest_config_options.guest_fullname }}"
+      when:
+        - guest_config_options.guest_id is defined
+        - guest_config_options.guest_id == expected_guest_id
+        - guest_config_options.guest_fullname is defined
+        - guest_config_options.guest_fullname is search('or later')
+        - not (expected_guest_fullname is search('or later'))
+        - guest_config_options.guest_fullname | regex_replace(' or later( versions)?', '') == expected_guest_fullname
+
+- name: "Get VM guest info"
+  include_tasks: ../../common/vm_get_guest_info.yml
+
 - name: "Display details about VM guest info"
   ansible.builtin.debug:
     msg:
       - "ESXi version: {{ esxi_version }}"
       - "Latest guest info hardware version: {{ guest_info_latest_hwv }}"
       - "VMware Tools version: {{ vmtools_version }}"
-      - "VM's hardware version: {{ vm_hardware_version }}"
+      - "VM hardware version: {{ vm_current_hw_version }}"
+      - "VM guest OS distribution: {{ vm_guest_os_distribution }}"
+      - "VM config guest id: {{ vm_guest_id }}"
       - "Expected guest id: {{ expected_guest_id }}"
       - "Actual guest id: {{ guestinfo_guest_id }}"
+      - "VM config guest OS version: {{ vm_guest_os_version }}"
       - "Expected guest full name: {{ expected_guest_fullname }}"
-      - "Actual guest id: {{ guestinfo_guest_full_name }}"
+      - "Actual guest full name: {{ guestinfo_guest_full_name }}"
       - "Expected guest family: {{ expected_guest_family }}"
       - "Actual guest family: {{ guestinfo_guest_family }}"
 
 - name: "Check whether unmapped guest id can be ignored"
   include_tasks: check_unmapped_guest_id.yml
-  when:
-    - expected_guest_id != guestinfo_guest_id
-    - (not guestinfo_guest_id) or (guestinfo_guest_id == vm_guest_id)
+  when: expected_guest_id != guestinfo_guest_id
 
-- name: "Check guest id in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
-  ansible.builtin.assert:
-    that:
-      - guestinfo_guest_id == expected_guest_id
-    fail_msg: >-
-      VM's guest id in guest info is '{{ guestinfo_guest_id }}', not expected '{{ expected_guest_id }}'.
-    success_msg: >-
-      VM's guest id in guest info is '{{ guestinfo_guest_id }}', which is as expected '{{ expected_guest_id }}'.
+- name: "Check VM guest info"
+  when: not skip_guest_info_checking
+  block:
+    - name: "Check guest id in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.assert:
+        that:
+          - guestinfo_guest_id == expected_guest_id
+        fail_msg: >-
+          VM's guest id in guest info is '{{ guestinfo_guest_id }}', not expected '{{ expected_guest_id }}'.
+        success_msg: >-
+          VM's guest id in guest info is '{{ guestinfo_guest_id }}', which is as expected '{{ expected_guest_id }}'.
 
-- name: "Check guest full name in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
-  ansible.builtin.assert:
-    that:
-      - guestinfo_guest_full_name == expected_guest_fullname
-    fail_msg: >-
-      VM's guest full name is '{{ guestinfo_guest_full_name }}', not expected '{{ expected_guest_fullname }}'.
-    success_msg: >-
-      VM's guest full name is '{{ guestinfo_guest_full_name }}', which is as expected '{{ expected_guest_fullname }}'.
+    - name: "Check guest full name in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.assert:
+        that:
+          - guestinfo_guest_full_name == expected_guest_fullname
+        fail_msg: >-
+          VM's guest full name is '{{ guestinfo_guest_full_name }}', not expected '{{ expected_guest_fullname }}'.
+        success_msg: >-
+          VM's guest full name is '{{ guestinfo_guest_full_name }}', which is as expected '{{ expected_guest_fullname }}'.
 
-- name: "Check guest family in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
-  ansible.builtin.assert:
-    that:
-      - guestinfo_guest_family == expected_guest_family
-    fail_msg: >-
-      VM's guest family in guest info is '{{ guestinfo_guest_family }}', not expected '{{ expected_guest_family }}'.
-    success_msg: >-
-      VM's guest family in guest info is '{{ guestinfo_guest_family }}', which is as expected '{{ expected_guest_family }}'.
+    - name: "Check guest family in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.assert:
+        that:
+          - guestinfo_guest_family == expected_guest_family
+        fail_msg: >-
+          VM's guest family in guest info is '{{ guestinfo_guest_family }}', not expected '{{ expected_guest_family }}'.
+        success_msg: >-
+          VM's guest family in guest info is '{{ guestinfo_guest_family }}', which is as expected '{{ expected_guest_family }}'.
+
+- name: "End to validate VM guest info"
+  ansible.builtin.debug:
+    msg: "End to validate VM guest info for hardware version {{ compatible_hw_version }}"

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -41,30 +41,6 @@
     - name: "Get VM guest IP"
       include_tasks: ../../common/update_inventory.yml
 
-# If the VM's hardware version is not the latest hardware version, other Linux and FreeBSD guest full names
-# might has 'or later'. In such case, expected guest full name should be same as the one in lower hardware version.
-- name: "Get guest full name for guest id {{ expected_guest_id }} when hardware version is {{ vm_hardware_version_num }}"
-  when:
-    - expected_guest_id is match('other\\dxLinux|freebsd')
-    - vm_current_hw_version | int < guest_info_latest_hwv | int
-  block:
-    - name: "Get guest id options for hardware version {{ vm_hardware_version_num }}"
-      include_tasks: ../../common/esxi_get_guest_config_options.yml
-      vars:
-        esxi_hardware_version: "{{ vm_current_hw_version }}"
-        guest_id: "{{ expected_guest_id }}"
-
-    - name: "Set expected guest full name for {{ vm_guest_os_distribution }}"
-      ansible.builtin.set_fact:
-        expected_guest_fullname: "{{ guest_config_options.guest_fullname }}"
-      when:
-        - guest_config_options.guest_id is defined
-        - guest_config_options.guest_id == expected_guest_id
-        - guest_config_options.guest_fullname is defined
-        - guest_config_options.guest_fullname is search('or later')
-        - not (expected_guest_fullname is search('or later'))
-        - guest_config_options.guest_fullname | regex_replace(' or later( versions)?', '') == expected_guest_fullname
-
 - name: "Get VM guest info"
   include_tasks: ../../common/vm_get_guest_info.yml
 
@@ -109,6 +85,21 @@
           VM's guest full name is '{{ guestinfo_guest_full_name }}', not expected '{{ expected_guest_fullname }}'.
         success_msg: >-
           VM's guest full name is '{{ guestinfo_guest_full_name }}', which is as expected '{{ expected_guest_fullname }}'.
+      when:
+        - not (expected_guest_fullname is search('or later'))
+        - not (guestinfo_guest_full_name is search('or later'))
+
+    - name: "Check guest full name in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
+      ansible.builtin.assert:
+        that:
+          - guestinfo_guest_full_name | regex_replace(' or later( versions)?', '') == expected_guest_fullname | regex_replace(' or later( versions)?', '')
+        fail_msg: >-
+          VM's guest full name is '{{ guestinfo_guest_full_name }}', not expected '{{ expected_guest_fullname }}'.
+        success_msg: >-
+          VM's guest full name is '{{ guestinfo_guest_full_name }}', which is as expected '{{ expected_guest_fullname }}'.
+      when: >-
+        expected_guest_fullname is search('or later') or
+        guestinfo_guest_full_name is search('or later')
 
     - name: "Check guest family in VM's guest info with VMware Tools {{ vmtools_version }} on ESXi {{ esxi_version }}"
       ansible.builtin.assert:

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -9,7 +9,7 @@
 
 - name: "Set facts of expected guest full name and whether to skip guest info checking"
   ansible.builtin.set_fact:
-    expected_guest_fullname: "{{ mapped_guest_fulname }}"
+    expected_guest_fullname: "{{ mapped_guest_fullname }}"
     skip_guest_info_checking: false
     upgrade_vm_hardware_version: >-
       {{

--- a/linux/check_os_fullname/validate_os_fullname.yml
+++ b/linux/check_os_fullname/validate_os_fullname.yml
@@ -5,16 +5,16 @@
 #
 - name: "Start to validate VM guest info"
   ansible.builtin.debug:
-    msg: "Start to validate VM guest info for hardware version {{ compatible_hw_version }}"
+    msg: "Start to validate VM guest info for hardware version {{ vm_compatible_hw_version }}"
 
 - name: "Set facts whether to upgrade VM hardware version and skip guest info checking"
   ansible.builtin.set_fact:
     skip_guest_info_checking: false
     upgrade_vm_hardware_version: >-
       {{
-        compatible_hw_version is defined and
-        compatible_hw_version is match('\d+') and
-        compatible_hw_version | int > vm_current_hw_version | int
+        vm_compatible_hw_version is defined and
+        vm_compatible_hw_version is match('\d+') and
+        vm_compatible_hw_version | int > vm_current_hw_version | int
       }}
 
 - name: "Upgrade VM hardware version"
@@ -23,10 +23,10 @@
     - name: "Shutdown VM"
       include_tasks: ../utils/shutdown.yml
 
-    - name: "Upgrade VM hardware version from {{ vm_current_hw_version }} to {{ compatible_hw_version }}"
+    - name: "Upgrade VM hardware version from {{ vm_current_hw_version }} to {{ vm_compatible_hw_version }}"
       include_tasks: ../../common/vm_upgrade_hardware_version.yml
       vars:
-        hw_version: "{{ compatible_hw_version }}"
+        hw_version: "{{ vm_compatible_hw_version }}"
 
     - name: "Set fact for VM current hardware version"
       ansible.builtin.set_fact:
@@ -47,7 +47,7 @@
   ansible.builtin.debug:
     msg:
       - "ESXi version: {{ esxi_version }}"
-      - "Latest guest info hardware version: {{ guest_info_latest_hwv }}"
+      - "Latest guest info hardware version: {{ guestinfo_latest_hw_version }}"
       - "VMware Tools version: {{ vmtools_version }}"
       - "VM hardware version: {{ vm_current_hw_version }}"
       - "VM guest OS distribution: {{ vm_guest_os_distribution }}"
@@ -111,4 +111,4 @@
 
 - name: "End to validate VM guest info"
   ansible.builtin.debug:
-    msg: "End to validate VM guest info for hardware version {{ compatible_hw_version }}"
+    msg: "End to validate VM guest info for hardware version {{ vm_compatible_hw_version }}"

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -15,6 +15,18 @@
   include_tasks: ../../common/check_vm_settings.yml
   when: vm_settings_checked is undefined
 
+- name: "Get VM info after reverting to base snapshot"
+  when:
+    - base_snapshot_exists | bool
+    - vm_info_retrieved is undefined or not vm_info_retrieved
+  block:
+    - name: "Get VM info at base snapshot"
+      include_tasks: ../../common/vm_get_vm_info.yml
+
+    - name: "Set fact that VM info at base snapshot retrieved"
+      ansible.builtin.set_fact:
+        vm_info_retrieved: true
+
 - name: "Get VM guest IP"
   include_tasks: ../../common/update_inventory.yml
 


### PR DESCRIPTION
VM's guest info relies on ESXi version, VMware Tools version and VM hardware version. This fix added VMware Tools version checking for guest OS identified by newer VMware Tools, and added guest info checking for all compatible hardware versions.