### PR TITLE
[FreeBSD] Enable auto login in slim for FreeBSD GNOME

### DIFF
--- a/linux/open_vm_tools/ovt_verify_status.yml
+++ b/linux/open_vm_tools/ovt_verify_status.yml
@@ -39,7 +39,7 @@
           include_tasks: ../utils/set_ovt_facts.yml
 
         - name: "Add user 'vmware' to check vmusr process"
-          when: "'open-vm-tools-desktop' in ovt_packages"
+          when: ovt_processes | length == 2
           block:
             - name: "Add new user 'vmware' if it doesn't exist"
               include_tasks: ../utils/add_user.yml

--- a/linux/utils/check_guest_os_gui.yml
+++ b/linux/utils/check_guest_os_gui.yml
@@ -56,7 +56,7 @@
             guest_os_with_gui: true
 
         - name: "Check display manager on {{ vm_guest_os_distribution }}"
-          ansible.builtin.shell: "grep -io -E '(gdm|lightdm|sddm|xdm)_enable=.*YES' /etc/rc.conf"
+          ansible.builtin.shell: "grep -io -E '^(gdm|slim|lightdm|sddm|xdm)_enable=.*YES' /etc/rc.conf"
           ignore_errors: true
           delegate_to: "{{ vm_guest_ip }}"
           register: check_dm_result

--- a/linux/utils/enable_auto_login.yml
+++ b/linux/utils/enable_auto_login.yml
@@ -16,40 +16,43 @@
     msg: "Can not enable auto login when guest_os_display_manager is {{ guest_os_display_manager | default('') }}."
   when: >
     guest_os_display_manager is undefined or
-    guest_os_display_manager not in ["gdm", "xdm", "lightdm", "lxdm", "sddm"]
+    guest_os_display_manager not in ["gdm", "xdm", "lightdm", "lxdm", "slim"]
 
-- name: "Set facts for enabling GNOME auto login"
+- name: "Set facts for enabling GDM auto login"
+  when: guest_os_display_manager == "gdm"
   block:
-    - name: "Set GNOME config file path in {{ guest_os_ansible_distribution }}"
+    - name: "Set GDM config file path in {{ vm_guest_os_distribution }}"
       ansible.builtin.set_fact:
         dm_conf_path: "/etc/gdm/custom.conf"
       when: guest_os_family == "RedHat"
 
-    - name: "Set GNOME config file path for Ubuntu"
+    - name: "Set GDM config file path for Ubuntu"
       ansible.builtin.set_fact:
         dm_conf_path: "/etc/gdm3/custom.conf"
       when: guest_os_ansible_distribution == "Ubuntu"
 
-    - name: "Set GNOME config file path for Debian"
+    - name: "Set GDM config file path for Debian"
       ansible.builtin.set_fact:
         dm_conf_path: "/etc/gdm3/daemon.conf"
       when: guest_os_ansible_distribution == "Debian"
+
+    - name: "Set GDM config file path for FreeBSD"
+      ansible.builtin.set_fact:
+        dm_conf_path: "/usr/local/etc/gdm/custom.conf"
+      when: guest_os_ansible_distribution == "FreeBSD"
 
     - name: "Set facts of autologin section and options"
       ansible.builtin.set_fact:
         dm_conf_section: "daemon"
         dm_autologin_options: {"AutomaticLogin": "{{ autologin_user }}", "AutomaticLoginEnable": "True"}
-  when: guest_os_display_manager == "gdm"
 
-- name: "Set facts for enabling XDM auto login"
-  block:
-    - name: "Set XDM config file path and options in {{ guest_os_ansible_distribution }}"
-      ansible.builtin.set_fact:
-        dm_conf_path: "/etc/sysconfig/displaymanager"
-        dm_conf_section: ""
-        dm_autologin_options: {"DISPLAYMANAGER_AUTOLOGIN": "{{ autologin_user }}"}
-      when: guest_os_family == "Suse"
-  when: guest_os_display_manager == "xdm"
+- name: "Set XDM config file path and options in {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    dm_conf_path: "/etc/sysconfig/displaymanager"
+    dm_autologin_options: {"DISPLAYMANAGER_AUTOLOGIN": "{{ autologin_user }}"}
+  when:
+    - guest_os_family == "Suse"
+    - guest_os_display_manager == "xdm"
 
 - name: "Set facts for enabling LightDM auto login"
   ansible.builtin.set_fact:
@@ -72,16 +75,19 @@
     dm_autologin_options:  {"autologin": "{{ autologin_user }}"}
   when: guest_os_display_manager == "lxdm"
 
-- name: "Set facts for enabling SDDM auto login"
+- name: "Set facts for enabling SLIM auto login"
   ansible.builtin.set_fact:
-    dm_conf_path: "/etc/sddm.conf.d/autologin.conf"
-    dm_conf_section: "Autologin"
-    dm_autologin_options:  {"User": "{{ autologin_user }}"}
-  when: guest_os_display_manager == "sddm"
+    dm_conf_path: "/usr/local/etc/slim.conf"
+    dm_autologin_options:  {"default_user": "{{ autologin_user }}", "auto_login": "yes"}
+  when:
+    - guest_os_display_manager == "slim"
+    - guest_os_ansible_distribution == "FreeBSD"
 
 - name: "Can not enable auto login when dm_conf_path is not set"
   ansible.builtin.fail:
-    msg: "Can not enable auto login because display manager config file is not set for {{ guest_os_display_manager }} display manager."
+    msg: >-
+      Can not enable auto login because the config file is not set for {{ guest_os_display_manager }} display manager
+      on {{ vm_guest_os_distribution }}
   when: not dm_conf_path
 
 - name: "Check display manager config file status"
@@ -94,25 +100,44 @@
     msg: "Can not enable auto login because display manager config file {{ dm_conf_path }} doesn't exist"
   when: not (guest_file_exists | bool)
 
-# Enable auto login
-- name: "Enable auto login for user {{ autologin_user }} in {{ guest_os_ansible_distribution }}"
-  block:
-    - include_tasks: ../../common/update_ini_style_file.yml
-      vars:
-        file_path: "{{ dm_conf_path }}"
-        section_name: "{{ dm_conf_section }}"
-        option_name: "{{ item.key }}"
-        option_value: "{{ item.value }}"
-      with_list: "{{ dm_autologin_options | dict2items }}"
-  when: guest_os_display_manager in ["gdm", "lightdm", "fly-dm", "lxdm", "sddm"]
+- name: "Enable auto login for user {{ autologin_user }} in {{ vm_guest_os_distribution }}"
+  include_tasks: ../../common/update_ini_style_file.yml
+  vars:
+    file_path: "{{ dm_conf_path }}"
+    section_name: "{{ dm_conf_section }}"
+    option_name: "{{ item.key }}"
+    option_value: "{{ item.value }}"
+  with_list: "{{ dm_autologin_options | dict2items }}"
+  when: guest_os_display_manager in ["gdm", "lightdm", "fly-dm", "lxdm"]
 
-# Enable auto login for SLES/SLED
-- name: "Enable auto login for user {{ autologin_user }} in {{ guest_os_ansible_distribution }}"
+- name: "Enable auto login for user {{ autologin_user }} in {{ vm_guest_os_distribution }}"
   include_tasks: replace_or_add_line_in_file.yml
   vars:
     file: "{{ dm_conf_path }}"
-    reg_exp: "DISPLAYMANAGER_AUTOLOGIN=.*"
-    line_content: "DISPLAYMANAGER_AUTOLOGIN={{ autologin_user }}"
+    reg_exp: "{{ item.key }}=.*"
+    line_content: "{{ item.key }}={{ item.value }}"
+  with_list: "{{ dm_autologin_options | dict2items }}"
   when:
     - guest_os_display_manager == "xdm"
     - guest_os_family == "Suse"
+
+- name: "Enable auto login on FreeBSD"
+  when:
+    - guest_os_display_manager == "slim"
+    - guest_os_ansible_distribution == "FreeBSD"
+  block:
+    - name: "Enable auto login for user {{ autologin_user }} in {{ vm_guest_os_distribution }}"
+      include_tasks: replace_or_add_line_in_file.yml
+      vars:
+        file: "{{ dm_conf_path }}"
+        reg_exp: "^#*{{ item.key }}    .*"
+        line_content: "{{ item.key }}    {{ item.value }}"
+      with_list: "{{ dm_autologin_options | dict2items }}"
+
+    - name: "Set default display session"
+      ansible.builtin.shell: |
+        user_home=$(getent passwd vmware | awk -F: '{ print $6 }')
+        echo 'exec gnome-session' > $user_home/.xinitrc
+        chmod a+x $user_home/.xinitrc
+        chown {{ autologin_user }} $user_home/.xinitrc
+      delegate_to: "{{ vm_guest_ip }}"


### PR DESCRIPTION
Enabling auto login in gdm will cause FreeBSD black screen. This fix added slim as the display manager in FreeBSD, and enabled auto login by using slim.

```
  - 'Guest os distribution: Ubuntu 20.04 Server x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Pardus GNU/Linux 21.5 XFCE x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: CentOS 10 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Debian 11 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: RedHat 7.9 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: SLES 16.0 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: FreeBSD 13.5-RELEASE amd64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: FreeBSD 14.2-RELEASE amd64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Pardus GNU/Linux 23.3 XFCE x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: ProLinux 8.6 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: SLES 15.7 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: MIRACLE 8.10 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: openSUSE Leap 15.6 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: SLED 15.7 x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'

  - 'Guest os distribution: Ubuntu 24.04 Desktop x86_64'
  - 'Results: Total (2), Passed (2)'
  - ' * deploy_vm_efi_paravirtual_vmxnet3...............................Passed'
  - ' * ovt_verify_status...............................................Passed'
```