### PR TITLE
[Linux] Remove serial port before PVRDMA testing

### DIFF
--- a/linux/network_device_ops/prepare_network_device_test.yml
+++ b/linux/network_device_ops/prepare_network_device_test.yml
@@ -33,7 +33,7 @@
   ansible.builtin.set_fact:
     eth0_name: "{{ network_adapters_before_hotadd[0] }}"
 
-- name: "Install rdma packages for PVRDMA testing"
+- name: "Prepare for PVRDMA testing"
   when: adapter_type == "pvrdma"
   block:
     - name: "Install rdma packages in {{ guest_os_ansible_distribution }} {{ guest_os_ansible_distribution_ver }}"
@@ -56,12 +56,13 @@
         network_adapter_name: "{{ eth0_name }}"
 
     - name: "Remove MAC address or UUID from network config file"
+      when: network_config_path
       block:
         - name: "Get network config file state"
           include_tasks: ../utils/get_file_stat_info.yml
           vars:
             guest_file_path: "{{ network_config_path }}"
-    
+
         - name: "Remove MAC address or UUID from network config file for '{{ eth0_name }}'"
           ansible.builtin.lineinfile:
             path: "{{ network_config_path }}"
@@ -69,7 +70,30 @@
             state: absent
           delegate_to: "{{ vm_guest_ip }}"
           when: guest_file_exists
-      when: network_config_path
+
+    - name: "Get VM serial port devices"
+      include_tasks: ../../common/vm_get_device_with_type.yml
+      vars:
+        device_vim_type: "vim.vm.device.VirtualSerialPort"
+
+    - name: "Remove VM serial port devices"
+      when:
+        - device_info_with_type is defined
+        - device_info_with_type | length > 0
+      block:
+        - name: "Shutdown guest OS for removing serial port"
+          include_tasks: ../utils/shutdown.yml
+
+        - name: "Remove VM serial port"
+          include_tasks: ../../common/vm_remove_serial_port.yml
+          vars:
+            vm_serial_file_ds_path: "{{ item.backing.fileName }}"
+          with_items: "{{ device_info_with_type }}"
+
+        - name: "Power on VM"
+          include_tasks: ../../common/vm_set_power_state.yml
+          vars:
+            vm_power_state_set: 'powered-on'
 
 - name: "Disable firewall in guest OS"
   include_tasks: ../utils/disable_firewall.yml


### PR DESCRIPTION
If VM has a serial port, VM instant clone will fail. This fix is to remove serial ports before PVRDMA testing, in which VM will be instant cloned.

Below test was run by keeping the serial port after VM deployment.
```
+------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                               |
|                           | bitness='64'                                     |
|                           | cpeString='cpe:/o:suse:sles:15:sp7'              |
|                           | distroAddlVersion='15-SP7'                       |
|                           | distroName='SLES'                                |
|                           | distroVersion='15.7'                             |
|                           | familyName='Linux'                               |
|                           | kernelVersion='6.4.0-150700.48-default'          |
|                           | prettyName='SUSE Linux Enterprise Server 15 SP7' |
+------------------------------------------------------------------------------+


Test Results (Total: 32, Passed: 32, Elapsed Time: 02:49:49)
+----------------------------------------------------------------+
| ID | Name                                 | Status | Exec Time |
+----------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    | Passed | 00:14:24  |
| 02 | check_inbox_driver                   | Passed | 00:02:57  |
| 03 | ovt_verify_pkg_install               | Passed | 00:05:54  |
| 04 | ovt_verify_status                    | Passed | 00:02:45  |
| 05 | vgauth_check_service                 | Passed | 00:00:51  |
| 06 | host_verify_saml_token               | Passed | 00:01:41  |
| 07 | check_ip_address                     | Passed | 00:00:50  |
| 08 | check_os_fullname                    | Passed | 00:01:29  |
| 09 | stat_balloon                         | Passed | 00:00:48  |
| 10 | stat_hosttime                        | Passed | 00:00:42  |
| 11 | device_list                          | Passed | 00:02:55  |
| 12 | power_operation_scripts              | Passed | 00:16:38  |
| 13 | check_quiesce_snapshot_custom_script | Passed | 00:01:09  |
| 14 | memory_hot_add_basic                 | Passed | 00:05:31  |
| 15 | cpu_hot_add_basic                    | Passed | 00:04:51  |
| 16 | cpu_multicores_per_socket            | Passed | 00:08:00  |
| 17 | check_efi_firmware                   | Passed | 00:00:41  |
| 18 | secureboot_enable_disable            | Passed | 00:04:07  |
| 19 | e1000e_network_device_ops            | Passed | 00:04:00  |
| 20 | vmxnet3_network_device_ops           | Passed | 00:03:07  |
| 21 | pvrdma_network_device_ops            | Passed | 00:07:55  |
| 22 | gosc_perl_dhcp                       | Passed | 00:05:21  |
| 23 | gosc_perl_staticip                   | Passed | 00:06:05  |
| 24 | gosc_cloudinit_dhcp                  | Passed | 00:05:35  |
| 25 | gosc_cloudinit_staticip              | Passed | 00:05:15  |
| 26 | paravirtual_vhba_device_ops          | Passed | 00:06:36  |
| 27 | lsilogic_vhba_device_ops             | Passed | 00:18:13  |
| 28 | lsilogicsas_vhba_device_ops          | Passed | 00:06:37  |
| 29 | sata_vhba_device_ops                 | Passed | 00:06:52  |
| 30 | nvme_vhba_device_ops                 | Passed | 00:06:37  |
| 31 | nvdimm_cold_add_remove               | Passed | 00:07:18  |
| 32 | ovt_verify_pkg_uninstall             | Passed | 00:03:00  |
+----------------------------------------------------------------+
```

```
TASK [Get VM serial port devices] **********************************************
task path: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/prepare_network_device_test.yml:74
included: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/../../common/vm_get_device_with_type.yml for localhost

TASK [Shutdown guest OS for removing serial port] ******************************
task path: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/prepare_network_device_test.yml:84
included: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/../utils/shutdown.yml for localhost

TASK [Remove VM serial port] ***************************************************
task path: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/prepare_network_device_test.yml:87
included: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/../../common/vm_remove_serial_port.yml for localhost => (item={'_vimtype': 'vim.vm.device.VirtualSerialPort', 'backing': {'_vimtype': 'vim.vm.device.VirtualSerialPort.FileBackingInfo', 'backingObjectId': None, 'datastore': 'vim.Datastore:datastore-18', 'fileName': '[datastore2] ansible_sles15/serial-20250421094540.log'}, 'connectable': {'_vimtype': 'vim.vm.device.VirtualDevice.ConnectInfo', 'allowGuestControl': True, 'connected': True, 'migrateConnect': None, 'startConnected': True, 'status': 'ok'}, 'controllerKey': 400, 'deviceGroupInfo': None, 'deviceInfo': {'_vimtype': 'vim.Description', 'label': 'Serial port 1', 'summary': 'File [datastore2] ansible_sles15/serial-20250421094540.log'}, 'key': 9000, 'numaNode': None, 'slotInfo': None, 'unitNumber': 0, 'yieldOnPoll': True})

TASK [Remove the serial port output file before removing serial port] **********
task path: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/common/vm_remove_serial_port.yml:8

TASK [Power on VM] *************************************************************
task path: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/prepare_network_device_test.yml:93
included: /home/worker/workspace/Ansible_Regression_SLES_15.x-329/ansible-vsphere-gos-validation/linux/network_device_ops/../../common/vm_set_power_state.yml for localhost
```