### PR TITLE
[ARM] Set CPU and memory hotadd test case results to not supported on ARM ESXi host

### DIFF
--- a/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for check VM vCPU hotadd works as expected.
-# When calculated vCPU hotadd number list from ESXi server CPU number
+#   This test case is used for check VM vCPU hot add works as expected.
+# When calculated vCPU hot add number list from ESXi server CPU number
 # and configured maximum CPU number (default 16) is empty, this test
 # case result is 'Blocked'.
 # Note: VM vCPU number will be set to 2, cores per socket will be set
-# to 1 before vCPU hotadd test.
+# to 1 before vCPU hot add test.
 #
 - name: cpu_hot_add_basic
   hosts: localhost
@@ -19,7 +19,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              Skip test case '{{ ansible_play_name }}' because vCPU hot add is not supported
               on ARM ESXi host.
             skip_reason: "Not Supported"
           when: esxi_cpu_vendor == 'arm'
@@ -30,7 +30,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              Skip test case '{{ ansible_play_name }}' because vCPU hot add is not supported
               by VM configured with guest ID {{ vm_guest_id }}.
             skip_reason: "Not Supported"
           when:
@@ -48,7 +48,7 @@
         - name: "Test case is blocked due to empty vCPU number list"
           include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCPU hotadd test value list is empty"
+            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCPU hot add test value list is empty"
             skip_reason: "Blocked"
           when: cpu_hotadd_num_list | length == 0
 

--- a/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/linux/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -15,14 +15,23 @@
   tasks:
     - name: "Test case block"
       block:
-        # Except for VM guest_id like 'fedora64Guest', 'freebsd.*Guest' not supporting vCPU hot-add,
-        # the other guest OS compatible with ansible-vsphere-gos-validation support vCPU hot-add
-        - name: "Skip test case '{{ ansible_play_name }}' due to VM not support vCPU hot-add"
+        - name: "Skip test case '{{ ansible_play_name }}'"
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because vCPU hot-add is not supported
-              by VM configured with guest ID {{ vm_guest_id }}
+              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              on ARM ESXi host.
+            skip_reason: "Not Supported"
+          when: esxi_cpu_vendor == 'arm'
+
+        # Except for VM guest_id like 'fedora64Guest', 'freebsd.*Guest' not supporting vCPU hot-add,
+        # the other guest OS compatible with ansible-vsphere-gos-validation support vCPU hot-add
+        - name: "Skip test case '{{ ansible_play_name }}'"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              by VM configured with guest ID {{ vm_guest_id }}.
             skip_reason: "Not Supported"
           when:
             - vm_guest_id is defined

--- a/linux/cpu_hot_add_basic/cpu_hot_add_prepare.yml
+++ b/linux/cpu_hot_add_basic/cpu_hot_add_prepare.yml
@@ -1,10 +1,10 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# When 'enable_vm_cpu_hotadd' is set to true and VM CPU hotadd
-# is not enabled, will enable VM CPU hotadd.
+# When 'enable_vm_cpu_hotadd' is set to true and VM CPU hot add
+# is not enabled, will enable VM CPU hot add.
 # When 'enable_vm_cpu_hotadd' is set to false, will not enable
-# VM CPU hotadd, just set the VM vCPU number to the initial value.
+# VM CPU hot add, just set the VM vCPU number to the initial value.
 #
 - include_tasks: ../../common/vm_get_cpu_info.yml
 - block:
@@ -34,5 +34,5 @@
     that:
       - guest_cpu_num | int == initial_cpu_num | int
       - guest_cpu_cores | int == initial_cores_num | int
-    fail_msg: "VM vCPU number is set to: {{ guest_cpu_num }} (not {{ initial_cpu_num }}), cores per socket: {{ guest_cpu_cores }} (not {{ initial_cores_num }}) before hotadd testing."
-    success_msg: "VM vCPU number is set to: {{ guest_cpu_num }}, cores per socket: {{ guest_cpu_cores }} before hotadd testing."
+    fail_msg: "VM vCPU number is set to: {{ guest_cpu_num }} (not {{ initial_cpu_num }}), cores per socket: {{ guest_cpu_cores }} (not {{ initial_cores_num }}) before hot add testing."
+    success_msg: "VM vCPU number is set to: {{ guest_cpu_num }}, cores per socket: {{ guest_cpu_cores }} before hot add testing."

--- a/linux/cpu_hot_add_basic/cpu_hot_add_validate.yml
+++ b/linux/cpu_hot_add_basic/cpu_hot_add_validate.yml
@@ -1,42 +1,48 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- include_tasks: ../../common/vm_get_guest_facts.yml
-- name: Set fact of the vCPU number before hotadd
+- name: "Get VM guest facts"
+  include_tasks: ../../common/vm_get_guest_facts.yml
+
+- name: "Set fact of the vCPU number before hot add"
   ansible.builtin.set_fact:
     vcpu_before_hotadd: "{{ vm_guest_facts.instance.hw_processor_count }}"
-- name: Set fact of the vCPU number after hotadd
+
+- name: "Set fact of the vCPU number after hot add"
   ansible.builtin.set_fact:
     vcpu_after_hotadd: "{{ (vcpu_before_hotadd | int) + ( hotadd_num | int) }}"
 
-- ansible.builtin.debug:
-    msg: "Hotadd '{{ hotadd_num }}', VM vCPU number will be '{{ vcpu_after_hotadd }}', greater than '{{ max_num_cpus }}', skip test"
+- name: "Exit hot add test"
+  ansible.builtin.debug:
+    msg: "Hot add '{{ hotadd_num }}', VM vCPU number will be '{{ vcpu_after_hotadd }}', greater than '{{ max_num_cpus }}', skip test"
   when: vcpu_after_hotadd | int > max_num_cpus | int
 
-- block:
-    # Set VM vCPU number
-    - include_tasks: ../../common/vm_set_cpu_number.yml
+- name: "Execute CPU hot add test"
+  when: vcpu_after_hotadd | int <= max_num_cpus | int
+  block:
+    - name: "Set VM vCPU number"
+      include_tasks: ../../common/vm_set_cpu_number.yml
       vars:
         num_cpus: "{{ vcpu_after_hotadd }}"
-    # Check VM connection is not broken after hotadd
     - name: "Pause 5 seconds then check VM connection"
       ansible.builtin.pause:
         seconds: 5
-    - include_tasks: ../../common/vm_wait_connection.yml
+    - name: "Check VM connection is not broken after hot add"
+      include_tasks: ../../common/vm_wait_connection.yml
       vars:
         vm_wait_connection_timeout: 20
-    # Get CPU number in guest OS
-    - include_tasks: ../utils/wait_for_cpus_online.yml
+    - name: "Wait for new added CPU online in guest OS"
+      include_tasks: ../utils/wait_for_cpus_online.yml
       vars:
         num_cpus: "{{ vcpu_after_hotadd }}"
-    - include_tasks: ../utils/get_cpu_info.yml
+    - name: "Get CPU info in guest OS"
+      include_tasks: ../utils/get_cpu_info.yml
     # Valiate CPU number in guest is equal to VM config
-    - name: Check CPU number in guest OS increased
+    - name: "Check CPU number in guest OS increased"
       ansible.builtin.assert:
         that:
           - vm_set_cpu_number_result | int == guest_cpu_num | int
         fail_msg: "Hotadd '{{ hotadd_num }}' CPU from '{{ vcpu_before_hotadd }}' to '{{ vcpu_after_hotadd }}', but got '{{ guest_cpu_num }}' in guest OS"
-    - name: Add test result
+    - name: "Add test result"
       ansible.builtin.set_fact:
-        cpu_hotadd_results: "{{ cpu_hotadd_results + ['vCPU hotadd succeeds: ' ~ vcpu_before_hotadd ~ '->' ~ vcpu_after_hotadd] }}"
-  when: vcpu_after_hotadd | int <= max_num_cpus | int
+        cpu_hotadd_results: "{{ cpu_hotadd_results + ['vCPU hot add succeeds: ' ~ vcpu_before_hotadd ~ '->' ~ vcpu_after_hotadd] }}"

--- a/linux/cpu_hot_add_basic/generate_cpu_hot_add_list.yml
+++ b/linux/cpu_hot_add_basic/generate_cpu_hot_add_list.yml
@@ -1,30 +1,30 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Initialize CPU hotadd number list
+- name: "Initialize CPU hot add number list"
   ansible.builtin.set_fact:
     cpu_hotadd_num_list: []
 
-# Get ESXi host logical processor number
-- include_tasks: ../../common/esxi_get_cpu_mem_info.yml
+- name: "Get ESXi host logical processor number"
+  include_tasks: ../../common/esxi_get_cpu_mem_info.yml
 
 # Set the maximum VM vCPU number set in this test to the
 # minimum of ESXi host logical processor number and the
 # configured parameter 'vm_cpu_hotadd_max' (default 16)
 # in vars/test.yml.
-- name: Set fact of the maximum vCPU number of hotadd test
+- name: "Set fact of the maximum vCPU number of hot add test"
   ansible.builtin.set_fact:
     max_num_cpus: "{{ [esxi_logical_cpu_num | int, vm_cpu_hotadd_max | default(16) | int] | min }}"
-- ansible.builtin.debug:
-    msg: "Maximum VM vCPU number of CPU hotadd test: {{ max_num_cpus }}"
+- name: "Maximum VM vCPU number of CPU hot add test"
+  ansible.builtin.debug: var=max_num_cpus
 
-# Assume hotadded vCPU number is 1, 2, 3, ..., etc. in each test loop,
-# and after hotadd, VM vCPU number is less than the value of 'max_num_cpus'.
-# Assume will do N times CPU hotadd,
+# Assume hot added vCPU number is 1, 2, 3, ..., etc. in each test loop,
+# and after hot add, VM vCPU number is less than the value of 'max_num_cpus'.
+# Assume will do N times CPU hot add,
 # 1 + 2 + 3 + ... + N = max_num_cpus - initial_cpu_num,
 # we set N = root((max_num_cpus - initial_cpu_num) * 2) here for convenience.
-- name: Set fact of the vCPU number increase list
+- name: "Set fact of the vCPU number increase list"
   ansible.builtin.set_fact:
     cpu_hotadd_num_list: "{{ range(1, (((max_num_cpus | int - initial_cpu_num | int) * 2) | root | int)) | list }}"
-- ansible.builtin.debug:
-    msg: "VM vCPU number increase list: {{ cpu_hotadd_num_list }}"
+- name: "Display the vCPU number increase list"
+  ansible.builtin.debug: var=cpu_hotadd_num_list

--- a/linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
+++ b/linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
@@ -1,36 +1,38 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: Initialize the memory hotadd size list
+- name: "Initialize the memory hot add size list"
   ansible.builtin.set_fact:
     memory_hotadd_size_list: []
 
-# Get ESXi host free memory size
-- include_tasks: ../../common/esxi_get_cpu_mem_info.yml
+- name: "Get ESXi host free memory size"
+  include_tasks: ../../common/esxi_get_cpu_mem_info.yml
 
-# Set maximum memory size of this hotadd test to the minimum of ESXi
+# Set maximum memory size of this hot add test to the minimum of ESXi
 # host free memory size and configured parameter value
 # 'vm_memory_hotadd_max'(default 16384) in vars/test.yml
-- block:
-    - name: Set fact of the maximum VM memory size
+- name: "Generate memory hot add size list when free memory size in host > 4096MB"
+  when: esxi_memory_free_mb | int > 4096
+  block:
+    - name: "Set fact of the maximum VM memory size"
       ansible.builtin.set_fact:
         max_memory_mb: "{{ [esxi_memory_free_mb | int - 4096 + vm_initial_mem_mb | int, vm_memory_hotadd_max | default(16384)] | min }}"
-    - ansible.builtin.debug:
-        msg: "Maximum memory size set in this testing: {{ max_memory_mb }}"
+    - name: "Display the maximum memory size set in this testing"
+      ansible.builtin.debug: var=max_memory_mb
 
-    # Assume hotadded memory size is 1GB, 2GB, 3GB, ...,etc. in this testing,
-    # after hotadd, VM memory size is less than the value of 'max_memory_mb'.
-    # Assume will do N times memory hotadd,
+    # Assume hot added memory size is 1GB, 2GB, 3GB, ...,etc. in this testing,
+    # after hot add, VM memory size is less than the value of 'max_memory_mb'.
+    # Assume will do N times memory hot add,
     # 1024 * (1 + 2 + 3 + ... + N) = max_memory_mb - vm_initial_mem_mb,
     # set N = root((max_memory_mb - vm_initial_mem_mb) * 2 / 1024) here for convenience.
-    - name: Set fact of the memory hotadd size list
+    - name: "Set fact of the memory hot add size list"
       ansible.builtin.set_fact:
         memory_hotadd_size_list: "{{ range(1024, (((max_memory_mb | int - vm_initial_mem_mb | int) * 2048) | root | int), 1024) | list }}"
-  when: esxi_memory_free_mb | int > 4096
 
-- ansible.builtin.debug:
-    msg: "Skip VM memory hotadd test, the free memory size of ESXi server is lower than 4096MB."
+- name: "Exit memory hot add test"
+  ansible.builtin.debug:
+    msg: "Skip VM memory hot add test, the free memory size of ESXi server is lower than 4096MB."
   when: esxi_memory_free_mb | int <= 4096
 
-- ansible.builtin.debug:
-    msg: "Under test memory hotadd size list: {{ memory_hotadd_size_list }}"
+- name: "Display the under test memory hot add size list"
+  ansible.builtin.debug: var=memory_hotadd_size_list

--- a/linux/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -14,14 +14,23 @@
   tasks:
     - name: "Test case block"
       block:
-        # Except for VM guest_id like 'freebsd.*Guest' not supporting memory hot-add,
-        # the other guest OS compatible with ansible-vsphere-gos-validation support memory hot-add
-        - name: "Skip test case '{{ ansible_play_name }}' due to VM not support memory hot-add"
+        - name: "Skip test case '{{ ansible_play_name }}'"
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because memory hot-add is not supported by
-              VM configured with guest ID {{ vm_guest_id }}
+              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+              on ARM ESXi host.
+            skip_reason: "Not Supported"
+          when: esxi_cpu_vendor == 'arm'
+
+        # Except for VM guest_id like 'freebsd.*Guest' not supporting memory hot-add,
+        # the other guest OS compatible with ansible-vsphere-gos-validation support memory hot-add
+        - name: "Skip test case '{{ ansible_play_name }}'"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported by
+              VM configured with guest ID {{ vm_guest_id }}.
             skip_reason: "Not Supported"
           when:
             - vm_guest_id is defined

--- a/linux/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -6,7 +6,7 @@
 # memory hot-add size list from free memory size on ESXi server and the configured
 # maximum memory size (default 16384MB) is empty, or the free memory size on ESXi server
 # is lower than 4096MB, this test case result is 'Blocked'.
-# Note: Linux VM memory size will be set to 2048MB before hotadd test.
+# Note: Linux VM memory size will be set to 2048MB before hot add test.
 #
 - name: memory_hot_add_basic
   hosts: localhost
@@ -18,7 +18,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+              Skip test case '{{ ansible_play_name }}' because memory hot add is not supported
               on ARM ESXi host.
             skip_reason: "Not Supported"
           when: esxi_cpu_vendor == 'arm'
@@ -29,7 +29,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported by
+              Skip test case '{{ ansible_play_name }}' because memory hot add is not supported by
               VM configured with guest ID {{ vm_guest_id }}.
             skip_reason: "Not Supported"
           when:
@@ -41,7 +41,7 @@
           vars:
             create_test_log_folder: true
 
-        - name: "Set fact of VM initial memory size to 2048MB before hotadd test"
+        - name: "Set fact of VM initial memory size to 2048MB before hot add test"
           ansible.builtin.set_fact:
             vm_initial_mem_mb: 2048
 

--- a/linux/memory_hot_add_basic/memory_hot_add_prepare.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_prepare.yml
@@ -1,35 +1,45 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- include_tasks: ../../common/vm_get_mem_info.yml
+- name: "Get VM memory info"
+  include_tasks: ../../common/vm_get_mem_info.yml
 
-# Enable VM memory hotadd and set VM memory size to 2048 MB
-- block:
-    - include_tasks: ../utils/shutdown.yml
-    - include_tasks: ../../common/vm_enable_memory_hotadd.yml
+- name: "Enable VM memory hot add and set VM memory size to initial value"
+  when: >
+    (not vm_mem_hotadd_enabled) or
+    (vm_mem_size_mb | int != vm_initial_mem_mb | int)
+  block:
+    - name: "Shutdown guest OS"
+      include_tasks: ../utils/shutdown.yml
+    - name: "Enable VM memory hot add"
+      include_tasks: ../../common/vm_enable_memory_hotadd.yml
       when: not vm_mem_hotadd_enabled
 
-    - include_tasks: ../../common/vm_set_memory_size.yml
+    - name: "Set VM memory size to the initial value"
+      include_tasks: ../../common/vm_set_memory_size.yml
       vars:
         memory_mb: "{{ vm_initial_mem_mb }}"
       when: vm_mem_size_mb | int != vm_initial_mem_mb | int
 
-    - include_tasks: ../../common/vm_set_power_state.yml
+    - name: "Power on VM"
+      include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'
-    - include_tasks: ../../common/update_inventory.yml
-  when: >
-    (not vm_mem_hotadd_enabled) or
-    (vm_mem_size_mb | int != vm_initial_mem_mb | int)
+    - name: "Refresh in memory host IP"
+      include_tasks: ../../common/update_inventory.yml
 
 # Check memory size is set to 2048 MB in guest OS
-- include_tasks: ../utils/wait_for_memory_blocks.yml
+- name: "Wait for memory blocks in guest OS"
+  include_tasks: ../utils/wait_for_memory_blocks.yml
   vars:
     memory_size_mb: "{{ vm_initial_mem_mb }}"
-- include_tasks: ../utils/memory_size_in_guest.yml
-- name: Check memory size got in guest OS
+
+- name: "Get memory size in guest OS"
+  include_tasks: ../utils/memory_size_in_guest.yml
+
+- name: "Check memory size got in guest OS"
   ansible.builtin.assert:
     that:
       - memtotal_mb_in_guest | int == vm_initial_mem_mb | int
-    fail_msg: "Get VM memory size in guest OS: {{ memtotal_mb_in_guest }}MB, not the initial memory size set for hotadd test {{ vm_initial_mem_mb }}MB."
-    success_msg: "Get VM memory size in guest OS before hotadd test: {{ memtotal_mb_in_guest }}MB."
+    fail_msg: "Get VM memory size in guest OS: {{ memtotal_mb_in_guest }}MB, not the initial memory size set for hot add test {{ vm_initial_mem_mb }}MB."
+    success_msg: "Get VM memory size in guest OS before hot add test: {{ memtotal_mb_in_guest }}MB."

--- a/linux/memory_hot_add_basic/memory_hot_add_prepare.yml
+++ b/linux/memory_hot_add_basic/memory_hot_add_prepare.yml
@@ -25,7 +25,7 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-on'
-    - name: "Refresh in memory host IP"
+    - name: "Refresh VM guest IP in the in-memory inventory hosts info"
       include_tasks: ../../common/update_inventory.yml
 
 # Check memory size is set to 2048 MB in guest OS

--- a/linux/memory_hot_add_basic/memory_set_and_validate.yml
+++ b/linux/memory_hot_add_basic/memory_set_and_validate.yml
@@ -2,44 +2,57 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Get VM memory size before memory hotadd
-- include_tasks: ../../common/vm_get_guest_facts.yml
-- name: "Set fact of the memory size before hotadd"
+- name: "Get VM guest facts"
+  include_tasks: ../../common/vm_get_guest_facts.yml
+
+- name: "Set fact of the memory size before hot add"
   ansible.builtin.set_fact:
     mem_before_hotadd: "{{ vm_guest_facts.instance.hw_memtotal_mb }}"
-- name: "Set fact of the memory size after hotadd"
+
+- name: "Set fact of the memory size after hot add"
   ansible.builtin.set_fact:
     mem_after_hotadd: "{{ (mem_before_hotadd | int) + (hotadd_mb | int) }}"
 
-- ansible.builtin.debug:
-    msg: "After hotadd {{ hotadd_mb }}MB, VM memory size will be greater than {{ max_memory_mb }}MB. Skip this hotadd test."
+- name: "Exit memory hot add test"
+  ansible.builtin.debug:
+    msg: "After hot add {{ hotadd_mb }}MB, VM memory size will be greater than {{ max_memory_mb }}MB. Skip this hot add test."
   when: mem_after_hotadd | int > max_memory_mb | int
 
-- block:
+- name: "Execute memory hot add test"
+  when: mem_after_hotadd | int <= max_memory_mb | int
+  block:
     # It requires a cold add when VM memory size is less than
-    # 3072MB before hotadd, and greater than 3072MB after hotadd.
-    - include_tasks: ../utils/shutdown.yml
+    # 3072MB before hot add, and greater than 3072MB after hot add.
+    - name: "Shutdown guest OS when VM memory size <= 3072MB"
+      include_tasks: ../utils/shutdown.yml
       when:
         - mem_before_hotadd | int <= 3072
         - mem_after_hotadd | int > 3072
-    - include_tasks: ../../common/vm_set_memory_size.yml
+    - name: "Cold add VM memory size from <= 3072MB to > 3072MB"
+      include_tasks: ../../common/vm_set_memory_size.yml
       vars:
         memory_mb: "{{ mem_after_hotadd }}"
 
-    - block:
-        - include_tasks: ../../common/vm_set_power_state.yml
-          vars:
-            vm_power_state_set: 'powered-on'
-
-        - include_tasks: ../../common/update_inventory.yml
+    - name: "Power on VM after memory cold add situation"
       when:
         - mem_before_hotadd | int <= 3072
         - mem_after_hotadd | int > 3072
-    # Check VM connection is not broken after memory hot add
-    - block:
+      block:
+        - name: "Power on VM"
+          include_tasks: ../../common/vm_set_power_state.yml
+          vars:
+            vm_power_state_set: 'powered-on'
+
+        - name: "Refresh in memory host IP info"
+          include_tasks: ../../common/update_inventory.yml
+
+    - name: "Check VM connection is not broken after memory hot add"
+      block:
         - name: "Pause 5 seconds then check VM connection status"
           ansible.builtin.pause:
             seconds: 5
-        - include_tasks: ../../common/vm_wait_connection.yml
+        - name: ""
+          include_tasks: ../../common/vm_wait_connection.yml
           vars:
             vm_wait_connection_timeout: 900
       when: >
@@ -60,4 +73,3 @@
     - name: Set fact of the memory hotadd results
       ansible.builtin.set_fact:
         mem_hotadd_results: "{{ mem_hotadd_results + ['Memory hotadd succeeds: ' ~ mem_before_hotadd ~ '->' ~ mem_after_hotadd] }}"
-  when: mem_after_hotadd | int <= max_memory_mb | int

--- a/linux/memory_hot_add_basic/memory_set_and_validate.yml
+++ b/linux/memory_hot_add_basic/memory_set_and_validate.yml
@@ -28,7 +28,7 @@
       when:
         - mem_before_hotadd | int <= 3072
         - mem_after_hotadd | int > 3072
-    - name: "Cold add VM memory size from <= 3072MB to > 3072MB"
+    - name: "Cold add VM memory size from {{ mem_before_hotadd }}MB to {{ mem_after_hotadd }}MB"
       include_tasks: ../../common/vm_set_memory_size.yml
       vars:
         memory_mb: "{{ mem_after_hotadd }}"
@@ -43,7 +43,7 @@
           vars:
             vm_power_state_set: 'powered-on'
 
-        - name: "Refresh in memory host IP info"
+        - name: "Refresh VM guest IP in the in-memory inventory hosts info"
           include_tasks: ../../common/update_inventory.yml
 
     - name: "Check VM connection is not broken after memory hot add"

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -14,6 +14,15 @@
   tasks:
     - name: "Test case block"
       block:
+        - name: "Skip test case"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              on ARM ESXi host.
+            skip_reason: "Not Supported"
+          when: esxi_cpu_vendor == 'arm'
+
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
 
@@ -21,10 +30,14 @@
           when: guest_os_ansible_architecture == "64-bit"
           block:
             # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
-            - include_tasks: ../../common/vm_get_vbs_status.yml
-            - include_tasks: ../../common/skip_test_case.yml
+            - name: "Get VM VBS enablement status"
+              include_tasks: ../../common/vm_get_vbs_status.yml
+            - name: "Skip test case"
+              include_tasks: ../../common/skip_test_case.yml
               vars:
-                skip_msg: "Skip test case due to CPU hotadd not supported for VM with VBS enabled."
+                skip_msg: >-
+                  Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+                  for VM with VBS enabled.
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
 

--- a/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_basic.yml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for test Windows VM vCPU hotadd.
-# For Windows client: hotadded CPU will not be recognized and used
-# after hotadd without OS restart.
-# For Windows server: hotadded CPU will be recognized and used after
-# hotadd without OS restart.
+#   This test case is used for test Windows VM vCPU hot add.
+# For Windows client: hot added CPU will not be recognized and used
+# after hot add without OS restart.
+# For Windows server: hot added CPU will be recognized and used after
+# hot add without OS restart.
 #
 - name: cpu_hot_add_basic
   hosts: localhost
@@ -18,7 +18,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+              Skip test case '{{ ansible_play_name }}' because vCPU hot add is not supported
               on ARM ESXi host.
             skip_reason: "Not Supported"
           when: esxi_cpu_vendor == 'arm'
@@ -36,7 +36,7 @@
               include_tasks: ../../common/skip_test_case.yml
               vars:
                 skip_msg: >-
-                  Skip test case '{{ ansible_play_name }}' because vCPU hotadd is not supported
+                  Skip test case '{{ ansible_play_name }}' because vCPU hot add is not supported
                   for VM with VBS enabled.
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
@@ -57,25 +57,25 @@
         - name: "Skip test case when the list of added CPU number is empty"
           include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCPU hotadd test value list is empty"
+            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because vCPU hot add test value list is empty"
             skip_reason: "Blocked"
           when: cpu_hotadd_num_list | length == 0
 
-        - name: "Initialize the CPU hotadd test result"
+        - name: "Initialize the CPU hot add test result"
           ansible.builtin.set_fact:
             cpu_hotadd_results: []
-        - name: "Preparation for CPU hotadd test"
+        - name: "Preparation for CPU hot add test"
           include_tasks: cpu_hot_add_prepare.yml
           vars:
             enable_vm_cpu_hotadd: true
-        - name: "CPU hotadd test on Windows Server"
+        - name: "CPU hot add test on Windows Server"
           include_tasks: cpu_hot_add_validate.yml
           loop: "{{ cpu_hotadd_num_list }}"
           loop_control:
             loop_var: hotadd_num
           when: guest_os_product_type == "server"
 
-        - name: "CPU hotadd test on Windows Client"
+        - name: "CPU hot add test on Windows Client"
           include_tasks: cpu_hot_add_test_client.yml
           when: guest_os_product_type == "client"
 

--- a/windows/cpu_hot_add_basic/cpu_hot_add_prepare.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_prepare.yml
@@ -1,39 +1,48 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Check VM CPU hotadd enable status and VM vCPU number
-- include_tasks: ../../common/vm_get_cpu_info.yml
+# Check VM CPU hot add enable status and VM vCPU number
+- name: "Get VM CPU info"
+  include_tasks: ../../common/vm_get_cpu_info.yml
 
-# Enable VM CPU hotadd or set initial VM CPU number
-- block:
-    - include_tasks: ../utils/win_shutdown_restart.yml
+- name: "Enable VM CPU hot add or set initial VM CPU number"
+  when: >
+    (not vm_cpu_hotadd_enabled and enable_vm_cpu_hotadd) or
+    (vm_cpu_num | int != initial_cpu_num | int) or
+    (vm_cpu_cores_per_socket | int != initial_cores_num | int)
+  block:
+    - name: "Shutdown guest OS"
+      include_tasks: ../utils/win_shutdown_restart.yml
       vars:
         set_win_power_state: "shutdown"
-    - include_tasks: ../../common/vm_enable_cpu_hotadd.yml
-      when: not vm_cpu_hotadd_enabled and enable_vm_cpu_hotadd
+    - name: "Enable VM CPU hot add"
+      include_tasks: ../../common/vm_enable_cpu_hotadd.yml
+      when:
+        - not vm_cpu_hotadd_enabled
+        - enable_vm_cpu_hotadd
 
-    - include_tasks: ../../common/vm_set_cpu_number.yml
+    - name: "Set VM CPU number to the initial value"
+      include_tasks: ../../common/vm_set_cpu_number.yml
       vars:
         num_cores_per_socket: "{{ initial_cores_num }}"
         num_cpus: "{{ initial_cpu_num }}"
       when: >
         (vm_cpu_num | int != initial_cpu_num | int) or
         (vm_cpu_cores_per_socket | int != initial_cores_num | int)
-    - include_tasks: ../../common/vm_set_power_state.yml
+    - name: "Power on VM"
+      include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
-    - include_tasks: ../utils/win_update_inventory.yml
-  when: >
-    (not vm_cpu_hotadd_enabled and enable_vm_cpu_hotadd) or
-    (vm_cpu_num | int != initial_cpu_num | int) or
-    (vm_cpu_cores_per_socket | int != initial_cores_num | int)
+    - name: "Refresh in memory host IP"
+      include_tasks: ../utils/win_update_inventory.yml
 
 # Validate VM CPU number in guest OS
-- include_tasks: ../utils/win_get_cpu_cores_sockets.yml
-- name: Check VM CPU number got in guest OS
+- name: "Get CPU info in guest OS"
+  include_tasks: ../utils/win_get_cpu_cores_sockets.yml
+- name: "Check VM CPU number got in guest OS"
   ansible.builtin.assert:
     that:
       - win_cpu_number | int == initial_cpu_num | int
       - win_cores_per_socket | int == initial_cores_num | int
-    fail_msg: "VM vCPU number is set to: {{ win_cpu_number }} (not {{ initial_cpu_num }}), cores per socket: {{ win_cores_per_socket }} (not {{ initial_cores_num }}) before hotadd testing."
-    success_msg: "VM vCPU number is set to: {{ win_cpu_number }}, cores per socket: {{ win_cores_per_socket }} before hotadd testing."
+    fail_msg: "VM vCPU number is set to: {{ win_cpu_number }} (not {{ initial_cpu_num }}), cores per socket: {{ win_cores_per_socket }} (not {{ initial_cores_num }}) before hot add testing."
+    success_msg: "VM vCPU number is set to: {{ win_cpu_number }}, cores per socket: {{ win_cores_per_socket }} before hot add testing."

--- a/windows/cpu_hot_add_basic/cpu_hot_add_prepare.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_prepare.yml
@@ -33,7 +33,7 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: "powered-on"
-    - name: "Refresh in memory host IP"
+    - name: "Refresh VM guest IP in the in-memory inventory hosts info"
       include_tasks: ../utils/win_update_inventory.yml
 
 # Validate VM CPU number in guest OS

--- a/windows/cpu_hot_add_basic/cpu_hot_add_test_client.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_test_client.yml
@@ -1,24 +1,23 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get ESXi version number if not set before
-- include_tasks: ../../common/esxi_get_version_build.yml
-  when: esxi_version is undefined or esxi_version == 'N/A'
-
 # On ESXi version < 7.0.2, Windows 10 VM max socket is 2,
 # on ESXi version >= 7.0.2, Windows 10 VM max socket is 4
-- name: Set fact of the hotadd CPU test list
+- name: "Set fact of the hot add CPU test list"
   ansible.builtin.set_fact:
     cpu_hotadd_num_list: ["{{ initial_cores_num }}"]
 
-- name: Set fact of the hotadd CPU test list
+- name: "Set fact of the hot add CPU test list"
   ansible.builtin.set_fact:
     cpu_hotadd_num_list: ["{{ cpu_hotadd_num_list * 3 }}"]
   when: esxi_version is version('7.0.2', '>=')
-- ansible.builtin.debug:
-    msg: "Hotadd vCPU test value list for Windows client: {{ cpu_hotadd_num_list | to_yaml }}"
 
-- include_tasks: cpu_hot_add_validate.yml
+- name: "Print the CPU hot add value list"
+  ansible.builtin.debug:
+    msg: "Hot add CPU test value list for Windows client: {{ cpu_hotadd_num_list | to_yaml }}"
+
+- name: "Execute VM CPU hot add and verify test"
+  include_tasks: cpu_hot_add_validate.yml
   loop: "{{ cpu_hotadd_num_list }}"
   loop_control:
     loop_var: hotadd_num

--- a/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
+++ b/windows/cpu_hot_add_basic/cpu_hot_add_validate.yml
@@ -4,17 +4,17 @@
 - name: "Get VM facts"
   include_tasks: ../../common/vm_get_guest_facts.yml
 
-- name: "Set fact of vCPU number before hotadd"
+- name: "Set fact of vCPU number before hot add"
   ansible.builtin.set_fact:
     vcpu_before_hotadd: "{{ vm_guest_facts.instance.hw_processor_count }}"
 
-- name: "Set fact of hotadd CPU number"
+- name: "Set fact of hot add CPU number"
   ansible.builtin.set_fact:
     vcpu_after_hotadd: "{{ vcpu_before_hotadd | int + hotadd_num | int }}"
 
 - name: "Target CPU number is larger than the maximum number"
   ansible.builtin.debug:
-    msg: "Hotadd '{{ hotadd_num }}', VM vCPU number is '{{ vcpu_after_hotadd }}', greater than '{{ max_num_cpus }}', skip hotadd test"
+    msg: "Hotadd '{{ hotadd_num }}', VM vCPU number is '{{ vcpu_after_hotadd }}', greater than '{{ max_num_cpus }}', skip hot add test"
   when: vcpu_after_hotadd | int > max_num_cpus | int
 
 - name: "Target CPU number not exceed the maximum number"
@@ -44,8 +44,8 @@
       include_tasks: ../utils/win_get_cpu_cores_sockets.yml
       when: guest_os_product_type == "server"
 
-    # Validate CPU number after hotadd
-    - name: "Verify hotadded vCPU can be detected in guest OS"
+    # Validate CPU number after hot add
+    - name: "Verify hot added vCPU can be detected in guest OS"
       ansible.builtin.assert:
         that:
           - win_cpu_number | int == vcpu_after_hotadd | int
@@ -54,4 +54,4 @@
 
     - name: "Add test result"
       ansible.builtin.set_fact:
-        cpu_hotadd_results: "{{ cpu_hotadd_results + ['vCPU hotadd succeeds: ' ~ vcpu_before_hotadd ~ '->' ~ vcpu_after_hotadd] }}"
+        cpu_hotadd_results: "{{ cpu_hotadd_results + ['vCPU hot add succeeds: ' ~ vcpu_before_hotadd ~ '->' ~ vcpu_after_hotadd] }}"

--- a/windows/memory_hot_add_basic/generate_cpu_num_list.yml
+++ b/windows/memory_hot_add_basic/generate_cpu_num_list.yml
@@ -1,17 +1,19 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get ESXi host logical processor number
-- include_tasks: ../../common/esxi_get_cpu_mem_info.yml
+- name: "Get ESXi host logical processor number"
+  include_tasks: ../../common/esxi_get_cpu_mem_info.yml
 
 # Set the default maximum vCPU number in this test to 8
 # And conduct memory hotadd testing with vCPU number set
 # to 2, 4, 6, 8 at most
-- name: Set fact of the maximum vCPU number
+- name: "Set fact of the maximum vCPU number"
   ansible.builtin.set_fact:
     max_cpu_number: "{{ [esxi_logical_cpu_num | int, 8] | min }}"
-- name: Set fact of the vCPU number list
+- name: "Set fact of the vCPU number list"
   ansible.builtin.set_fact:
     cpu_number_list: "{{ range(2, max_cpu_number | int + 1, 2) }}"
-- ansible.builtin.debug:
+
+- name: "Display the vCPU number list"
+  ansible.builtin.debug:
     msg: "vCPU number list: {{ cpu_number_list }}"

--- a/windows/memory_hot_add_basic/hotadd_memory_for_vcpu.yml
+++ b/windows/memory_hot_add_basic/hotadd_memory_for_vcpu.yml
@@ -22,7 +22,7 @@
   include_tasks: ../../common/vm_set_power_state.yml
   vars:
     vm_power_state_set: "powered-on"
-- name: "Refresh in memory host IP"
+- name: "Refresh VM guest IP in the in-memory inventory hosts info"
   include_tasks: ../utils/win_update_inventory.yml
 
 # Check CPU number in guest OS before memory hot add

--- a/windows/memory_hot_add_basic/hotadd_memory_for_vcpu.yml
+++ b/windows/memory_hot_add_basic/hotadd_memory_for_vcpu.yml
@@ -1,44 +1,52 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get VM power status and shutdown
-- include_tasks: ../../common/vm_get_power_state.yml
-- include_tasks: ../utils/shutdown_vm.yml
+- name: "Get VM power status"
+  include_tasks: ../../common/vm_get_power_state.yml
+- name: "Shutdown guest OS"
+  include_tasks: ../utils/shutdown_vm.yml
   when: vm_power_state_get != "poweredOff"
 
 # Set vCPU to specified value, set initial memory
-- include_tasks: ../../common/vm_set_memory_size.yml
+- name: "Set VM memory size to the initial value"
+  include_tasks: ../../common/vm_set_memory_size.yml
   vars:
     memory_mb: "{{ vm_initial_mem_mb }}"
-- include_tasks: ../../common/vm_set_cpu_number.yml
+- name: "Set VM vCPU number"
+  include_tasks: ../../common/vm_set_cpu_number.yml
   vars:
     num_cpus: "{{ vcpu_number }}"
     num_cores_per_socket: "{{ vcpu_number }}"
 
-- include_tasks: ../../common/vm_set_power_state.yml
+- name: "Power on VM"
+  include_tasks: ../../common/vm_set_power_state.yml
   vars:
     vm_power_state_set: "powered-on"
-- include_tasks: ../utils/win_update_inventory.yml
+- name: "Refresh in memory host IP"
+  include_tasks: ../utils/win_update_inventory.yml
 
-# Check CPU number in guest OS before memory hotadd
-- include_tasks: ../utils/win_get_cpu_cores_sockets.yml
-- name: Check initial CPU number got from guest
+# Check CPU number in guest OS before memory hot add
+- name: "Get CPU info in guest OS"
+  include_tasks: ../utils/win_get_cpu_cores_sockets.yml
+- name: "Check initial CPU number got from guest OS"
   ansible.builtin.assert:
     that:
       - win_cpu_number | int == vcpu_number | int
     success_msg: "Get CPU number in guest is same as configured CPU: {{ vcpu_number | int }}"
     fail_msg: "Get CPU number in guest: {{ win_cpu_number | int }}, not same as configured CPU: {{ vcpu_number | int }}"
 
-# Check memory size in guest OS before hotadd
-- include_tasks: ../utils/win_get_mem_size.yml
-- name: Check initial memory size got from guest
+# Check memory size in guest OS before hot add
+- name: "Get memory info in guest OS"
+  include_tasks: ../utils/win_get_mem_size.yml
+- name: "Check initial memory size got from guest OS"
   ansible.builtin.assert:
     that:
       - vm_initial_mem_mb | int == win_get_mem_size | int
     success_msg: "Get memory size in guest is same as initial memory: {{ win_get_mem_size | int }}MB"
     fail_msg: "Get memory size in guest: {{ win_get_mem_size | int }}MB, not same as initial memory set: {{ vm_initial_mem_mb }}MB"
 
-- include_tasks: hotadd_memory_verify.yml
+- name: "Execute memory hot add test"
+  include_tasks: hotadd_memory_verify.yml
   loop: "{{ memory_hotadd_size_list }}"
   loop_control:
     loop_var: hotadd_mb

--- a/windows/memory_hot_add_basic/hotadd_memory_verify.yml
+++ b/windows/memory_hot_add_basic/hotadd_memory_verify.yml
@@ -1,28 +1,32 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Get VM memory size before memory hotadd
-- include_tasks: ../../common/vm_get_guest_facts.yml
-- name: "Set fact of the memory size before hotadd"
+- name: "Get VM guest facts"
+  include_tasks: ../../common/vm_get_guest_facts.yml
+- name: "Set fact of the memory size before hot add"
   ansible.builtin.set_fact:
     mem_before_hotadd: "{{ vm_guest_facts.instance.hw_memtotal_mb }}"
 
-- name: "Set fact of the memory size after hotadd"
+- name: "Set fact of the memory size after hot add"
   ansible.builtin.set_fact:
     mem_after_hotadd: "{{ (mem_before_hotadd | int) + (hotadd_mb | int) }}"
 
-- include_tasks: ../../common/vm_set_memory_size.yml
+- name: "Set VM memory size"
+  include_tasks: ../../common/vm_set_memory_size.yml
   vars:
     memory_mb: "{{ mem_after_hotadd }}"
 
-- name: Wait for 20 seconds after changing VM memory
+- name: "Wait for 20 seconds after changing VM memory"
   ansible.builtin.pause:
     seconds: 20
-# Add check guest OS winrm can be connected after memory size change
-- include_tasks: ../utils/win_check_winrm.yml
 
-- include_tasks: ../utils/win_get_mem_size.yml
-- name: Check memory size got from guest OS
+- name: "Check guest OS connection after memory size change"
+  include_tasks: ../utils/win_check_winrm.yml
+
+- name: "Get memory size in guest OS"
+  include_tasks: ../utils/win_get_mem_size.yml
+
+- name: "Check memory size got from guest OS"
   ansible.builtin.assert:
     that:
       - mem_after_hotadd | int == win_get_mem_size | int
@@ -31,7 +35,7 @@
     (guest_os_ansible_architecture == "64-bit") or
     (guest_os_ansible_architecture == "32-bit" and mem_after_hotadd | int < 4096)
 
-- name: Check memory size got from guest OS
+- name: "Check memory size got from guest OS"
   ansible.builtin.assert:
     that:
       - win_get_mem_size | int == 3072
@@ -40,6 +44,6 @@
     - guest_os_ansible_architecture == "32-bit"
     - mem_after_hotadd | int >= 4096
 
-- name: Set fact of the memory hotadd results
+- name: "Set fact of the memory hot add results"
   ansible.builtin.set_fact:
-    mem_hotadd_results: "{{ mem_hotadd_results + ['Memory hotadd succeeds: ' ~ mem_before_hotadd ~ '->' ~ mem_after_hotadd ~ ' with vCPU number: ' ~ vcpu_number] }}"
+    mem_hotadd_results: "{{ mem_hotadd_results + ['Memory hot add succeeds: ' ~ mem_before_hotadd ~ '->' ~ mem_after_hotadd ~ ' with vCPU number: ' ~ vcpu_number] }}"

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Description:
-#   This test case is used for test VM memory hotadd with different VM vCPUs.
+#   This test case is used for test VM memory hot add with different VM vCPUs.
 # Note: VM memory size will be set to 2GB for 32 bit guest, 4GB for 64 bit
-# guest before hotadd testing.
+# guest before hot add testing.
 #
 - name: memory_hot_add_basic
   hosts: localhost
@@ -16,7 +16,7 @@
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-
-              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+              Skip test case '{{ ansible_play_name }}' because memory hot add is not supported
               on ARM ESXi host.
             skip_reason: "Not Supported"
           when: esxi_cpu_vendor == 'arm'
@@ -34,7 +34,7 @@
               include_tasks: ../../common/skip_test_case.yml
               vars:
                 skip_msg: >-
-                  Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+                  Skip test case '{{ ansible_play_name }}' because memory hot add is not supported
                   for VM with VBS enabled.
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
@@ -52,36 +52,36 @@
 
         # Memory limit for 32bit Windows is 4GB:
         # https://docs.microsoft.com/en-us/windows/win32/memory/memory-limits-for-windows-releases
-        - name: "Set fact of memory hotadd list for 32bit Windows"
+        - name: "Set fact of memory hot add list for 32bit Windows"
           ansible.builtin.set_fact:
             memory_hotadd_size_list: [1024, 1024]
           when: guest_os_ansible_architecture == "32-bit"
 
-        - name: "Generate hotadded memory size list for 64bit Windows"
+        - name: "Generate hot added memory size list for 64bit Windows"
           include_tasks: ../../linux/memory_hot_add_basic/generate_mem_hot_add_list.yml
           when: guest_os_ansible_architecture == "64-bit"
 
-        - name: "Skip test case when hotadded memory size list is empty"
+        - name: "Skip test case when hot added memory size list is empty"
           include_tasks: ../../common/skip_test_case.yml
           vars:
-            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because memory hotadd test value list is empty"
+            skip_msg: "Test case '{{ ansible_play_name }}' is blocked because memory hot add test value list is empty"
             skip_reason: "Blocked"
           when: memory_hotadd_size_list | length == 0
 
-        # Workaround of connection reset failure, not loop on CPU number when hotadd memory
+        # Workaround of connection reset failure, not loop on CPU number when hot add memory
         # to try to see if it can decrease the failure rate
         # - include_tasks: generate_cpu_num_list.yml
 
-        - name: "Initialize the memory hotadd test result"
+        - name: "Initialize the memory hot add test result"
           ansible.builtin.set_fact:
             mem_hotadd_results: []
 
         - name: "Shutdown guest OS"
           include_tasks: ../utils/shutdown_vm.yml
-        - name: "Enable memory hotadd"
+        - name: "Enable memory hot add"
           include_tasks: ../../common/vm_enable_memory_hotadd.yml
 
-        - name: "Do memory hotadd with vCPU number 2"
+        - name: "Do memory hot add with vCPU number 2"
           include_tasks: hotadd_memory_for_vcpu.yml
           vars:
             vcpu_number: 2

--- a/windows/memory_hot_add_basic/memory_hot_add_basic.yml
+++ b/windows/memory_hot_add_basic/memory_hot_add_basic.yml
@@ -12,6 +12,15 @@
   tasks:
     - name: "Test case block"
       block:
+        - name: "Skip test case"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >-
+              Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+              on ARM ESXi host.
+            skip_reason: "Not Supported"
+          when: esxi_cpu_vendor == 'arm'
+
         - name: "Test setup"
           include_tasks: ../setup/test_setup.yml
 
@@ -21,10 +30,12 @@
             # Refer to KB article https://knowledge.broadcom.com/external/article?legacyId=52584
             - name: "Get VM VBS status"
               include_tasks: ../../common/vm_get_vbs_status.yml
-            - name: "Skip test case when VM VBS is enabled"
+            - name: "Skip test case"
               include_tasks: ../../common/skip_test_case.yml
               vars:
-                skip_msg: "Skip test case due to memory hotadd not supported for VM with VBS enabled."
+                skip_msg: >-
+                  Skip test case '{{ ansible_play_name }}' because memory hotadd is not supported
+                  for VM with VBS enabled.
                 skip_reason: "Not Supported"
               when: vm_vbs_enabled
 


### PR DESCRIPTION
```
VM information:
+-------------------------------------------------+
| Name                      | photon5_iso         |
+-------------------------------------------------+
| Guest OS Distribution     |                     |
+-------------------------------------------------+
| IP                        |                     |
+-------------------------------------------------+
| GUI Installed             |                     |
+-------------------------------------------------+
| CloudInit Version         |                     |
+-------------------------------------------------+
| Hardware Version          |                   |
+-------------------------------------------------+
| VMTools Version           |                     |
+-------------------------------------------------+
| Config Guest Id           | vmwarePhoton64Guest |
+-------------------------------------------------+
| GuestInfo Guest Id        |                     |
+-------------------------------------------------+
| GuestInfo Guest Full Name |                     |
+-------------------------------------------------+
| GuestInfo Guest Family    |                     |
+-------------------------------------------------+
| GuestInfo Detailed Data   |                     |
+-------------------------------------------------+


Test Results (Total: 2, Skipped: 2, Elapsed Time: 00:02:00)
+---------------------------------------------------------+
| ID | Name                 |   Status        | Exec Time |
+---------------------------------------------------------+
|  1 | memory_hot_add_basic | * Not Supported | 00:00:00  |
|  2 | cpu_hot_add_basic    | * Not Supported | 00:00:00  |
+---------------------------------------------------------+

```