### PR TITLE
[Linux] Disable ProLinux online repos because they are not reachable

### DIFF
--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -108,25 +108,6 @@
               - name: "ol{{ guest_os_ansible_distribution_major_ver }}_{{ oraclelinux_uek_release }}"
                 baseurl: "{{ oraclelinux_repo_url }}/{{ oraclelinux_uek_release }}/$basearch/"
 
-- name: "Set online repositories for ProLinux"
-  when: guest_os_ansible_distribution == "ProLinux"
-  block:
-    - name: "Set online repositories for ProLinux {{ guest_os_ansible_distribution_ver }}"
-      ansible.builtin.set_fact:
-        online_repos:
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}"
-            baseurl: "http://prolinux-repo.tmaxos.com/prolinux/7/os/$basearch/"
-      when: guest_os_ansible_distribution_major_ver | int == 7
-
-    - name: "Set online repositories for ProLinux {{ guest_os_ansible_distribution_ver }}"
-      ansible.builtin.set_fact:
-        online_repos:
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_BaseOS"
-            baseurl: "http://prolinux-repo.tmaxos.com/prolinux/$releasever/os/$basearch/BaseOS"
-          - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_AppStrem"
-            baseurl: "http://prolinux-repo.tmaxos.com/prolinux/$releasever/os/$basearch/AppStream"
-      when: guest_os_ansible_distribution_major_ver | int >= 8
-
 - name: "Set online repositories for {{ vm_guest_os_distribution }}"
   ansible.builtin.set_fact:
     online_repos:

--- a/linux/utils/disable_repo.yml
+++ b/linux/utils/disable_repo.yml
@@ -3,35 +3,27 @@
 ---
 # Disable a package reposiotory
 # Parameter
-#   guest_repo_list(Optional): A list of repo names to disable. By default, all repos will be disabled
+#   repo_name: (Optional)The repo name to disable. By default, all repos will be disabled
 
-- name: "Get enabled repositories list on {{ vm_guest_os_distribution }}"
-  when:
-    - guest_os_family == 'RedHat'
-    - guest_repo_list is undefined
-  block:
-    - name: "List all yum repositories"
-      ansible.builtin.shell: "yum repolist 2>/dev/null | grep -v 'repo id.*repo name' | awk '{print $1}'"
-      delegate_to: "{{ vm_guest_ip }}"
-      ignore_errors: true
-      register: yum_repo_list_result
-
-    - name: "Set fact of the repo list"
-      ansible.builtin.set_fact:
-        guest_repo_list: "{{ yum_repo_list_result.stdout_lines | select }}"
-      when:
-        - not yum_repo_list_result.failed
-        - yum_repo_list_result.stdout_lines
-
+# Disable all repositories and ignore errors if no repo exists
 - name: "Disable all repositories"
-  when: guest_repo_list is undefined or guest_repo_list | length == 0
+  when: repo_name is undefined or not repo_name
   block:
     # RHEL-like OS
     - name: "Disable all yum repositories"
       ansible.builtin.shell: "sed -i 's/enabled *= *1/enabled=0/' /etc/yum.repos.d/*.repo"
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
-      when: guest_os_family == 'VMware Photon OS'
+      when:
+        - guest_os_family in ['RedHat', 'VMware Photon OS']
+        - guest_os_ansible_distribution != 'ProLinux'
+
+    # ProLinux
+    - name: "Remove all yum repositories"
+      ansible.builtin.shell: "rm /etc/yum.repos.d/*.repo"
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: true
+      when: guest_os_ansible_distribution == 'ProLinux'
 
     # SUSE
     - name: "Disable all zypper repositories"
@@ -40,35 +32,31 @@
       ignore_errors: true
       when: guest_os_family == "Suse"
 
-- name: "Disable guest OS repositories"
-  when: guest_repo_list | length > 0
+- name: "Disable repository {{ repo_name }}"
+  when: repo_name is defined and repo_name
   block:
     # RHEL-like OS
-    - name: "Disable repositories for {{ vm_guest_os_distribution }}"
+    - name: "Disable repository {{ repo_name }} for {{ vm_guest_os_distribution }}"
       when: guest_os_family == 'RedHat'
       block:
-        - name: "Disable yum repository"
-          ansible.builtin.command: "yum-config-manager --disable {{ item }}"
+        - name: "Disable yum repository {{ repo_name }}"
+          ansible.builtin.command: "yum-config-manager --disable {{ repo_name }}"
           delegate_to: "{{ vm_guest_ip }}"
-          with_items: "{{ guest_repo_list }}"
           when: guest_os_ansible_pkg_mgr == "yum"
 
-        - name: "Disable yum repository"
-          ansible.builtin.command: "dnf config-manager --set-disabled {{ item }}"
+        - name: "Disable yum repository {{ repo_name }}"
+          ansible.builtin.command: "dnf config-manager --set-disabled {{ repo_name }}"
           delegate_to: "{{ vm_guest_ip }}"
-          with_items: "{{ guest_repo_list }}"
           when: guest_os_ansible_pkg_mgr in ["dnf", "dnf5"]
 
     # VMware Photon OS
-    - name: "Disable yum repository {{ item }}"
-      ansible.builtin.shell: "grep -l '\\[{{ item }}\\]' /etc/yum.repos.d/*.repo | xargs sed -i 's/enabled *= *1/enabled=0/'"
+    - name: "Disable yum repository {{ repo_name }}"
+      ansible.builtin.shell: "grep -l '\\[{{ repo_name }}\\]' /etc/yum.repos.d/*.repo | xargs sed -i 's/enabled *= *1/enabled=0/'"
       delegate_to: "{{ vm_guest_ip }}"
-      with_items: "{{ guest_repo_list }}"
       when: guest_os_ansible_distribution == 'VMware Photon OS'
 
     # SUSE
-    - name: "Disable zypper repository {{ item }}"
-      ansible.builtin.command: "zypper mr -d {{ item }}"
+    - name: "Disable zypper repository {{ repo_name }}"
+      ansible.builtin.command: "zypper mr -d {{ repo_name }}"
       delegate_to: "{{ vm_guest_ip }}"
-      with_items: "{{ guest_repo_list }}"
       when: guest_os_family == "Suse"

--- a/linux/utils/disable_repo.yml
+++ b/linux/utils/disable_repo.yml
@@ -3,16 +3,35 @@
 ---
 # Disable a package reposiotory
 # Parameter
-#   repo_name: (Optional)The repo name to disable. By default, all repos will be disabled
+#   guest_repo_list(Optional): A list of repo names to disable. By default, all repos will be disabled
 
-# Disable all repositories and ignore errors if no repo exists
-- block:
+- name: "Get enabled repositories list on {{ vm_guest_os_distribution }}"
+  when:
+    - guest_os_family == 'RedHat'
+    - guest_repo_list is undefined
+  block:
+    - name: "List all yum repositories"
+      ansible.builtin.shell: "yum repolist 2>/dev/null | grep -v 'repo id.*repo name' | awk '{print $1}'"
+      delegate_to: "{{ vm_guest_ip }}"
+      ignore_errors: true
+      register: yum_repo_list_result
+
+    - name: "Set fact of the repo list"
+      ansible.builtin.set_fact:
+        guest_repo_list: "{{ yum_repo_list_result.stdout_lines | select }}"
+      when:
+        - not yum_repo_list_result.failed
+        - yum_repo_list_result.stdout_lines
+
+- name: "Disable all repositories"
+  when: guest_repo_list is undefined or guest_repo_list | length == 0
+  block:
     # RHEL-like OS
     - name: "Disable all yum repositories"
       ansible.builtin.shell: "sed -i 's/enabled *= *1/enabled=0/' /etc/yum.repos.d/*.repo"
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
-      when: guest_os_family in ['RedHat', 'VMware Photon OS']
+      when: guest_os_family == 'VMware Photon OS'
 
     # SUSE
     - name: "Disable all zypper repositories"
@@ -20,32 +39,36 @@
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
       when: guest_os_family == "Suse"
-  when: repo_name is undefined or not repo_name
 
-# Disable repo with name {{ repo_name }}
-- block:
+- name: "Disable guest OS repositories"
+  when: guest_repo_list | length > 0
+  block:
     # RHEL-like OS
-    - block:
-        - name: "Disable yum repository {{ repo_name }}"
-          ansible.builtin.command: "yum-config-manager --disable {{ repo_name }}"
+    - name: "Disable repositories for {{ vm_guest_os_distribution }}"
+      when: guest_os_family == 'RedHat'
+      block:
+        - name: "Disable yum repository"
+          ansible.builtin.command: "yum-config-manager --disable {{ item }}"
           delegate_to: "{{ vm_guest_ip }}"
+          with_items: "{{ guest_repo_list }}"
           when: guest_os_ansible_pkg_mgr == "yum"
 
-        - name: "Disable yum repository {{ repo_name }}"
-          ansible.builtin.command: "dnf config-manager --set-disabled {{ repo_name }}"
+        - name: "Disable yum repository"
+          ansible.builtin.command: "dnf config-manager --set-disabled {{ item }}"
           delegate_to: "{{ vm_guest_ip }}"
+          with_items: "{{ guest_repo_list }}"
           when: guest_os_ansible_pkg_mgr in ["dnf", "dnf5"]
-      when: guest_os_family == 'RedHat'
 
     # VMware Photon OS
-    - name: "Disable yum repository {{ repo_name }}"
-      ansible.builtin.shell: "grep -l '\\[{{ repo_name }}\\]' /etc/yum.repos.d/*.repo | xargs sed -i 's/enabled *= *1/enabled=0/'"
+    - name: "Disable yum repository {{ item }}"
+      ansible.builtin.shell: "grep -l '\\[{{ item }}\\]' /etc/yum.repos.d/*.repo | xargs sed -i 's/enabled *= *1/enabled=0/'"
       delegate_to: "{{ vm_guest_ip }}"
+      with_items: "{{ guest_repo_list }}"
       when: guest_os_ansible_distribution == 'VMware Photon OS'
 
     # SUSE
-    - name: "Disable zypper repository {{ repo_name }}"
-      ansible.builtin.command: "zypper mr -d {{ repo_name }}"
+    - name: "Disable zypper repository {{ item }}"
+      ansible.builtin.command: "zypper mr -d {{ item }}"
       delegate_to: "{{ vm_guest_ip }}"
+      with_items: "{{ guest_repo_list }}"
       when: guest_os_family == "Suse"
-  when: repo_name is defined and repo_name

--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -84,11 +84,11 @@
             - name: "Add a local repo from ISO image for {{ guest_os_ansible_distribution }}"
               include_tasks: ../utils/add_local_dvd_repo.yml
               when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'Rocky',
-                                                'AlmaLinux', 'openSUSE Leap']
+                                                'AlmaLinux', 'openSUSE Leap', 'ProLinux']
 
             - name: "Add known online repos for other Linux OS"
               include_tasks: ../utils/add_official_online_repo.yml
-              when: guest_os_ansible_distribution not in ['SLES', 'SLED', 'RedHat']
+              when: guest_os_ansible_distribution not in ['SLES', 'SLED', 'RedHat', 'ProLinux']
 
     - name: "{{ package_manage_op }} packages on {{ guest_os_ansible_distribution }}"
       when: guest_os_ansible_distribution in ["VMware Photon OS", "FreeBSD"]


### PR DESCRIPTION
Removed ProLinux online repos and changed to install packages from ProLinux ISO only.

```
TASK [Install latest packages on ProLinux 8.6] ***************************************************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/linux/utils/install_uninstall_package.yml:153
changed: [localhost -> ] => {
    "changed": true,
    "cmd": "dnf install -y python3-rpm",
    "delta": "0:00:06.324375",
    "end": "2025-02-07 00:58:10.186537",
    "invocation": {
        "module_args": {
            "_raw_params": "dnf install -y python3-rpm",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true
        }
    },
    "msg": "",
    "rc": 0,
    "start": "2025-02-07 00:58:03.862162",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "ProLinux-8.6-dvd-AppStream                       17 MB/s | 6.7 MB     00:00    \nProLinux-8.6-dvd-BaseOS                          33 MB/s | 2.1 MB     00:00    \nLast metadata expiration check: 0:00:01 ago on Fri 07 Feb 2025 12:58:07 AM EST.\nPackage python3-rpm-4.14.3-23.el8.x86_64 is already installed.\nDependencies resolved.\nNothing to do.\nComplete!",
    "stdout_lines": [
        "ProLinux-8.6-dvd-AppStream                       17 MB/s | 6.7 MB     00:00    ",
        "ProLinux-8.6-dvd-BaseOS                          33 MB/s | 2.1 MB     00:00    ",
        "Last metadata expiration check: 0:00:01 ago on Fri 07 Feb 2025 12:58:07 AM EST.",
        "Package python3-rpm-4.14.3-23.el8.x86_64 is already installed.",
        "Dependencies resolved.",
        "Nothing to do.",
        "Complete!"
    ]
}
```

```
+-----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                        |
|                           | bitness='64'                              |
|                           | cpeString='cpe:/o:prolinux:prolinux:8.6'  |
|                           | distroAddlVersion='8.6'                   |
|                           | distroName='ProLinux'                     |
|                           | distroVersion='8.6'                       |
|                           | familyName='Linux'                        |
|                           | kernelVersion='4.18.0-372.9.1.el8.x86_64' |
|                           | prettyName='ProLinux 8.6'                 |
+-----------------------------------------------------------------------+

Test Results (Total: 2, Passed: 2, Elapsed Time: 00:08:15)
+--------------------------------------------------+
| ID | Name                   | Status | Exec Time |
+--------------------------------------------------+
|  1 | check_inbox_driver     | Passed | 00:02:02  |
|  2 | ovt_verify_pkg_install | Passed | 00:05:54  |
+--------------------------------------------------+
```