### PR TITLE
Replace "include" with "include_tasks" in testcase power_operation_scripts

### DIFF
--- a/linux/power_operation_scripts/set_power_script.yml
+++ b/linux/power_operation_scripts/set_power_script.yml
@@ -13,7 +13,7 @@
       - "Start to test {{ power_script_type }} {{ power_script_op }} script"
 
 - name: "Set {{ power_script_type }} {{ power_script_op }} script"
-  include: set_power_script_{{ power_script_type }}.yml
+  include_tasks: set_power_script_{{ power_script_type }}.yml
   vars:
     power_cmd_op: "{{ power_script_op }}"
 

--- a/windows/power_operation_scripts/set_power_script.yml
+++ b/windows/power_operation_scripts/set_power_script.yml
@@ -10,7 +10,7 @@
       - "Start to test {{ power_script_type }} {{ power_script_op }} script"
 
 - name: "Set {{ power_script_type }} {{ power_script_op }} script"
-  include: set_power_script_{{ power_script_type }}.yml
+  include_tasks: set_power_script_{{ power_script_type }}.yml
   vars:
     power_cmd_op: "{{ power_script_op }}"
 


### PR DESCRIPTION
ansible.builtin.include has been removed and use include_tasks instead for testcase power_operation_scripts


Test passed:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/a288c12d-ef9b-4ed5-afb4-3115c0fd15db" />
