### PR TITLE
Test ssh connection after ESXi, VMTools and guest compatibilty check

### DIFF
--- a/linux/host_verify_saml_token/host_verify_saml_token.yml
+++ b/linux/host_verify_saml_token/host_verify_saml_token.yml
@@ -25,18 +25,6 @@
           vars:
             skip_test_no_vmtools: true
 
-        - name: "Check SSH connection to vCenter Server"
-          include_tasks: ../../common/test_ssh_connection.yml
-          vars:
-            ssh_server_ip: "{{ vcenter_hostname }}"
-
-        - name: "Block test case due to vCenter Server is not connectable via SSH"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
-            skip_reason: "Blocked"
-          when: not ssh_connect_success
-
         - name: "Skip test case for {{ guest_os_ansible_distribution }}"
           include_tasks: ../../common/skip_test_case.yml
           vars:
@@ -60,6 +48,18 @@
 
         - name: "Check VMware Tools capability exists for host verified SAML token"
           include_tasks: ../../common/vm_check_vmtools_capability.yml
+
+        - name: "Check SSH connection to vCenter Server"
+          include_tasks: ../../common/test_ssh_connection.yml
+          vars:
+            ssh_server_ip: "{{ vcenter_hostname }}"
+
+        - name: "Block test case due to vCenter Server is not connectable via SSH"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
+            skip_reason: "Blocked"
+          when: not ssh_connect_success
 
         - name: "Initialize facts about domain user information"
           ansible.builtin.set_fact:

--- a/linux/host_verify_saml_token/host_verify_saml_token.yml
+++ b/linux/host_verify_saml_token/host_verify_saml_token.yml
@@ -10,16 +10,6 @@
   tasks:
     - name: "Test case block"
       block:
-        - name: "Skip test case due to missing vCenter Server variables"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
-            skip_reason: "Not Applicable"
-          when: >
-            (not vcenter_is_defined) or
-            (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
-            (vcenter_ssh_password is undefined or not vcenter_ssh_password)
-
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
           vars:
@@ -45,6 +35,16 @@
               VMware Tools version is {{ vmtools_version }} < 12.3.0.
             skip_reason: "Not Supported"
           when: esxi_version is version('8.0.2', '<') or vmtools_version is version('12.3.0', '<')
+
+        - name: "Skip test case due to missing vCenter Server variables"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
+            skip_reason: "Not Applicable"
+          when: >
+            (not vcenter_is_defined) or
+            (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
+            (vcenter_ssh_password is undefined or not vcenter_ssh_password)
 
         - name: "Check VMware Tools capability exists for host verified SAML token"
           include_tasks: ../../common/vm_check_vmtools_capability.yml

--- a/windows/host_verify_saml_token/host_verify_saml_token.yml
+++ b/windows/host_verify_saml_token/host_verify_saml_token.yml
@@ -10,16 +10,6 @@
   tasks:
     - name: "Test case block"
       block:
-        - name: "Skip test case due to missing vCenter Server variables"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
-            skip_reason: "Not Applicable"
-          when: >
-            (not vcenter_is_defined) or
-            (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
-            (vcenter_ssh_password is undefined or not vcenter_ssh_password)
-
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
           vars:
@@ -34,6 +24,16 @@
               VMware Tools version is {{ vmtools_version }} < 12.3.0.
             skip_reason: "Not Supported"
           when: esxi_version is version('8.0.2', '<') or vmtools_version is version('12.3.0', '<')
+
+        - name: "Skip test case due to missing vCenter Server variables"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Skip test case {{ ansible_play_name }} is because of missing vCenter Server variables."
+            skip_reason: "Not Applicable"
+          when: >
+            (not vcenter_is_defined) or
+            (vcenter_ssh_username is undefined or not vcenter_ssh_username) or
+            (vcenter_ssh_password is undefined or not vcenter_ssh_password)
 
         - name: "Check VMware Tools capability exists for host verified SAML token"
           include_tasks: ../../common/vm_check_vmtools_capability.yml

--- a/windows/host_verify_saml_token/host_verify_saml_token.yml
+++ b/windows/host_verify_saml_token/host_verify_saml_token.yml
@@ -26,18 +26,6 @@
             skip_test_no_vmtools: true
             create_current_test_folder: true
 
-        - name: "Check SSH connection to vCenter Server"
-          include_tasks: ../../common/test_ssh_connection.yml
-          vars:
-            ssh_server_ip: "{{ vcenter_hostname }}"
-
-        - name: "Block test case due to vCenter Server is not connectable via SSH"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
-            skip_reason: "Blocked"
-          when: not ssh_connect_success
-
         - name: "Skip test case for old ESXi server or VMware Tools"
           include_tasks: ../../common/skip_test_case.yml
           vars:
@@ -49,6 +37,18 @@
 
         - name: "Check VMware Tools capability exists for host verified SAML token"
           include_tasks: ../../common/vm_check_vmtools_capability.yml
+
+        - name: "Check SSH connection to vCenter Server"
+          include_tasks: ../../common/test_ssh_connection.yml
+          vars:
+            ssh_server_ip: "{{ vcenter_hostname }}"
+
+        - name: "Block test case due to vCenter Server is not connectable via SSH"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: "Test case {{ ansible_play_name }} is blocked because SSH connection to vCenter Server failed."
+            skip_reason: "Blocked"
+          when: not ssh_connect_success
 
         - name: "Enable guest OS timesync with ESXi server"
           include_tasks: ../utils/win_execute_cmd.yml


### PR DESCRIPTION
Test ssh connection only when ESXi, VMTools and guest OS support this test case

```
Testbed information:
+------------------------------------------------------------------------------------------------+
| Product | Version | Build    | Hostname or IP                   | Server Model                                               |
+------------------------------------------------------------------------------------------------+
| vCenter | 8.0.0   | 20519528 |                                  |                                                       |
+------------------------------------------------------------------------------------------------+
| ESXi    | 8.0.0   | 21493926 |                                  | Dell Inc. PowerEdge R6525                                  |
|         |         |          |                                  | AMD EPYC 7452 32-Core Processor                 (amd-zen2) |
+-------------------------------------------------------------------------------------------------+

VM information:
+-------------------------------------------------------------------------------------------------+
| Name                      | Ansible_win_next_vbs_80ga_amd                                       |
+-------------------------------------------------------------------------------------------------+
| Guest OS Distribution     | Microsoft Windows 11 Enterprise Insider Preview 10.0.27818.0 64-bit |
+-------------------------------------------------------------------------------------------------+
| IP                        |                                                                     |
+-------------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                                              |
+-------------------------------------------------------------------------------------------------+
| VMTools Version           | 12.1.5 (build-20735119)                                             |
+-------------------------------------------------------------------------------------------------+
| Config Guest Id           | windows11_64Guest                                                   |
+-------------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | windows11_64Guest                                                   |
+-------------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Microsoft Windows 11 (64-bit)                                       |
+-------------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | windowsGuest                                                        |
+-------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                  |
|                           | bitness='64'                                                        |
|                           | buildNumber='27818'                                                 |
|                           | distroName='Windows'                                                |
|                           | distroVersion='10.0'                                                |
|                           | familyName='Windows'                                                |
|                           | kernelVersion='27818.1000'                                          |
|                           | prettyName='Windows 11 Enterprise, 64-bit (Build 27818.1000)'       |
+-------------------------------------------------------------------------------------------------+

Test Results (Total: 1, Skipped: 1, Elapsed Time: 00:01:08)
+-----------------------------------------------------------+
| ID | Name                   |   Status        | Exec Time |
+-----------------------------------------------------------+
|  1 | host_verify_saml_token | * Not Supported | 00:00:52  |
+-----------------------------------------------------------+
```