### PR TITLE
[Plugin] Add task reason to extracted error message

### DIFF
--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -41,7 +41,7 @@ def extract_error_msg(json_obj):
     message = ''
     try:
         for key, value in json_obj.items():
-            if key != 'msg':
+            if key not in ['msg', 'reason']:
                 continue
 
             if isinstance(value, str):
@@ -59,7 +59,6 @@ def extract_error_msg(json_obj):
                         message += '\n' + json_obj['module_stderr'].strip()
                     elif 'module_stdout' in json_obj and str(json_obj['module_stdout']) != '':
                         message += '\n' + json_obj['module_stdout'].strip()
-
             elif isinstance(value, list):
                 message += '\n'.join(value)
             elif isinstance(value, dict):


### PR DESCRIPTION
This change is to print reason in error message.

Some failed task result only has 'reason' as below, which led to error message is empty
```
2025-02-13 11:40:22,013 | TASK [localhost][Get SSH public key from localhost] ********
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/tests/unit_tests/test_rebuild_iso.yml:27
fatal: [localhost]: FAILED! => {
    "reason": "Could not find or access '/home/qiz/workspace/ansible-vsphere-gos-validation/tests/utils/get_local_ssh_public_key.yml' on the Ansible Controller."
}
error message:
```
With this change, we can extract error message as:
```
error message:
Could not find or access '/home/qiz/workspace/ansible-vsphere-gos-validation/tests/utils/get_local_ssh_public_key.yml' on the Ansible Controller.
```

Some failed task result has both of 'msg' and 'reason' as below:
```
2025-02-08 02:54:02,008 | Failed at Play [01_deploy_vm] ******************************

2025-02-08 02:54:02,008 | TASK [01_deploy_vm][Datastore file operation] **************
task path: /home/worker/workspace/Ansible_FreeBSD_13.x_64bit_80GA_LSILOGICSAS_VMXNET3_EFI-30/ansible-vsphere-gos-validation/common/esxi_check_delete_datastore_file.yml:28
fatal: [localhost]: FAILED! => {
    "changed": false,
    "errno": null,
...
    "msg": "Failed to query for file 'FreeBSD-13.5-BETA1-amd64-dvd1-20250208024143.iso'",
    "path": "FreeBSD-13.5-BETA1-amd64-dvd1-20250208024143.iso",
    "reason": "Internal Server Error",
    "size": null,
    "state": "absent",
    "status": 500,
    "url": "https://x.x.x.x/folder/FreeBSD-13.5-BETA1-amd64-dvd1-20250208024143.iso?dsName=datastore2&dcPath=ansible_test"
}
error message:
Failed to query for file 'FreeBSD-13.5-BETA1-amd64-dvd1-20250208024143.iso'
```

With this change, above task's error message will be like:
```
error message:
Failed to query for file 'FreeBSD-13.5-BETA1-amd64-dvd1-20250208024143.iso'
Internal Server Error
```