### PR TITLE
[FreeBSD] Use GNOME as FreeBSD 64bit desktop environment

### DIFF
--- a/linux/deploy_vm/templates/post_install_scripts/freebsd_post_config.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/freebsd_post_config.sh
@@ -73,7 +73,7 @@ env ASSUME_ALWAYS_YES=YES pkg update -f > /dev/ttyu0
 # Different packages between the 32bit image and 64bit image
 packages_to_install="bash sudo wget curl e2fsprogs iozone lsblk"
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    packages_to_install="$packages_to_install xorg kde5 xf86-video-vmware sddm open-vm-tools xf86-input-vmmouse"
+    packages_to_install="$packages_to_install xorg gnome xf86-video-vmware open-vm-tools xf86-input-vmmouse"
 else
     packages_to_install="$packages_to_install open-vm-tools-nox11"
 fi
@@ -122,7 +122,7 @@ fi
 # Add new user. 
 {% if new_user is defined and new_user != 'root' %}
 printf "Adding new user {{ new_user }} ..." >/dev/ttyu0
-echo "{{ vm_password }}" | pw useradd {{ new_user }} -s /bin/sh -d /home/{{ new_user }} -m -g wheel -h 0
+echo "{{ vm_password }}" | pw useradd {{ new_user }} -c {{ new_user }} -s /bin/sh -d /home/{{ new_user }} -m -g wheel -h 0
 echo '{{ new_user }} ALL=(ALL:ALL) ALL' >> /usr/local/etc/sudoers
 echo "DONE" >/dev/ttyu0
 {% endif %}
@@ -154,20 +154,19 @@ printf "Enable ZFS ..." > /dev/ttyu0
 sysrc zfs_enable="YES"
 echo "DONE" >/dev/ttyu0
 
-# Configure KDE desktop
+# Configure GNOME desktop
 if [ "$machtype" == "amd64" ] || [ "$machtype" == "x86_64" ]; then
-    printf "Configuring KDE desktop ... " >/dev/ttyu0
+    printf "Configuring GNOME desktop ... " >/dev/ttyu0
     echo "proc      /proc       procfs  rw  0   0" >> /etc/fstab
+    sysrc hald_enable="YES"
     sysrc dbus_enable="YES"
-    sysrc sddm_enable="YES"
+    sysrc gnome_enable="YES"
+    sysrc moused_enable="YES"
+    sysrc gdm_enable="YES"
     echo "DONE" >/dev/ttyu0
 
-    # Autologin to desktop environment
-    printf "Enabling auto login for user {{ new_user }}... " >/dev/ttyu0
-    echo "[Autologin]" >> /usr/local/etc/sddm.conf
-    echo "User={{ new_user }}" >> /usr/local/etc/sddm.conf
-    echo "Session=plasma.desktop" >> /usr/local/etc/sddm.conf
-    echo "DONE" >/dev/ttyu0
+    # GNOME auto login config doesn't work well on FreeBSD.
+    # So skip it here
 fi
 
 if [ "$BSDINSTALL_LOG" != "" ] && [ -f $BSDINSTALL_LOG ]; then

--- a/linux/deploy_vm/wait_autoinstall_complete.yml
+++ b/linux/deploy_vm/wait_autoinstall_complete.yml
@@ -117,5 +117,5 @@
   vars:
     vm_wait_log_name: "{{ vm_serial_file_name }}"
     vm_wait_log_msg: "{{ autoinstall_complete_msg }}"
-    vm_wait_log_retries: "{{ 20 if unattend_installer == 'FreeBSD' else 120 }}"
+    vm_wait_log_retries: "{{ 50 if unattend_installer == 'FreeBSD' else 150 }}"
     vm_wait_log_delay: 30

--- a/linux/open_vm_tools/install_ovt_from_source.yml
+++ b/linux/open_vm_tools/install_ovt_from_source.yml
@@ -35,6 +35,7 @@
   ansible.builtin.shell: "modinfo -F filename vmxnet3 vmw_pvscsi vmw_balloon"
   delegate_to: "{{ vm_guest_ip }}"
   register: guest_inbox_drivers_before
+  when: guest_os_ansible_system == "linux"
 
 - name: "Install open-vm-tools build dependencies"
   include_tasks: ../utils/install_uninstall_package.yml

--- a/linux/utils/freebsd_update_fstab_with_uuid.yml
+++ b/linux/utils/freebsd_update_fstab_with_uuid.yml
@@ -35,7 +35,7 @@
           ansible.builtin.set_fact:
             freebsd_partitions_dict: >-
               {{
-                freebsd_geom_list | map(attribute='provider') | flatten |
+                freebsd_geom_list | selectattr('provider', 'defined') | map(attribute='provider') | flatten |
                 items2dict(key_name='name', value_name='config')
               }}
 


### PR DESCRIPTION
The KDE desktop fails to display correctly after the automatic installation of FreeBSD 13.5 64-bit. This issue arises because the sddm package, which was included in the ISO, was installed, but the kde5 package was not available on the ISO and had to be installed from the online repository. Additionally, several other dependent packages had version mismatches between the ISO and the online repository. These version differences caused the sddm greeter to fail, preventing the desktop from working properly.

Upon reviewing the FreeBSD 13.5 and 14.2 ISOs, it appears both contain GNOME and the gdm package. This means GNOME and gdm can be directly installed from the ISO, which may help avoid compatibility issues with package versions. Since the contents of FreeBSD ISOs can change between versions, there is no guarantee that GNOME and gdm will always be included. However, for the time being, using GNOME instead of KDE seems to be a more reliable choice.