### PR TITLE
[Linux] Fix Ubuntu 25.04 Server autoinstall crashes when installing ndctl and rdma packages

### DIFF
--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -46,7 +46,7 @@ autoinstall:
     geoip: true
   packages:
     - sg3-utils
-{% if ubuntu_version is defined and ubuntu_version is version('22.04', '>=') %}
+{% if ubuntu_version is defined and ubuntu_version >= '22.04' and ubuntu_version != '25.04' %}
     - ndctl
     - rdma-core
     - rdmacm-utils

--- a/autoinstall/Ubuntu/Server/user-data.j2
+++ b/autoinstall/Ubuntu/Server/user-data.j2
@@ -46,7 +46,7 @@ autoinstall:
     geoip: true
   packages:
     - sg3-utils
-{% if ubuntu_version is defined and ubuntu_version >= '22.04' and ubuntu_version != '25.04' %}
+{% if ubuntu_version is defined and ubuntu_version is version('22.04', '>=') and ubuntu_version is version('25.04', '!=') %}
     - ndctl
     - rdma-core
     - rdmacm-utils


### PR DESCRIPTION
Ubuntu 25.04 Server autoinstall crashes due to failed to install package ndctl ..

Jira Task: GOSV-4514
