### PR TITLE
[Pardus] Change GOSC with cloud-init of pardus 21.x/23.x to unsupportted status

### DIFF
--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -83,7 +83,7 @@
       when:
         - enable_cloudinit_gosc
         - ((guest_os_ansible_distribution == "Debian" and guest_os_ansible_distribution_major_ver | int == 12) or 
-           (guest_os_ansible_distribution == "Pardus GNU/Linux" and guest_os_ansible_distribution_major_ver | int >= 21))
+           (guest_os_ansible_distribution == "Pardus GNU/Linux" and guest_os_ansible_distribution_major_ver | int <= 23))
       block:
         - name: "Set fact of cloud-init GOSC support status to False for {{ vm_guest_os_distribution }}"
           ansible.builtin.set_fact:

--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -82,8 +82,8 @@
     - name: "Set cloud-init GOSC support status for {{ vm_guest_os_distribution }}"
       when:
         - enable_cloudinit_gosc
-        - guest_os_ansible_distribution == "Debian"
-        - guest_os_ansible_distribution_major_ver | int == 12
+        - ((guest_os_ansible_distribution == "Debian" and guest_os_ansible_distribution_major_ver | int == 12) or 
+           (guest_os_ansible_distribution == "Pardus GNU/Linux" and guest_os_ansible_distribution_major_ver | int >= 21))
       block:
         - name: "Set fact of cloud-init GOSC support status to False for {{ vm_guest_os_distribution }}"
           ansible.builtin.set_fact:


### PR DESCRIPTION
Task:
GOSV-4718: Change GOSC with cloud-init of pardus 21.x/23.x to unsupportted status



Test result:
Done. please check GOSV-4718