### PR TITLE
Update ovf_deploy.yml to reconfigure vcpu and memory

### DIFF
--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -23,17 +23,10 @@
   when: enable_debug is defined and enable_debug
 
 - name: "Update VM memory"
-  when: memory_mb is defined and memory_mb
-  block:
-    - name: "Set the facts of vm memory and initial configuration"
-      ansible.builtin.set_fact:
-        vm_mem_mb: "{{ ovf_deploy.instance.hw_memtotal_mb | int }}"
-        initial_mem_mb: "{{ memory_mb | int }}"
-    - name: "Set initial VM memory"
-      include_tasks: vm_set_memory_size.yml
-      vars:
-        memory_mb: "{{ initial_mem_mb }}"
-      when: vm_mem_mb | int != initial_mem_mb | int
+  include_tasks: vm_set_memory_size.yml
+  when:
+   - memory_mb is defined and memory_mb
+   - ovf_deploy.instance.hw_memtotal_mb | int != memory_mb | int
 
 - name: "Update VM cpu"
   when: >-
@@ -44,8 +37,8 @@
       ansible.builtin.set_fact:
         vm_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
         vm_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
-        initial_cpu_num: "{{ cpu_number | default(2) | int }}"
-        initial_cores_num: "{{ cpu_cores_per_socket | default(2) | int }}"
+        initial_cpu_num: "{{ cpu_number | default(ovf_deploy.instance.hw_processor_count) | int }}"
+        initial_cores_num: "{{ cpu_cores_per_socket | default(ovf_deploy.instance.hw_cores_per_socket) | int }}"
     - name: "Set initial VM cpu"
       include_tasks: vm_set_cpu_number.yml
       vars:

--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -28,8 +28,8 @@
     - name: "Update VM memory"
       include_tasks: vm_set_memory_size.yml
       when:
-      - memory_mb is defined and memory_mb
-      - ovf_deploy.instance.hw_memtotal_mb | int != memory_mb | int
+        - memory_mb is defined and memory_mb
+        - ovf_deploy.instance.hw_memtotal_mb | int != memory_mb | int
 
     - name: "Update VM CPU"
       when: >-

--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -38,13 +38,17 @@
       block:
         - name: "Set the facts of vm cpu and initial configuration"
           ansible.builtin.set_fact:
-            vm_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
-            vm_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
+            ovf_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
+            ovf_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
             initial_cpu_num: "{{ cpu_number | default(ovf_deploy.instance.hw_processor_count) | int }}"
             initial_cores_num: "{{ cpu_cores_per_socket | default(ovf_deploy.instance.hw_cores_per_socket) | int }}"
+        - name: "Override initial_cores_num to 1 if not divisible"
+          ansible.builtin.set_fact:
+            initial_cores_num: 1
+          when: (initial_cpu_num | int) % (initial_cores_num | int) !=0
         - name: "Set initial VM CPU"
           include_tasks: vm_set_cpu_number.yml
           vars:
             num_cpus: "{{ initial_cpu_num }}"
             num_cores_per_socket: "{{ initial_cores_num }}"
-          when: (vm_cpu_num | int != initial_cpu_num | int) or (vm_cpu_cores_per_socket | int != initial_cores_num | int)
+          when: (ovf_cpu_num | int != initial_cpu_num | int) or (ovf_cpu_cores_per_socket | int != initial_cores_num | int)

--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -21,3 +21,34 @@
 - name: Display the result of ovf template deploy
   ansible.builtin.debug: var=ovf_deploy
   when: enable_debug is defined and enable_debug
+
+- name: "Update VM memory"
+  when: memory_mb is defined and memory_mb
+  block:
+    - name: "Set the facts of vm memory and initial configuration"
+      ansible.builtin.set_fact:
+        vm_mem_mb: "{{ ovf_deploy.instance.hw_memtotal_mb | int }}"
+        initial_mem_mb: "{{ memory_mb | int }}"
+    - name: "Set initial VM memory"
+      include_tasks: vm_set_memory_size.yml
+      vars:
+        memory_mb: "{{ initial_mem_mb }}"
+      when: vm_mem_mb | int != initial_mem_mb | int
+
+- name: "Update VM cpu"
+  when: >-
+    (cpu_number is defined and cpu_number) or
+    (cpu_cores_per_socket is defined and cpu_cores_per_socket)
+  block:
+    - name: "Set the facts of vm cpu and initial configuration"
+      ansible.builtin.set_fact:
+        vm_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
+        vm_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
+        initial_cpu_num: "{{ cpu_number | default(2) | int }}"
+        initial_cores_num: "{{ cpu_cores_per_socket | default(2) | int }}"
+    - name: "Set initial VM cpu"
+      include_tasks: vm_set_cpu_number.yml
+      vars:
+        num_cpus: "{{ initial_cpu_num }}"
+        num_cores_per_socket: "{{ initial_cores_num }}"
+      when: (vm_cpu_num | int != initial_cpu_num | int) or (vm_cpu_cores_per_socket | int != initial_cores_num | int)

--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -36,7 +36,7 @@
         (cpu_number is defined and cpu_number) or
         (cpu_cores_per_socket is defined and cpu_cores_per_socket)
       block:
-        - name: "Set the facts of vm cpu and initial configuration"
+        - name: "Set the facts of VM CPU and initial configuration"
           ansible.builtin.set_fact:
             ovf_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
             ovf_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
@@ -45,7 +45,7 @@
         - name: "Override initial_cores_num to 1 if not divisible"
           ansible.builtin.set_fact:
             initial_cores_num: 1
-          when: (initial_cpu_num | int) % (initial_cores_num | int) !=0
+          when: (initial_cpu_num | int) % (initial_cores_num | int) != 0
         - name: "Set initial VM CPU"
           include_tasks: vm_set_cpu_number.yml
           vars:

--- a/common/ovf_deploy.yml
+++ b/common/ovf_deploy.yml
@@ -22,26 +22,29 @@
   ansible.builtin.debug: var=ovf_deploy
   when: enable_debug is defined and enable_debug
 
-- name: "Update VM memory"
-  include_tasks: vm_set_memory_size.yml
-  when:
-   - memory_mb is defined and memory_mb
-   - ovf_deploy.instance.hw_memtotal_mb | int != memory_mb | int
-
-- name: "Update VM cpu"
-  when: >-
-    (cpu_number is defined and cpu_number) or
-    (cpu_cores_per_socket is defined and cpu_cores_per_socket)
+- name: "Update VM memory and CPU"
+  when: update_vm_mem_cpu is defined and update_vm_mem_cpu
   block:
-    - name: "Set the facts of vm cpu and initial configuration"
-      ansible.builtin.set_fact:
-        vm_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
-        vm_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
-        initial_cpu_num: "{{ cpu_number | default(ovf_deploy.instance.hw_processor_count) | int }}"
-        initial_cores_num: "{{ cpu_cores_per_socket | default(ovf_deploy.instance.hw_cores_per_socket) | int }}"
-    - name: "Set initial VM cpu"
-      include_tasks: vm_set_cpu_number.yml
-      vars:
-        num_cpus: "{{ initial_cpu_num }}"
-        num_cores_per_socket: "{{ initial_cores_num }}"
-      when: (vm_cpu_num | int != initial_cpu_num | int) or (vm_cpu_cores_per_socket | int != initial_cores_num | int)
+    - name: "Update VM memory"
+      include_tasks: vm_set_memory_size.yml
+      when:
+      - memory_mb is defined and memory_mb
+      - ovf_deploy.instance.hw_memtotal_mb | int != memory_mb | int
+
+    - name: "Update VM CPU"
+      when: >-
+        (cpu_number is defined and cpu_number) or
+        (cpu_cores_per_socket is defined and cpu_cores_per_socket)
+      block:
+        - name: "Set the facts of vm cpu and initial configuration"
+          ansible.builtin.set_fact:
+            vm_cpu_num: "{{ ovf_deploy.instance.hw_processor_count | int }}"
+            vm_cpu_cores_per_socket: "{{ ovf_deploy.instance.hw_cores_per_socket | int }}"
+            initial_cpu_num: "{{ cpu_number | default(ovf_deploy.instance.hw_processor_count) | int }}"
+            initial_cores_num: "{{ cpu_cores_per_socket | default(ovf_deploy.instance.hw_cores_per_socket) | int }}"
+        - name: "Set initial VM CPU"
+          include_tasks: vm_set_cpu_number.yml
+          vars:
+            num_cpus: "{{ initial_cpu_num }}"
+            num_cores_per_socket: "{{ initial_cores_num }}"
+          when: (vm_cpu_num | int != initial_cpu_num | int) or (vm_cpu_cores_per_socket | int != initial_cores_num | int)

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -279,9 +279,9 @@ windows_has_inbox_driver: true
 # ova_nfs_server_path: "192.168.1.10:/Images"
 # ova_path: "OS/Linux/Photon/3.0/Rev3/photon-hw13_uefi-3.0-a383732.ova"
 
-# Whether update vm's memory and cpu when 'vm_deploy_method' is set to 'ova': default is false.
+# Whether update VM's memory and CPU when 'vm_deploy_method' is set to 'ova': default is false.
 # If it's true, vm will be re-configured with 'memory_mb', 'cpu_number' and 'cpu_cores_per_socket' settings.
-update_vm_mem_cpu: false
+# update_vm_mem_cpu: false
 
 # 2. Linux: ovt_verify_pkg_install, ovt_verify_src_install
 #    Windows: wintools_complete_install_verify

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -185,9 +185,6 @@ secureboot_enabled: false
 memory_mb: 4096
 cpu_number: 2
 cpu_cores_per_socket: 2
-# Whether update vm's memory and cpu when 'vm_deploy_method' is set to 'ova': default is false.
-# If it's true, vm will be re-configured with 'memory_mb', 'cpu_number' and 'cpu_cores_per_socket' settings.
-update_vm_mem_cpu: false
 # Firmware valid value 'bios' or 'efi'.
 firmware: "efi"
 # Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', 'nvme', 'sata' or 'ide'.
@@ -281,6 +278,10 @@ windows_has_inbox_driver: true
 #
 # ova_nfs_server_path: "192.168.1.10:/Images"
 # ova_path: "OS/Linux/Photon/3.0/Rev3/photon-hw13_uefi-3.0-a383732.ova"
+
+# Whether update vm's memory and cpu when 'vm_deploy_method' is set to 'ova': default is false.
+# If it's true, vm will be re-configured with 'memory_mb', 'cpu_number' and 'cpu_cores_per_socket' settings.
+update_vm_mem_cpu: false
 
 # 2. Linux: ovt_verify_pkg_install, ovt_verify_src_install
 #    Windows: wintools_complete_install_verify

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -185,6 +185,9 @@ secureboot_enabled: false
 memory_mb: 4096
 cpu_number: 2
 cpu_cores_per_socket: 2
+# Whether update vm's memory and cpu when 'vm_deploy_method' is set to 'ova': default is false.
+# If it's true, vm will be re-configured with 'memory_mb', 'cpu_number' and 'cpu_cores_per_socket' settings.
+update_vm_mem_cpu: false
 # Firmware valid value 'bios' or 'efi'.
 firmware: "efi"
 # Boot disk controller type valid value 'paravirtual', 'lsilogic', 'buslogic', 'lsilogicsas', 'nvme', 'sata' or 'ide'.


### PR DESCRIPTION
Update ovf_deploy.yml to reconfigure vCPU and memory settings when memory_mb, cpu_number, and cpu_cores_per_socket are specified and differ from the default configuration of the VM deployed from the OVF. This enhancement will improve performance and ensure a smoother experience when running desktop applications on it by allocating additional CPU and memory resources.

Testing done:
```
TASK [Set the facts of vm memory and initial configuration] ********************
task path: /home/worker/workspace/Ansible_Cycle_Photon_5.x_Update_OVA-42/ansible-vsphere-gos-validation/common/ovf_deploy.yml:28
ok: [localhost] => {
    "ansible_facts": {
        "initial_mem_mb": "4096",
        "vm_mem_mb": "1024"
    },
    "changed": false
}
......
TASK [Check VM memory size after setting] **************************************
task path: /home/worker/workspace/Ansible_Cycle_Photon_5.x_Update_OVA-42/ansible-vsphere-gos-validation/common/vm_set_memory_size.yml:23
ok: [localhost] => {
    "changed": false,
    "msg": "Memory size is set to 4096 MB"
}
......
TASK [Set the facts of vm cpu and initial configuration] ***********************
task path: /home/worker/workspace/Ansible_Cycle_Photon_5.x_Update_OVA-42/ansible-vsphere-gos-validation/common/ovf_deploy.yml:43
ok: [localhost] => {
    "ansible_facts": {
        "initial_cores_num": "2",
        "initial_cpu_num": "2",
        "vm_cpu_cores_per_socket": "1",
        "vm_cpu_num": "1"
    },
    "changed": false
}
......
TASK [Check CPU cores per socket is set correctly] *****************************
task path: /home/worker/workspace/Ansible_Cycle_Photon_5.x_Update_OVA-42/ansible-vsphere-gos-validation/common/vm_set_cpu_number.yml:31
ok: [localhost] => {
    "changed": false,
    "msg": "CPU cores per socket is set to 2"
}

TASK [Check CPU number is set correctly] ***************************************
task path: /home/worker/workspace/Ansible_Cycle_Photon_5.x_Update_OVA-42/ansible-vsphere-gos-validation/common/vm_set_cpu_number.yml:39
ok: [localhost] => {
    "changed": false,
    "msg": "CPU number is set to 2"
}
```