### PR TITLE
[Linux] Increase Debian VM's video memory to 8 MB

### DIFF
--- a/linux/deploy_vm/deploy_vm_from_iso.yml
+++ b/linux/deploy_vm/deploy_vm_from_iso.yml
@@ -90,7 +90,7 @@
   ansible.builtin.set_fact:
     vm_video_memory_mb: 8
   when:
-    - unattend_installer in ['RHEL', 'SLE', 'Ubuntu-Ubiquity', 'Ubuntu-Subiquity']
+    - unattend_installer in ['RHEL', 'SLE', 'Ubuntu-Ubiquity', 'Ubuntu-Subiquity', 'Debian']
     - unattend_install_conf | lower is not search('minimal|server_without_gui|ubuntu/server')
 
 - name: "Set video memory size"


### PR DESCRIPTION
Debian 11.11 GNOME desktop couldn't display because the video memory is too small. Increase Debian VM's video memory to 8 MB to fix it.