### PR TITLE
Add assertion for checking GOSC result and check VM power state before collecting Linux GOSC logs

### DIFF
--- a/linux/guest_customization/linux_gosc_execution.yml
+++ b/linux/guest_customization/linux_gosc_execution.yml
@@ -28,7 +28,20 @@
     wait_for_customization: true
     wait_for_customization_timeout: "{{ linux_gosc_timeout | default(omit) }}"
   register: customize_linux_result
+  ignore_errors: true
 
 - name: "Display the Linux customization result"
   ansible.builtin.debug: var=customize_linux_result
   when: enable_debug
+
+- name: "Check the Linux guest OS is customized"
+  ansible.builtin.assert:
+    that:
+      - customize_linux_result.failed is defined
+      - not customize_linux_result.failed
+      - customize_linux_result.changed is defined
+      - customize_linux_result.changed
+    fail_msg: >-
+      Failed to perform guest customization on {{ vm_guest_os_distribution }} with error: {{ customize_linux_result.msg | default('') }}
+      {{ ', warnings: ' ~ customize_linux_result.warnings if customize_linux_result.warnings | default('') else '' }}
+    success_msg: "Successfully performed guest customization on {{ vm_guest_os_distribution }}"

--- a/linux/guest_customization/linux_gosc_execution.yml
+++ b/linux/guest_customization/linux_gosc_execution.yml
@@ -42,6 +42,6 @@
       - customize_linux_result.changed is defined
       - customize_linux_result.changed
     fail_msg: >-
-      Failed to perform guest customization on {{ vm_guest_os_distribution }} with error: {{ customize_linux_result.msg | default('') }}
+      Guest customization failed on {{ vm_guest_os_distribution }} with error: {{ customize_linux_result.msg | default('') }}
       {{ ', warnings: ' ~ customize_linux_result.warnings if customize_linux_result.warnings | default('') else '' }}
-    success_msg: "Successfully performed guest customization on {{ vm_guest_os_distribution }}"
+    success_msg: "Guest customization succeeded on {{ vm_guest_os_distribution }}"

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -177,29 +177,35 @@
     - name: "Test case failure"
       include_tasks: ../../common/test_rescue.yml
   always:
-    - name: "Collect GOSC log"
-      when:
-        - gosc_deploypkg_log_local is defined
-        - gosc_deploypkg_log_local
+    - name: "Get VM's power state"
+      include_tasks: ../../common/vm_get_power_state.yml
+
+    - name: "Collect guest customization logs"
+      when: vm_power_state_get == "poweredOn"
       block:
-        - name: "Get stat of {{ gosc_deploypkg_log_local }}"
-          ansible.builtin.stat:
-            path: "{{ gosc_deploypkg_log_local }}"
-          register: gosc_deploypkg_log_stat
-
-        - name: "Fetch GOSC log file {{ gosc_deploypkg_log_file }}"
-          include_tasks: ../../common/vm_guest_file_operation.yml
-          vars:
-            operation: "fetch_file"
-            src_path: "{{ gosc_deploypkg_log_file }}"
-            dest_path: "{{ gosc_deploypkg_log_local }}"
+        - name: "Collect GOSC log"
           when:
-            - not (gosc_deploypkg_log_stat.stat.exists | default(False))
-            - vmtools_is_running is defined
-            - vmtools_is_running | bool
+            - gosc_deploypkg_log_local is defined
+            - gosc_deploypkg_log_local
+          block:
+            - name: "Get stat of {{ gosc_deploypkg_log_local }}"
+              ansible.builtin.stat:
+                path: "{{ gosc_deploypkg_log_local }}"
+              register: gosc_deploypkg_log_stat
 
-    - name: "Colect cloud-init logs"
-      include_tasks: ../utils/collect_cloudinit_logs.yml
-      when: >
-        enable_cloudinit_gosc or
-        (guest_os_ansible_distribution == "VMware Photon OS")
+            - name: "Fetch GOSC log file {{ gosc_deploypkg_log_file }}"
+              include_tasks: ../../common/vm_guest_file_operation.yml
+              vars:
+                operation: "fetch_file"
+                src_path: "{{ gosc_deploypkg_log_file }}"
+                dest_path: "{{ gosc_deploypkg_log_local }}"
+              when:
+                - not (gosc_deploypkg_log_stat.stat.exists | default(False))
+                - vmtools_is_running is defined
+                - vmtools_is_running | bool
+
+        - name: "Colect cloud-init logs"
+          include_tasks: ../utils/collect_cloudinit_logs.yml
+          when: >
+            enable_cloudinit_gosc or
+            (guest_os_ansible_distribution == "VMware Photon OS")

--- a/linux/guest_customization/linux_gosc_workflow.yml
+++ b/linux/guest_customization/linux_gosc_workflow.yml
@@ -200,7 +200,7 @@
                 src_path: "{{ gosc_deploypkg_log_file }}"
                 dest_path: "{{ gosc_deploypkg_log_local }}"
               when:
-                - not (gosc_deploypkg_log_stat.stat.exists | default(False))
+                - not (gosc_deploypkg_log_stat.stat.exists | default(false))
                 - vmtools_is_running is defined
                 - vmtools_is_running | bool
 

--- a/windows/guest_customization/win_gosc_execution.yml
+++ b/windows/guest_customization/win_gosc_execution.yml
@@ -36,10 +36,23 @@
     wait_for_customization: true
     wait_for_customization_timeout: 2400
   register: win_gosc_result
+  ignore_errors: true
 
 - name: "Display the Windows GOSC result"
   ansible.builtin.debug: var=win_gosc_result
   when: enable_debug
+
+- name: "Check the Windows guest OS is customized"
+  ansible.builtin.assert:
+    that:
+      - win_gosc_result.failed is defined
+      - not win_gosc_result.failed
+      - win_gosc_result.changed is defined
+      - win_gosc_result.changed
+    fail_msg: >-
+      Guest customization failed on {{ vm_guest_os_distribution }} with error: {{ win_gosc_result.msg | default('') }}
+      {{ ', warnings: ' ~ win_gosc_result.warnings if win_gosc_result.warnings | default('') else '' }}
+    success_msg: "Guest customization succeeded on {{ vm_guest_os_distribution }}"
 
 - name: "Set fact of the password for user 'Administrator'"
   ansible.builtin.set_fact:


### PR DESCRIPTION
When GOSC failed, the VM power state is powered off. In such state, we can't collect any logs from guest OS. Here added power state checking before collecting logs. 

This fix also added an assertion task to print GOSC failure message like:

```
TASK [Check the Linux guest OS is customized] *******************************************************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/linux/guest_customization/linux_gosc_execution.yml:41
fatal: [localhost]: FAILED! => {
    "assertion": "not customize_linux_result.failed",
    "changed": false,
    "evaluated_to": false,
    "msg": "Guest customization failed on Pardus GNU/Linux 21.5 XFCE x86_64 with error: Customization failed. For detailed information see warnings , warnings: ['Waiting for customization result event timed out.']"
}

```