### PR TITLE
[Windows] Set nvme_vhba_device_ops_spec13 "Not Applicable" on ESXi 8.0.2 and later

### DIFF
--- a/windows/utils/win_get_nvme_spec_version.yml
+++ b/windows/utils/win_get_nvme_spec_version.yml
@@ -1,0 +1,27 @@
+# Copyright 2025 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Get implemented NVMe spec version in Windows guest OS.
+# Return:
+#   win_nvme_spec_version: the NVMe spec version got in guest OS.
+#
+- name: "Initialize the NVMe spec version in Windows guest OS"
+  ansible.builtin.set_fact:
+    win_nvme_spec_version: ''
+
+- name: "Get NVMe spec version in Windows guest OS"
+  include_tasks: win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: >-
+      Get-Physicaldisk | where-object {$_.Friendlyname -like '*NVMe*'} | 
+      Get-StorageFirmwareInformation).FirmwareVersionInSlot
+
+- name: "Set fact of NVMe spec version"
+  ansible.builtin.set_fact:
+    win_nvme_spec_version: "{{ win_powershell_cmd_output.stdout_lines[0] }}"
+  when:
+    - win_powershell_cmd_output.stdout_lines is defined
+    - win_powershell_cmd_output.stdout_lines | length != 0
+
+- name: "Print NVMe spec version in Windows guest OS"
+  ansible.builtin.debug: var=win_nvme_spec_version

--- a/windows/utils/win_get_nvme_spec_version.yml
+++ b/windows/utils/win_get_nvme_spec_version.yml
@@ -13,7 +13,7 @@
   include_tasks: win_execute_cmd.yml
   vars:
     win_powershell_cmd: >-
-      Get-Physicaldisk | where-object {$_.Friendlyname -like '*NVMe*'} | 
+      (Get-Physicaldisk | where-object {$_.Friendlyname -like '*NVMe*'} | 
       Get-StorageFirmwareInformation).FirmwareVersionInSlot
 
 - name: "Set fact of NVMe spec version"

--- a/windows/vhba_hot_add_remove/check_disk_after_adding.yml
+++ b/windows/vhba_hot_add_remove/check_disk_after_adding.yml
@@ -41,6 +41,10 @@
       the same as the expected value {{ ctrl_num_guest_before | int + 1 }}.
   when: on_new_controller
 
+- name: "Get NVMe spec version in guest OS"
+  include_tasks: ../utils/win_get_nvme_spec_version.yml
+  when: test_disk_ctrl_type == "nvme"
+
 - name: "Initialize new disk and create disk partition in guest OS"
   include_tasks: create_partition_raw_disk.yml
   vars:

--- a/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
+++ b/windows/vhba_hot_add_remove/hot_extend_disk_test.yml
@@ -91,3 +91,6 @@
     that:
       - win_disk_volume_size_after | int == 2
     fail_msg: "Got disk volume '{{ drive_letter_new }}' size '{{ win_disk_volume_size_after }}' GB after extend, not 2GB."
+
+- name: "Get NVMe spec version in guest OS"
+  include_tasks: ../utils/win_get_nvme_spec_version.yml

--- a/windows/vhba_hot_add_remove/nvme_vhba_device_ops_spec13.yml
+++ b/windows/vhba_hot_add_remove/nvme_vhba_device_ops_spec13.yml
@@ -10,9 +10,8 @@
 # https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/
 # release-notes/esxi-update-and-patch-release-notes/vsphere-esxi-802-release-notes.html
 # Default NVMe version 1.3 for Windows virtual machines:
-# Starting with vSphere 8.0 Update 2, the NVMe version of Windows Server 2022
-# or Windows 11 and later virtual machines with hardware version 21 and later,
-# and a virtual NVMe controller, is set to 1.3 by default.
+# Starting with vSphere 8.0 Update 2, the NVMe version is set to 1.3 by default for
+# Windows Server 2022 or Windows 11 and later VMs with hardware version 21 and later.
 # Set this test case result to "Not Applicable" in above situation.
 #
 - name: nvme_vhba_device_ops_spec13
@@ -46,20 +45,6 @@
           when:
             - guest_os_product_type == 'server'
             - guest_os_ansible_kernel is version('10.0.20348.0', '<')
-
-        - name: "Skip test case"
-          include_tasks: ../../common/skip_test_case.yml
-          vars:
-            skip_msg: >-
-              Skip testing on this guest OS '{{ guest_os_ansible_distribution }}' with VM hardware version
-              '{{ vm_hardware_version_num }}', since NVMe version is 1.3 by default for Windows Server 2022,
-              Windows 11 and later VMs with hardware version 21 on ESXi 8.0.2 and later.
-              So skip this test case and only run test case 'nvme_vhba_device_ops' with default NVMe v1.3.
-            skip_reason: "Not Applicable"
-          when:
-            - vm_hardware_version_num | int >= 21
-            - (guest_os_product_type == 'server' and guest_os_build_num | int >= 20348) or 
-              (guest_os_product_type == 'client' and guest_os_build_num | int >= 22000)
 
         - name: "Test run"
           include_tasks: vhba_test.yml

--- a/windows/vhba_hot_add_remove/nvme_vhba_device_ops_spec13.yml
+++ b/windows/vhba_hot_add_remove/nvme_vhba_device_ops_spec13.yml
@@ -3,7 +3,17 @@
 ---
 # Description:
 #   This test case is used for check hotadd, hot remove disk
-# on a new and existing NVMe controller with NVMe Spec 1.3 enabled.
+# on a new and existing NVMe controller with NVMe Spec 1.3 enabled
+# manually.
+# Notes:
+#   Please refer to the release notes of ESXi 8.0.2:
+# https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/
+# release-notes/esxi-update-and-patch-release-notes/vsphere-esxi-802-release-notes.html
+# Default NVMe version 1.3 for Windows virtual machines:
+# Starting with vSphere 8.0 Update 2, the NVMe version of Windows Server 2022
+# or Windows 11 and later virtual machines with hardware version 21 and later,
+# and a virtual NVMe controller, is set to 1.3 by default.
+# Set this test case result to "Not Applicable" in above situation.
 #
 - name: nvme_vhba_device_ops_spec13
   hosts: localhost
@@ -36,6 +46,20 @@
           when:
             - guest_os_product_type == 'server'
             - guest_os_ansible_kernel is version('10.0.20348.0', '<')
+
+        - name: "Skip test case"
+          include_tasks: ../../common/skip_test_case.yml
+          vars:
+            skip_msg: >-
+              Skip testing on this guest OS '{{ guest_os_ansible_distribution }}' with VM hardware version
+              '{{ vm_hardware_version_num }}', since NVMe version is 1.3 by default for Windows Server 2022,
+              Windows 11 and later VMs with hardware version 21 on ESXi 8.0.2 and later.
+              So skip this test case and only run test case 'nvme_vhba_device_ops' with default NVMe v1.3.
+            skip_reason: "Not Applicable"
+          when:
+            - vm_hardware_version_num | int >= 21
+            - (guest_os_product_type == 'server' and guest_os_build_num | int >= 20348) or 
+              (guest_os_product_type == 'client' and guest_os_build_num | int >= 22000)
 
         - name: "Test run"
           include_tasks: vhba_test.yml

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -7,18 +7,20 @@
 # - buslogic: not supported in 64bit Windows guest OS, so no testing.
 #
 - name: "Set fact of whether VM NVMe version 1.3 is enabled by default"
-  ansible.builtin.set_fact:
-    vm_nvme_spec13_enabled: >-
-      {{
-         vm_hardware_version_num | int >= 21 and 
-         ((guest_os_product_type == 'server' and 
-         (vm_guest_id | regex_search('windows(\\d+)srvNext', '\\1'))[0] | int >= 2019) or 
-         (guest_os_product_type == 'client' and 
-         (vm_guest_id | regex_search('windows(\\d+)_', '\\1'))[0] | int >= 11))
-      }}
   when:
+    - vm_hardware_version_num | int >= 21
     - test_disk_ctrl_type == 'nvme'
     - vm_nvme_spec13_enabled is undefined
+  block:
+    - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
+      ansible.builtin.set_fact:
+        vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)srvNext', '\\1') | first | int >= 2019 }}"
+      when: guest_os_product_type == 'server'
+
+    - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
+      ansible.builtin.set_fact:
+        vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)_', '\\1') | first | int >= 11 }}"
+      when: guest_os_product_type == 'client'
 
 - name: "Skip test case"
   include_tasks: ../../common/skip_test_case.yml
@@ -32,7 +34,7 @@
   when:
     - test_disk_ctrl_type == 'nvme'
     - test_purpose == "hot-add-spec13"
-    - vm_nvme_spec13_enabled
+    - vm_nvme_spec13_enabled is defined and vm_nvme_spec13_enabled
 
 - name: "Get VM current disk controller info"
   include_tasks: get_vm_disk_ctrl_info.yml

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -11,8 +11,10 @@
     vm_nvme_spec13_enabled: >-
       {{
          vm_hardware_version_num | int >= 21 and 
-         ((guest_os_product_type == 'server' and guest_os_build_num | int >= 20348) or 
-         (guest_os_product_type == 'client' and guest_os_build_num | int >= 22000))
+         ((guest_os_product_type == 'server' and 
+         (vm_guest_id | regex_search('windows(\\d+)srvNext', '\\1'))[0] | int >= 2019) or 
+         (guest_os_product_type == 'client' and 
+         (vm_guest_id | regex_search('windows(\\d+)_', '\\1'))[0] | int >= 11))
       }}
   when:
     - test_disk_ctrl_type == 'nvme'

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -15,12 +15,16 @@
     - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
       ansible.builtin.set_fact:
         vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)srvNext', '\\1') | first | int >= 2019 }}"
-      when: guest_os_product_type == 'server'
+      when:
+        - guest_os_product_type == 'server'
+        - vm_guest_id | regex_search('windows(\\d+)srvNext')
 
     - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
       ansible.builtin.set_fact:
         vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)_', '\\1') | first | int >= 11 }}"
-      when: guest_os_product_type == 'client'
+      when:
+        - guest_os_product_type == 'client'
+        - vm_guest_id | regex_search('windows(\\d+)_')
 
 - name: "Skip test case"
   include_tasks: ../../common/skip_test_case.yml

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -28,8 +28,9 @@
       So skip this test case and only run test case 'nvme_vhba_device_ops' with default NVMe v1.3.
     skip_reason: "Not Applicable"
   when:
-    - vm_nvme_spec13_enabled is defined and vm_nvme_spec13_enabled
+    - test_disk_ctrl_type == 'nvme'
     - test_purpose == "hot-add-spec13"
+    - vm_nvme_spec13_enabled
 
 - name: "Get VM current disk controller info"
   include_tasks: get_vm_disk_ctrl_info.yml

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -15,16 +15,12 @@
     - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
       ansible.builtin.set_fact:
         vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)srvNext', '\\1') | first | int >= 2019 }}"
-      when:
-        - guest_os_product_type == 'server'
-        - vm_guest_id | regex_search('windows(\\d+)srvNext')
+      when: vm_guest_id | regex_search('windows(\\d+)srvNext')
 
     - name: "For Windows {{ guest_os_product_type }} with guest ID {{ vm_guest_id }}"
       ansible.builtin.set_fact:
         vm_nvme_spec13_enabled: "{{ vm_guest_id | regex_search('windows(\\d+)_', '\\1') | first | int >= 11 }}"
-      when:
-        - guest_os_product_type == 'client'
-        - vm_guest_id | regex_search('windows(\\d+)_')
+      when: vm_guest_id | regex_search('windows(\\d+)_')
 
 - name: "Skip test case"
   include_tasks: ../../common/skip_test_case.yml

--- a/windows/vhba_hot_add_remove/vhba_test.yml
+++ b/windows/vhba_hot_add_remove/vhba_test.yml
@@ -6,6 +6,31 @@
 # - lsilogic: no inbox driver in Windows guest OS now, so no testing.
 # - buslogic: not supported in 64bit Windows guest OS, so no testing.
 #
+- name: "Set fact of whether VM NVMe version 1.3 is enabled by default"
+  ansible.builtin.set_fact:
+    vm_nvme_spec13_enabled: >-
+      {{
+         vm_hardware_version_num | int >= 21 and 
+         ((guest_os_product_type == 'server' and guest_os_build_num | int >= 20348) or 
+         (guest_os_product_type == 'client' and guest_os_build_num | int >= 22000))
+      }}
+  when:
+    - test_disk_ctrl_type == 'nvme'
+    - vm_nvme_spec13_enabled is undefined
+
+- name: "Skip test case"
+  include_tasks: ../../common/skip_test_case.yml
+  vars:
+    skip_msg: >-
+      Skip testing on this guest OS '{{ guest_os_ansible_distribution }}' with VM hardware version
+      '{{ vm_hardware_version_num }}', since NVMe version is 1.3 by default for Windows Server 2022,
+      Windows 11 and later VMs with hardware version 21 on ESXi 8.0.2 and later.
+      So skip this test case and only run test case 'nvme_vhba_device_ops' with default NVMe v1.3.
+    skip_reason: "Not Applicable"
+  when:
+    - vm_nvme_spec13_enabled is defined and vm_nvme_spec13_enabled
+    - test_purpose == "hot-add-spec13"
+
 - name: "Get VM current disk controller info"
   include_tasks: get_vm_disk_ctrl_info.yml
 

--- a/windows/vhba_hot_add_remove/vhba_test_prepare.yml
+++ b/windows/vhba_hot_add_remove/vhba_test_prepare.yml
@@ -16,8 +16,8 @@
     disk_controller_facts_data: "{{ disk_ctrls_before_hotadd }}"
     new_vhba_type: "{{ disk_controller }}"
 
-- name: "Enable NVMe spec 1.3"
+- name: "Enable NVMe spec 1.3 for NVMe '{{ test_purpose }}' testing"
   include_tasks: enable_vm_nvme_spec13.yml
   when:
     - test_disk_ctrl_type == 'nvme'
-    - test_purpose in ["hot-add-spec13", "hot-extend"]
+    - test_purpose == "hot-add-spec13" or (test_purpose == "hot-extend" and not vm_nvme_spec13_enabled)

--- a/windows/vhba_hot_add_remove/vhba_test_prepare.yml
+++ b/windows/vhba_hot_add_remove/vhba_test_prepare.yml
@@ -20,4 +20,5 @@
   include_tasks: enable_vm_nvme_spec13.yml
   when:
     - test_disk_ctrl_type == 'nvme'
-    - test_purpose == "hot-add-spec13" or (test_purpose == "hot-extend" and not vm_nvme_spec13_enabled)
+    - test_purpose == "hot-add-spec13" or (test_purpose == "hot-extend" and 
+      (vm_nvme_spec13_enabled is undefined or not vm_nvme_spec13_enabled))


### PR DESCRIPTION
On vSphere 8.0.2 and later with VM hwv 21 or higher, `nvme_vhba_device_ops_spec13` will not run.
```
Test Results (Total: 5, Passed: 4, Skipped: 1, Elapsed Time: 01:55:30)
+-----------------------------------------------------------------+
| ID | Name                        |   Status         | Exec Time |
+-----------------------------------------------------------------+
|  1 | deploy_vm_bios_nvme_e1000e  |   Passed         | 00:19:12  |
|  2 | paravirtual_vhba_device_ops |   Passed         | 00:12:38  |
|  3 | nvme_vhba_device_ops        |   Passed         | 01:19:53  |
|  4 | nvme_vhba_device_ops_spec13 | * Not Applicable | 00:00:44  |
|  5 | nvme_disk_hot_extend_spec13 |   Passed         | 00:02:52  |
+-----------------------------------------------------------------+
```