### PR TITLE
[Linux] Support SLES 16 automation testing on existing VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| SUSE Linux Enterprise 15 SP3, SP4, SP5, SP6, SP7       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise 15 SP3 ~ SP7                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | SUSE Linux Enterprise 16                               |                                  |                          | :heavy_check_mark:                 |
 | VMware Photon OS 3.0, 4.0, 5.0                         | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Ubuntu 20.04 and later                                 | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ This project supports below scenarios for end-to-end guest operating system vali
 | Oracle Linux 7.x, 8.x, 9.x                             | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Rocky Linux 8.x, 9.x                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | AlmaLinux 8.x, 9.x                                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| SUSE Linux Enterprise 15 SP3 and later                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise 15 SP3, SP4, SP5, SP6, SP7       | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise 16                               |                                  |                          | :heavy_check_mark:                 |
 | VMware Photon OS 3.0, 4.0, 5.0                         | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Ubuntu 20.04 and later                                 | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Flatcar 2592.0.0 and later                             |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |

--- a/linux/network_device_ops/hot_add_network_adapter.yml
+++ b/linux/network_device_ops/hot_add_network_adapter.yml
@@ -8,6 +8,7 @@
   vars:
     dmesg_options: '-c'
     dmesg_output_file_name: 'dmesg_before_nic_hotadd.log'
+    dmesg_no_log: true
 
 - name: "Hot add a new network adapter to VM"
   include_tasks: ../../common/vm_add_network_adapter.yml

--- a/linux/open_vm_tools/check_inbox_drivers_unchanged.yml
+++ b/linux/open_vm_tools/check_inbox_drivers_unchanged.yml
@@ -5,49 +5,20 @@
 # open-vm-tools from source. Inbox drivers to be checked include vmxnet3,
 # vmw_pvscsi, vmw_balloon.
 #
-- name: "Get system lib directory"
-  include_tasks: ../utils/get_file_real_path.yml
-  vars:
-    src_file: "/lib"
-
-- name: "Set fact of guest OS inbox drivers directory path"
-  ansible.builtin.set_fact:
-    guest_inbox_drivers_dir: "{{ file_real_path }}/modules/{{ guest_os_ansible_kernel }}/kernel/drivers"
-
-- name: "Get guest OS inbox drivers' filenames"
-  ansible.builtin.shell: "modinfo -F filename {{ item }}"
-  ignore_errors: true
+- name: "Get guest OS inbox drivers' files after installing open-vm-tools from source"
+  ansible.builtin.shell: "modinfo -F filename vmxnet3 vmw_pvscsi vmw_balloon"
   delegate_to: "{{ vm_guest_ip }}"
-  with_items:
-    - vmxnet3
-    - vmw_pvscsi
-    - vmw_balloon
-  register: modinfo_results
-
-- name: "Check results of getting guest OS inbox drivers' filenames"
-  ansible.builtin.assert:
-    that:
-      - modinfo_results.results is defined
-      - modinfo_results.results | length == 3
-    fail_msg: "Failed to get guest OS inbox drivers' filenames"
-
-- name: "Set facts inbox drivers paths after installing open-vm-tools from source"
-  ansible.builtin.set_fact:
-    guest_inbox_drivers: "{{ dict(_keys | zip(_values)) }}"
-  vars:
-    _keys: "{{ modinfo_results.results | map(attribute='item') }}"
-    _values: "{{ modinfo_results.results | map(attribute='stdout', default='') | flatten }}"
-
-- name: "Display inbox drivers paths after installing open-vm-tools from source"
-  ansible.builtin.debug: var=guest_inbox_drivers
+  register: guest_inbox_drivers_after
 
 - name: "Check guest OS inbox drivers are not changed"
   ansible.builtin.assert:
     that:
-      - guest_inbox_drivers['vmxnet3'] is match(guest_inbox_drivers_dir + '/net/vmxnet3/vmxnet3.*')
-      - guest_inbox_drivers['vmw_pvscsi'] is match(guest_inbox_drivers_dir + '/scsi/vmw_pvscsi.*')
-      - guest_inbox_drivers['vmw_balloon'] is match(guest_inbox_drivers_dir + '/misc/vmw_balloon.*')
+      - guest_inbox_drivers_before.stdout_lines is defined
+      - guest_inbox_drivers_after.stdout_lines is defined
+      - guest_inbox_drivers_after.stdout_lines | length == 3
+      - guest_inbox_drivers_after.stdout_lines == guest_inbox_drivers_before.stdout_lines
     fail_msg: >-
-      Inbox drivers' paths should not be changed after installing open-vm-tools from source,
-      but now at least one of them is changed: {{ guest_inbox_drivers }}
+      At least one of inbox drivers' paths has been changed since installing open-vm-tools from source.
+      Before installing open-vm-tools, inbox drivers are {{ guest_inbox_drivers_before.stdout_lines | default([]) }}
+      After installing open-vm-tools, inbox drivers are {{ guest_inbox_drivers_after.stdout_lines | default([]) }}
     success_msg: "Inbox drivers' paths are not changed after installing open-vm-tools from source."

--- a/linux/open_vm_tools/check_inbox_drivers_unchanged.yml
+++ b/linux/open_vm_tools/check_inbox_drivers_unchanged.yml
@@ -5,9 +5,14 @@
 # open-vm-tools from source. Inbox drivers to be checked include vmxnet3,
 # vmw_pvscsi, vmw_balloon.
 #
+- name: "Get system lib directory"
+  include_tasks: ../utils/get_file_real_path.yml
+  vars:
+    src_file: "/lib"
+
 - name: "Set fact of guest OS inbox drivers directory path"
   ansible.builtin.set_fact:
-    guest_inbox_drivers_dir: "/lib/modules/{{ guest_os_ansible_kernel }}/kernel/drivers"
+    guest_inbox_drivers_dir: "{{ file_real_path }}/modules/{{ guest_os_ansible_kernel }}/kernel/drivers"
 
 - name: "Get guest OS inbox drivers' filenames"
   ansible.builtin.shell: "modinfo -F filename {{ item }}"

--- a/linux/open_vm_tools/check_ovt_plugins_loaded.yml
+++ b/linux/open_vm_tools/check_ovt_plugins_loaded.yml
@@ -4,7 +4,7 @@
 # Check Linux open-vm-tools common and vmsvc plugins installed from source are loaded
 #
 - name: "Get loaded open-vm-tools plugins"
-  ansible.builtin.shell: "lsof 2>/dev/null | grep '{{ ovt_install_prefix }}/lib/open-vm-tools/plugins' | awk '{print $NF}' | sort | uniq"
+  ansible.builtin.shell: "lsof 2>/dev/null | grep -o '{{ ovt_install_prefix }}/lib/open-vm-tools/plugins/.*' | awk '{print $1}' | sort | uniq"
   register: ovt_plugins_load_result
   ignore_errors: true
   delegate_to: "{{ vm_guest_ip }}"

--- a/linux/open_vm_tools/install_ovt_from_package.yml
+++ b/linux/open_vm_tools/install_ovt_from_package.yml
@@ -27,3 +27,26 @@
       Failed to install open-vm-tools by executing command:
       {{ package_install_cmd }} {{' '.join(ovt_packages) }}
       Caught error: {{ ovt_install_result.stderr | default('') }}
+
+# Workaround for SLES 16, in which vmtoolsd and vgauthd services
+# are disabled after reinstall.
+# Issue was tracked in https://bugzilla.suse.com/show_bug.cgi?id=1237180
+- name: "Enable VMware Tools services"
+  when:
+    - guest_os_ansible_distribution == 'SLES'
+    - guest_os_ansible_distribution_major_ver | int == 16
+  block:
+    - name: "Enable open-vm-tools service"
+      include_tasks: ../utils/service_operation.yml
+      vars:
+        service_name: "{{ ovt_service_name }}"
+        service_enabled: true
+        service_state: "started"
+
+    - name: "Enable VGAuthService service"
+      include_tasks: ../utils/service_operation.yml
+      vars:
+        service_name: "{{ vgauth_service_name }}"
+        service_enabled: true
+        service_state: "started"
+      when: vgauth_service_name

--- a/linux/open_vm_tools/install_ovt_from_source.yml
+++ b/linux/open_vm_tools/install_ovt_from_source.yml
@@ -31,6 +31,11 @@
     fail_msg: "Missing dependencies for installing open-vm-tools from source on {{ vm_guest_os_distribution }}"
     success_msg: "Dependencies to be installed for open-vm-tools: {{ ovt_dependencies }}"
 
+- name: "Get guest OS inbox drivers' files before installing open-vm-tools from source"
+  ansible.builtin.shell: "modinfo -F filename vmxnet3 vmw_pvscsi vmw_balloon"
+  delegate_to: "{{ vm_guest_ip }}"
+  register: guest_inbox_drivers_before
+
 - name: "Install open-vm-tools build dependencies"
   include_tasks: ../utils/install_uninstall_package.yml
   vars:

--- a/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
@@ -64,9 +64,12 @@ dependencies:
   - valgrind-devel
   - xmlsec1-devel
   - xmlsec1-openssl-devel
+  {% if guest_os_ansible_distribution_major_ver | int < 16 -%}
   - xorg-x11-devel
+  {%- endif -%}
 {% endif %}
-{% if guest_os_ansible_distribution == 'Ubuntu' and guest_os_ansible_distribution_ver == '24.04' %}
+
+{% if guest_os_ansible_distribution == "Ubuntu" and guest_os_ansible_distribution_ver == "24.04" %}
 configure_options:
   - "--without-x"
 {% endif %}

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -30,6 +30,16 @@
     - guest_os_python_version is version('3.0.0', '>=')
     - guest_os_ansible_pkg_mgr is search('yum|dnf')
 
+# Install python311-rpm on SUSE 16
+- name: "Install 'python311-rpm' on {{ guest_os_ansible_distribution }}"
+  include_tasks: ../utils/install_uninstall_package.yml
+  vars:
+    package_list: ["python311-rpm"]
+    package_state: "latest"
+  when:
+    - guest_os_family == "Suse"
+    - guest_os_ansible_distribution_major_ver | int == 16
+
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
   block:
@@ -59,7 +69,9 @@
         package_state: "latest"
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
-  when: guest_os_family == "Suse"
+  when:
+    - guest_os_family == "Suse"
+    - guest_os_ansible_distribution_major_ver | int < 16
   block:
     - name: "Check 'PackageKit' service state"
       include_tasks: ../utils/get_service_info.yml

--- a/linux/utils/collect_dmesg.yml
+++ b/linux/utils/collect_dmesg.yml
@@ -7,6 +7,7 @@
 #   dmesg_options: the dmesg command options
 #   dmesg_output_file_name (optional): the file name for saving dmesg output in test case log folder
 #   dmesg_ignore_errors (optional): ignore errors when executing dmesg. Default is false.
+#   dmesg_no_log (optional): true to hide output on console. Default is false.
 # Return:
 #   dmesg_output_file_path: the file path to save dmesg output at localhost
 #
@@ -21,13 +22,13 @@
   ignore_errors: "{{ dmesg_ignore_errors | default(false) }}"
   delegate_to: "{{ vm_guest_ip }}"
   register: dmesg_cmd_result
+  no_log: "{{ dmesg_no_log | default(false) }}"
 
 - name: "Save dmesg output to local file in test case log folder"
   when:
     - dmesg_cmd_result.rc is defined
     - dmesg_cmd_result.rc == 0
     - dmesg_cmd_result.stdout is defined
-    - dmesg_cmd_result.stdout
   block:
     # Set a default dmesg output file with execution timestamp
     - name: "Set default file name for saving the dmesg command output"
@@ -48,3 +49,7 @@
       when:
         - save_dmesg_result.failed is defined
         - not save_dmesg_result.failed
+
+    - name: "Display the demst output file path"
+      ansible.builtin.debug:
+        msg: "The output of dmesg is saved into {{ dmesg_output_file_path }}"

--- a/linux/utils/disable_firewall.yml
+++ b/linux/utils/disable_firewall.yml
@@ -15,12 +15,22 @@
     firewall_service_name: "ufw.service"
   when: guest_os_ansible_distribution == "Ubuntu"
 
-- name: "Stop and disable firewall service"
-  include_tasks: service_operation.yml
-  vars:
-    service_name: "{{ firewall_service_name }}"
-    service_enabled: false
-    service_state: "stopped"
+- name: "Check firewall service status and disable it"
   when:
     - firewall_service_name is defined
     - firewall_service_name
+  block:
+    - name: "Get firewall service status"
+      include_tasks: get_service_info.yml
+      vars:
+        service_name: "{{ firewall_service_name }}"
+
+    - name: "Stop and disable firewall service"
+      include_tasks: service_operation.yml
+      vars:
+        service_name: "{{ firewall_service_name }}"
+        service_enabled: false
+        service_state: "stopped"
+      when:
+        - service_info.state is defined
+        - service_info.state in ['active', 'running']

--- a/linux/utils/get_file_real_path.yml
+++ b/linux/utils/get_file_real_path.yml
@@ -18,10 +18,10 @@
 
 - name: "Get the source file path of symlink {{ src_file }}"
   ansible.builtin.set_fact:
-    file_real_path: "{{ stat_file_result.stat.lnk_source }}"
+    file_real_path: "{{ guest_file_stat.lnk_source }}"
   when:
     - guest_file_stat.islnk | default(false)
-    - guest_file_stat.stat.lnk_source is defined
+    - guest_file_stat.lnk_source is defined
 
 - name: "Print the real path of {{ src_file }}"
   ansible.builtin.debug: var=file_real_path

--- a/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
+++ b/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
@@ -26,7 +26,7 @@
     disk_size_gb: "{{ new_disk_size_gb }}"
     ctrl_number: "{{ new_ctrl_number }}"
     unit_number: "{{ new_unit_number }}"
-  when: add_new_controller
+  when: new_disk_ctrl_state == "new"
 
 - name: "Hot add a new disk on an existing {{ new_disk_ctrl_type }} controller"
   include_tasks: ../../common/vm_hot_add_remove_disk.yml
@@ -36,9 +36,15 @@
     disk_size_gb: "{{ new_disk_size_gb }}"
     ctrl_number: "{{ new_ctrl_number }}"
     unit_number: "{{ new_unit_number }}"
-  when: not add_new_controller
+  when: new_disk_ctrl_state == "existing"
 
-- name: "Wait for hot-added disk being present in guest OS"
+- name: "Collect dmesg after hot adding a disk to {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller"
+  include_tasks: ../utils/collect_dmesg.yml
+  vars:
+    dmesg_options: "-c"
+    dmesg_output_file_name: "dmesg_after_{{ new_disk_ctrl_state }}_ctrl_disk_hot_add.log"
+
+- name: "Wait for hot-added disk to {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller being present in guest OS"
   include_tasks: wait_device_list_changed.yml
   vars:
     device_list_before_change: "{{ guest_disk_list_before_hotadd }}"
@@ -60,7 +66,8 @@
   ansible.builtin.assert:
     that:
       - guest_disk_list_after_hotadd | difference(guest_disk_list_before_hotadd) | length == 1
-    fail_msg: "Guest OS failed to recognize the new hot-added {{ new_disk_ctrl_type }} disk"
+    fail_msg: "Guest OS failed to recognize the new disk hot added to {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller"
+    success_msg: "Guest OS successfully recognized the new disk hot added to {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller"
 
 - name: "Set fact of the new guest disk info"
   ansible.builtin.set_fact:
@@ -129,6 +136,12 @@
     unit_number: "{{ new_unit_number }}"
     disk_controller_type: "{{ new_disk_ctrl_type }}"
 
+- name: "Collect dmesg after hot removing the disk from the {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller"
+  include_tasks: ../utils/collect_dmesg.yml
+  vars:
+    dmesg_options: "-c"
+    dmesg_output_file_name: "dmesg_after_{{ new_disk_ctrl_state }}_ctrl_disk_hot_remove.log"
+
 - name: "Wait for disk being absent in guest OS"
   include_tasks: wait_device_list_changed.yml
   vars:
@@ -152,4 +165,5 @@
   ansible.builtin.assert:
     that:
       - guest_disk_list_before_hotremove | difference(guest_disk_list_after_hotremove) | length == 1
-    fail_msg: "After disk hot-remove, the Guest OS still can see it"
+    fail_msg: "After the disk hot removed from {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller, it is still present in guest OS."
+    success_msg: "After the disk hot removed from {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller, it is absent in guest OS."

--- a/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
+++ b/linux/vhba_hot_add_remove/hot_add_remove_disk.yml
@@ -43,6 +43,7 @@
   vars:
     dmesg_options: "-c"
     dmesg_output_file_name: "dmesg_after_{{ new_disk_ctrl_state }}_ctrl_disk_hot_add.log"
+    dmesg_no_log: true
 
 - name: "Wait for hot-added disk to {{ new_disk_ctrl_state }} {{ new_disk_ctrl_type }} controller being present in guest OS"
   include_tasks: wait_device_list_changed.yml
@@ -141,6 +142,7 @@
   vars:
     dmesg_options: "-c"
     dmesg_output_file_name: "dmesg_after_{{ new_disk_ctrl_state }}_ctrl_disk_hot_remove.log"
+    dmesg_no_log: true
 
 - name: "Wait for disk being absent in guest OS"
   include_tasks: wait_device_list_changed.yml

--- a/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
+++ b/linux/vhba_hot_add_remove/vhba_device_hot_add_remove.yml
@@ -102,15 +102,17 @@
       vars:
         dmesg_options: "-c"
         dmesg_output_file_name: "dmesg_before_vhba_test.log"
+        dmesg_no_log: true
 
     - name: "Clear /var/log/messages"
       ansible.builtin.shell: "cat /dev/null >/var/log/messages"
       changed_when: false
       delegate_to: "{{ vm_guest_ip }}"
 
-    - name: "Firstly hot add a new disk controller and disk at the same time"
+    # Firstly hot add a new disk controller and disk at the same time
+    - name: "Set fact of the new disk controller state to 'new'"
       ansible.builtin.set_fact:
-        add_new_controller: true
+        new_disk_ctrl_state: "new"
 
     - name: "Hot add a new controller and disk at the same time, test it and then hot remove the disk"
       include_tasks: hot_add_remove_disk.yml
@@ -128,9 +130,10 @@
         disk_controller_facts['disk_controller_data'][new_vhba_type] is undefined or
         disk_controller_facts['disk_controller_data'][new_vhba_type][new_ctrl_number | quote] is undefined
 
-    - name: "Then hot add a new disk on previously added controller {{new_disk_ctrl_type }}{{ new_ctrl_number }}"
+    # Then hot add a new disk on previously added controller
+    - name: "Set fact of the new disk controller state to 'existing'"
       ansible.builtin.set_fact:
-        add_new_controller: false
+        new_disk_ctrl_state: "existing"
 
     - name: "Hot add a new disk on the previous added controller, test it and then hot remove it"
       include_tasks: hot_add_remove_disk.yml


### PR DESCRIPTION
Changes in this fix is to support run testing on an existing SLES 16 SP0 VM.
1. Fixed open-vm-tools source install dependencies
2. Fixed inbox drivers checking after installing open-vm-tools from source
3. Fixed open-vm-tools plugins paths after installing open-vm-tools from source
4. Added workaround for disabled vmtoolsd and vgauthd after reinstalling open-vm-tools packages
5. Installed dependency 'python311-rpm' before testing starts.
6. Added firewall service checking before stopping and disabling it.
7. Added dmesg collection after hot adding or removing a hard disk.

Test results:
```
+------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                     |
|                           | bitness='64'                                           |
|                           | cpeString='cpe:/o:suse:sles:16.0'                      |
|                           | distroAddlVersion='16.0 Beta1'                         |
|                           | distroName='SLES'                                      |
|                           | distroVersion='16.0'                                   |
|                           | familyName='Linux'                                     |
|                           | kernelVersion='6.12.0-slfo.1.2-default'                |
|                           | prettyName='SUSE Linux Enterprise Server 16.0 (Beta1)' |
+------------------------------------------------------------------------------------+


Test Results (Total: 31, Passed: 24, Failed: 4, Skipped: 3, Elapsed Time: 03:08:53)
+--------------------------------------------------------------------------+
| ID | Name                                 |   Status         | Exec Time |
+--------------------------------------------------------------------------+
| 01 | check_inbox_driver                   |   Passed         | 00:01:49  |
| 02 | ovt_verify_src_install               |   Passed         | 00:31:14  |
| 03 | ovt_verify_status                    | * Not Applicable | 00:00:38  |
| 04 | vgauth_check_service                 | * Not Applicable | 00:00:40  |
| 05 | host_verify_saml_token               |   Passed         | 00:01:36  |
| 06 | check_ip_address                     |   Passed         | 00:00:48  |
| 07 | check_os_fullname                    |   Passed         | 00:01:03  |
| 08 | stat_balloon                         |   Passed         | 00:00:44  |
| 09 | stat_hosttime                        |   Passed         | 00:00:39  |
| 10 | device_list                          |   Passed         | 00:02:19  |
| 11 | power_operation_scripts              |   Passed         | 00:16:05  |
| 12 | check_quiesce_snapshot_custom_script |   Passed         | 00:01:06  |
| 13 | memory_hot_add_basic                 |   Passed         | 00:05:33  |
| 14 | cpu_hot_add_basic                    |   Passed         | 00:04:44  |
| 15 | cpu_multicores_per_socket            |   Passed         | 00:07:28  |
| 16 | check_efi_firmware                   |   Passed         | 00:00:43  |
| 17 | secureboot_enable_disable            |   Passed         | 00:04:14  |
| 18 | e1000e_network_device_ops            |   Passed         | 00:03:28  |
| 19 | vmxnet3_network_device_ops           |   Passed         | 00:02:35  |
| 20 | pvrdma_network_device_ops            |   Passed         | 00:09:24  |
| 21 | gosc_perl_dhcp                       | * Failed         | 00:17:12  |
| 22 | gosc_perl_staticip                   | * Failed         | 00:16:43  |
| 23 | gosc_cloudinit_dhcp                  | * Failed         | 00:01:24  |
| 24 | gosc_cloudinit_staticip              | * Failed         | 00:01:23  |
| 25 | paravirtual_vhba_device_ops          |   Passed         | 00:06:16  |
| 26 | lsilogic_vhba_device_ops             |   Passed         | 00:17:53  |
| 27 | lsilogicsas_vhba_device_ops          |   Passed         | 00:06:21  |
| 28 | sata_vhba_device_ops                 |   Passed         | 00:06:38  |
| 29 | nvme_vhba_device_ops                 |   Passed         | 00:06:23  |
| 30 | nvdimm_cold_add_remove               |   Passed         | 00:07:20  |
| 31 | ovt_verify_pkg_uninstall             | * Not Applicable | 00:00:37  |
+--------------------------------------------------------------------------+
```