### PR TITLE
Fix the conditions for ova deployment

### DIFF
--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -110,6 +110,7 @@
 
 - name: "Shutdown guest OS"
   include_tasks: ../utils/shutdown.yml
+  when: vm_guest_ip is defined and vm_guest_ip
 
 - name: "Collect serial port log before removing serial port"
   include_tasks: collect_serial_port_log.yml
@@ -130,6 +131,7 @@
   loop_control:
     loop_var: vm_cdrom
   when:
+    - guest_os_ansible_distribution is defined
     - guest_os_ansible_distribution == "Ubuntu"
     - vm_existing_cdrom_list is defined
     - vm_existing_cdrom_list | length > 0

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -89,18 +89,6 @@
     - (hardware_version == "latest" or
        (vm_hardware_version_num | int < hardware_version | int))
 
-# Add serial port for collecting messages
-- name: "Add a serial port for VM"
-  include_tasks: ../../common/vm_add_serial_port.yml
-
-- name: "Reconfigure VM with cloud-init"
-  include_tasks: reconfigure_vm_with_cloudinit.yml
-  when: ova_guest_os_type in ['photon', 'ubuntu', 'amazon']
-
-- name: "Reconfigure VM with Ignition"
-  include_tasks: reconfigure_vm_with_ignition.yml
-  when: ova_guest_os_type in ['flatcar', 'rhcos']
-
 - name: "Warning about unknown guest OS type"
   ansible.builtin.debug:
     msg: >-
@@ -108,33 +96,46 @@
       reconfiguration. Please add it if needed or the following tests might fail.
   when: ova_guest_os_type == 'unknown'
 
-- name: "Shutdown guest OS"
-  include_tasks: ../utils/shutdown.yml
-  when: vm_guest_ip is defined and vm_guest_ip
+- name: "Reconfigure VM when guest OS type is {{ ova_guest_os_type }}"
+  when: ova_guest_os_type != 'unknown'
+  block:
+    # Add serial port for collecting messages
+    - name: "Add a serial port for VM"
+      include_tasks: ../../common/vm_add_serial_port.yml
 
-- name: "Collect serial port log before removing serial port"
-  include_tasks: collect_serial_port_log.yml
+    - name: "Reconfigure VM with cloud-init"
+      include_tasks: reconfigure_vm_with_cloudinit.yml
+      when: ova_guest_os_type in ['photon', 'ubuntu', 'amazon']
 
-- name: "Remove serial port from VM"
-  include_tasks: ../../common/vm_remove_serial_port.yml
+    - name: "Reconfigure VM with Ignition"
+      include_tasks: reconfigure_vm_with_ignition.yml
+      when: ova_guest_os_type in ['flatcar', 'rhcos']
 
-# The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
-- name: "Remove existing CDROMs"
-  include_tasks: ../../common/vm_configure_cdrom.yml
-  vars:
-    cdrom_type: client
-    cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
-    cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
-    cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
-    cdrom_state: absent
-  with_items: "{{ vm_existing_cdrom_list }}"
-  loop_control:
-    loop_var: vm_cdrom
-  when:
-    - guest_os_ansible_distribution is defined
-    - guest_os_ansible_distribution == "Ubuntu"
-    - vm_existing_cdrom_list is defined
-    - vm_existing_cdrom_list | length > 0
+    - name: "Shutdown guest OS"
+      include_tasks: ../utils/shutdown.yml
+
+    - name: "Collect serial port log before removing serial port"
+      include_tasks: collect_serial_port_log.yml
+
+    - name: "Remove serial port from VM"
+      include_tasks: ../../common/vm_remove_serial_port.yml
+
+    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+    - name: "Remove existing CDROMs"
+      include_tasks: ../../common/vm_configure_cdrom.yml
+      vars:
+        cdrom_type: client
+        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+        cdrom_state: absent
+      with_items: "{{ vm_existing_cdrom_list }}"
+      loop_control:
+        loop_var: vm_cdrom
+      when:
+        - guest_os_ansible_distribution == "Ubuntu"
+        - vm_existing_cdrom_list is defined
+        - vm_existing_cdrom_list | length > 0
 
 - name: "Power on VM"
   include_tasks: ../../common/vm_set_power_state.yml


### PR DESCRIPTION
When ova_path=/mnt/fedora-42-GA-64bit/fedora-42-GA-64bit.ovf instead of the official ova from ubuntu, photon, rhcos or flatcar, deploy_vm_from_ova failed due to "vm_guest_ip is undefined". 

Fixed this issue and testing done:
```
+--------------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                             |
+--------------------------------------------------------------------------------+
| VMTools Version           | 12.4.0 (build-23259341)                            |
+--------------------------------------------------------------------------------+
| Config Guest Id           | other4xLinux64Guest                                |
+--------------------------------------------------------------------------------+
| GuestInfo Guest Id        | fedora64Guest                                      |
+--------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Fedora (64-bit)                            |
+--------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                         |
+--------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                 |
|                           | bitness='64'                                       |
|                           | cpeString='cpe:/o:fedoraproject:fedora:42'         |
|                           | distroAddlVersion='42 (Workstation Edition)'       |
|                           | distroName='Fedora Linux'                          |
|                           | distroVersion='42'                                 |
|                           | familyName='Linux'                                 |
|                           | kernelVersion='6.14.0-63.fc42.x86_64'              |
|                           | prettyName='Fedora Linux 42 (Workstation Edition)' |
+--------------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:04:17)
+-----------------------------------------+
| ID | Name          | Status | Exec Time |
+-----------------------------------------+
|  1 | deploy_vm_ova | Passed | 00:04:04  |
+-----------------------------------------+
```