### PR TITLE
Ignore unreachable error for vCenter Server SSH connection

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -185,6 +185,7 @@
 * vds_network_cleanup.yml: Cleanup vSphere Distributed Switch networking
 * test_rescue: Tasks executed when test case failure
 * skip_test_case.yml: Tasks for skipping testcase and ending play
+* test_ssh_connection.yml: Tasks for testing SSH connection
 
 ## Common tasks for Linux and Windows test cases
 * compose_vm_cdroms.yml: Generate VM CDROM device info list for creating new VM

--- a/common/test_ssh_connection.yml
+++ b/common/test_ssh_connection.yml
@@ -1,0 +1,27 @@
+# Copyright 2025 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Test SSH connection
+# Parameters:
+#   ssh_server_ip: IP address or hostname of the remote server
+# Return:
+#   ssh_connect_success: true if SSH connection succeeds to remote server.
+#
+- name: "Initialize the result of testing SSH connection"
+  ansible.builtin.set_fact:
+    ssh_connect_success: false
+
+- name: "Test SSH connection to {{ ssh_server_ip }}"
+  ansible.builtin.setup:
+    gather_subset: ['!all','!min','system']
+  delegate_to: "{{ ssh_server_ip }}"
+  ignore_unreachable: true
+  register: test_ssh_result
+
+- name: "Set result of testing SSH connection"
+  ansible.builtin.set_fact:
+    ssh_connect_success: >-
+      {{
+        test_ssh_result.unreachable is undefined and
+        not (test_ssh_result.failed | default(false))
+      }}

--- a/common/vcenter_manage_domain_user.yml
+++ b/common/vcenter_manage_domain_user.yml
@@ -77,6 +77,7 @@
   ansible.builtin.command: "{{ manage_domain_user_cmd }}"
   delegate_to: "{{ vcenter_hostname }}"
   ignore_unreachable: true
+  ignore_errors: true
   register: manage_domain_user_result
 
 - name: "Display result of managing domain user"
@@ -117,6 +118,7 @@
       ansible.builtin.command: "{{ modify_user_group_cmd }}"
       delegate_to: "{{ vcenter_hostname }}"
       ignore_unreachable: true
+      ignore_errors: true
       register: modify_user_group_result
 
     - name: "Display result of adding domain user to user group"
@@ -126,7 +128,7 @@
     - name: "Check the result of adding domain user to user group '{{ vcenter_domain_user_group }}'"
       ansible.builtin.assert:
         that:
-          - modify_user_group_result.unreachable is defined
+          - modify_user_group_result.unreachable is undefined
           - modify_user_group_result.failed is defined
           - not modify_user_group_result.failed
         fail_msg: >-

--- a/common/vcenter_manage_domain_user.yml
+++ b/common/vcenter_manage_domain_user.yml
@@ -75,8 +75,8 @@
 
 - name: "{{ vcenter_domain_user_op | capitalize }} domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
   ansible.builtin.command: "{{ manage_domain_user_cmd }}"
-  ignore_errors: true
   delegate_to: "{{ vcenter_hostname }}"
+  ignore_unreachable: true
   register: manage_domain_user_result
 
 - name: "Display result of managing domain user"
@@ -86,12 +86,20 @@
 - name: "Check the result of managing domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'"
   ansible.builtin.assert:
     that:
-      - manage_domain_user_result.rc is defined
-      - manage_domain_user_result.rc == 0
+      - manage_domain_user_result.unreachable is undefined
+      - manage_domain_user_result.failed is defined
+      - not manage_domain_user_result.failed
     fail_msg: >-
       Failed to {{ vcenter_domain_user_op }} domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'.
-      Return code is '{{ manage_domain_user_result.rc | default("unknown") }}'.
-      Hit error '{{ manage_domain_user_result.stderr | default("unknown") }}'.
+      {%- if manage_domain_user_result.rc is defined and manage_domain_user_result.rc != 0 -%}
+          Return code is '{{ manage_domain_user_result.rc }}'.
+      {%- endif -%}Hit error:
+      {%- if manage_domain_user_result.stderr is defined -%}
+          {{ manage_domain_user_result.stderr }}
+      {%- elif manage_domain_user_result.msg is defined and manage_domain_user_result.msg -%}
+          {{ manage_domain_user_result.msg }}.
+      {%- else -%}unknown
+      {%- endif -%}
     success_msg: "{{ manage_domain_user_result.stdout | default(omit) }}"
 
 - name: "Add domain user to user group"
@@ -108,6 +116,7 @@
     - name: "Add domain user to user group '{{ vcenter_domain_user_group }}'"
       ansible.builtin.command: "{{ modify_user_group_cmd }}"
       delegate_to: "{{ vcenter_hostname }}"
+      ignore_unreachable: true
       register: modify_user_group_result
 
     - name: "Display result of adding domain user to user group"
@@ -117,13 +126,21 @@
     - name: "Check the result of adding domain user to user group '{{ vcenter_domain_user_group }}'"
       ansible.builtin.assert:
         that:
-          - modify_user_group_result.rc is defined
-          - modify_user_group_result.rc == 0
+          - modify_user_group_result.unreachable is defined
+          - modify_user_group_result.failed is defined
+          - not modify_user_group_result.failed
         fail_msg: >-
           Failed to add domain user '{{ vcenter_domain_user_name }}@{{ vcenter_domain_name }}'
           to user group '{{ vcenter_domain_user_group }}'.
-          Return code is '{{ modify_user_group_result.rc | default("unknown") }}'.
-          Hit error '{{ modify_user_group_result.stderr | default("unknown") }}'
+          {%- if modify_user_group_result.rc is defined and modify_user_group_result.rc != 0 -%}
+              Return code is '{{ modify_user_group_result.rc }}'.
+          {%- endif -%}Hit error:
+          {%- if modify_user_group_result.stderr is defined -%}
+              {{ modify_user_group_result.stderr }}
+          {%- elif modify_user_group_result.msg is defined and modify_user_group_result.msg -%}
+              {{ modify_user_group_result.msg }}
+          {%- else -%}unknown
+          {%- endif -%}
         success_msg: "{{ modify_user_group_result.stdout | default(omit) }}"
   when:
     - vcenter_domain_user_op == "add"

--- a/linux/host_verify_saml_token/host_verify_saml_token.yml
+++ b/linux/host_verify_saml_token/host_verify_saml_token.yml
@@ -25,6 +25,18 @@
           vars:
             skip_test_no_vmtools: true
 
+        - name: "Check SSH connection to vCenter Server"
+          include_tasks: ../../common/test_ssh_connection.yml
+          vars:
+            ssh_server_ip: "{{ vcenter_hostname }}"
+
+        - name: "Block test case due to vCenter Server is not connectable via SSH"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
+            skip_reason: "Blocked"
+          when: not ssh_connect_success
+
         - name: "Skip test case for {{ guest_os_ansible_distribution }}"
           include_tasks: ../../common/skip_test_case.yml
           vars:

--- a/windows/host_verify_saml_token/host_verify_saml_token.yml
+++ b/windows/host_verify_saml_token/host_verify_saml_token.yml
@@ -26,6 +26,18 @@
             skip_test_no_vmtools: true
             create_current_test_folder: true
 
+        - name: "Check SSH connection to vCenter Server"
+          include_tasks: ../../common/test_ssh_connection.yml
+          vars:
+            ssh_server_ip: "{{ vcenter_hostname }}"
+
+        - name: "Block test case due to vCenter Server is not connectable via SSH"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
+            skip_reason: "Blocked"
+          when: not ssh_connect_success
+
         - name: "Skip test case for old ESXi server or VMware Tools"
           include_tasks: ../../common/skip_test_case.yml
           vars:


### PR DESCRIPTION
Added a task file to test SSH connection before starting host_verify_saml_token test. If SSH connection failed, test case is blocked.
Added ignore_unreachable for vCenter Server shell command so that unreachable error won't block the following test cases.

SSH success:
```
+-----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                        |
|                           | bitness='64'                              |
|                           | cpeString='cpe:/o:prolinux:prolinux:8.6'  |
|                           | distroAddlVersion='8.6'                   |
|                           | distroName='ProLinux'                     |
|                           | distroVersion='8.6'                       |
|                           | familyName='Linux'                        |
|                           | kernelVersion='4.18.0-372.9.1.el8.x86_64' |
|                           | prettyName='ProLinux 8.6'                 |
+-----------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:02:20)
+--------------------------------------------------+
| ID | Name                   | Status | Exec Time |
+--------------------------------------------------+
|  1 | host_verify_saml_token | Passed | 00:02:07  |
+--------------------------------------------------+
```

SSH fail at test setup:
```
TASK [Test SSH connection to 10.162.217.140] **********************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/test_ssh_connection.yml:14
fatal: [localhost -> 10.162.217.140]: UNREACHABLE! => {
    "changed": false,
    "msg": "Invalid/incorrect username/password. Skipping remaining 5 retries to prevent account lockout: Warning: Permanently added '10.162.217.140' (ED25519) to the list of known hosts.\r\n\nVMware vCenter Server\nRelease: 9.0.0.0\nVersion: 9.0.0.0\nBuild: 24528267\nType: vCenter Server with an embedded Platform Services Controller",
    "unreachable": true
}
...ignoring

TASK [Set result of testing SSH connection] ***********************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/test_ssh_connection.yml:21
ok: [localhost] => {
    "ansible_facts": {
        "ssh_connect_success": false
    },
    "changed": false
}

TASK [Block test case due to vCenter Server is not connectable via SSH] *******************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/linux/host_verify_saml_token/host_verify_saml_token.yml:33
included: /home/qiz/workspace/ansible-vsphere-gos-validation/common/skip_test_case.yml for localhost

TASK [Validate test result] ***************************************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/skip_test_case.yml:14
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [Skip testcase: host_verify_saml_token, reason: Blocked] *****************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/skip_test_case.yml:21
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Test case host_verify_saml_token is blocked because SSH connection to vCenter Server failed."
}
```

SSH unreachable during tests:
```
TASK [Check the result of managing domain user 'vcuser_20250122081619@vsphere.local'] *****************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/vcenter_manage_domain_user.yml:86
fatal: [localhost]: FAILED! => {
    "assertion": "manage_domain_user_result.unreachable is undefined",
    "changed": false,
    "evaluated_to": false,
    "msg": "Failed to add domain user 'vcuser_20250122081619@vsphere.local'.Hit error:Invalid/incorrect username/password. Skipping remaining 5 retries to prevent account lockout: Warning: Permanently added '10.162.217.140' (ED25519) to the list of known hosts.\r\n\nVMware vCenter Server\nRelease: 9.0.0.0\nVersion: 9.0.0.0\nBuild: 24528267\nType: vCenter Server with an embedded Platform Services Controller."
}
```

domain user cmd failed:
```
TASK [Check the result of managing domain user 'vcuser_20250122081619@vsphere.local'] *****************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/vcenter_manage_domain_user.yml:87
fatal: [localhost]: FAILED! => {
    "assertion": "not manage_domain_user_result.failed",
    "changed": false,
    "evaluated_to": false,
    "msg": "Failed to add domain user 'vcuser_20250122081619@vsphere.local'.Return code is '68'.Hit error:dir-cli failed, error= Entry already exists 9706"
}
```