### PR TITLE
[Linux] Update dependencies for SLES 16 OVT source install

### DIFF
--- a/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/linux_ovt_build_config.tmpl
@@ -37,7 +37,6 @@ dependencies:
   - gtk3-devel
   - gtkmm3-devel
   - libcurl-devel
-  - libdnet-devel
   - libdrm-devel
   - libmspack-devel
   - libopenssl-devel
@@ -65,7 +64,10 @@ dependencies:
   - xmlsec1-devel
   - xmlsec1-openssl-devel
   {% if guest_os_ansible_distribution_major_ver | int < 16 -%}
+  - libdnet-devel
   - xorg-x11-devel
+  {% else -%}
+  - libvmtools-devel
   {%- endif -%}
 {% endif %}
 


### PR DESCRIPTION
`libdnet-devel` was removed from SLES 16 Snapshot-202504-1, but `libvmtools-devel` is required in SLES 16 now.

```
+------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                         |
|                           | bitness='64'                               |
|                           | cpeString='cpe:/o:suse:sles:16:16.0'       |
|                           | distroAddlVersion='16.0 Snapshot-202504-1' |
|                           | distroName='SUSE Linux'                    |
|                           | distroVersion='16.0'                       |
|                           | familyName='Linux'                         |
|                           | kernelVersion='6.12.0-160000.9-default'    |
|                           | prettyName='SUSE Linux 16.0'               |
+------------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:19:15)
+--------------------------------------------------+
| ID | Name                   | Status | Exec Time |
+--------------------------------------------------+
|  1 | ovt_verify_src_install | Passed | 00:19:01  |
+--------------------------------------------------+
```

```
+------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                               |
|                           | bitness='64'                                     |
|                           | cpeString='cpe:/o:suse:sles:15:sp7'              |
|                           | distroAddlVersion='15-SP7'                       |
|                           | distroName='SLES'                                |
|                           | distroVersion='15.7'                             |
|                           | familyName='Linux'                               |
|                           | kernelVersion='6.4.0-150700.48-default'          |
|                           | prettyName='SUSE Linux Enterprise Server 15 SP7' |
+------------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 2, Elapsed Time: 00:37:37)
+-------------------------------------------------------------+
| ID | Name                              | Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:17:38  |
|  2 | ovt_verify_src_install            | Passed | 00:19:48  |
+-------------------------------------------------------------+
```