### PR TITLE
[FreeBSD] Get rid of TOTAL SYSTEM STORAGE in output of listing disks

### DIFF
--- a/linux/utils/get_device_list.yml
+++ b/linux/utils/get_device_list.yml
@@ -13,7 +13,7 @@
   ansible.builtin.set_fact:
     guest_device_list: []
     get_device_list_cmd: |-
-      {%- if guest_os_family == 'FreeBSD' -%}lsblk -d | grep -v SIZE | grep -v cd0
+      {%- if guest_os_family == 'FreeBSD' -%}lsblk -d | grep -i '^[a-z]' | grep -v SIZE | grep -v cd0
       {%- else -%}lsblk -o NAME,TYPE,SIZE,FSTYPE -b --nodeps
       {%- endif -%}
 


### PR DESCRIPTION
Before hot adding a SATA disk on FreeBSD, its disk list is as below:
```
$ lsblk -d | grep -v SIZE | grep -v cd0
da0     40G VMware Virtual disk
-        0G TOTAL SYSTEM STORAGE
```

After hot adding a SATA disk, its disk list is as below:
```
$ lsblk -d | grep -v SIZE | grep -v cd0
ada0   1.0G VMware Virtual SATA Hard Drive
da0     40G VMware Virtual disk
-       41G TOTAL SYSTEM STORAGE
```

The value of TOTAL SYSTEM STORAGE changed, therefore we got two different items after hot adding SATA disk, which led to test failed.

This fix will only list disks without the line of 'TOTAL SYSTEM STORAGE' , so that we can only compare the changed devices list.

```
        "guest_disk_list_before_hotadd": [
            {
                "model": "VMware Virtual disk",
                "name": "da0",
                "size": "40G"
            }
        ]
...
        "guest_disk_list_after_hotadd": [
            {
                "model": "VMware Virtual SATA Hard Drive",
                "name": "ada0",
                "size": "1.0G"
            },
            {
                "model": "VMware Virtual disk",
                "name": "da0",
                "size": "40G"
            }
        ]
```

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:11:41)
+------------------------------------------------+
| ID | Name                 | Status | Exec Time |
+------------------------------------------------+
|  1 | sata_vhba_device_ops | Passed | 00:11:29  |
+------------------------------------------------+
