### PR TITLE
[Linux] Skip GOSC testing for scale out guest ids

### DIFF
--- a/linux/guest_customization/check_gosc_support_status.yml
+++ b/linux/guest_customization/check_gosc_support_status.yml
@@ -22,9 +22,9 @@
   vars:
     skip_msg: "Test case '{{ ansible_play_name }}' is skipped because guest id {{ vm_guest_id }} doesn't support guest OS customization on vCenter Server {{ vcenter_version }}"
     skip_reason: "Not Supported"
-  when:
-    - vm_guest_id is match('asianux.*')
-    - vcenter_version is version('8.0.0', '<')
+  when: >-
+    (vm_guest_id is match('asianux.*') and vcenter_version is version('8.0.0', '<')) or
+    vm_guest_id is match('(prolinux|fusionos|kylinlinux)_64Guest')
 
 - name: "Check GOSC support status"
   when:


### PR DESCRIPTION
Skip GOSC testing for scale out guest ids which don't support guest customization.

```
| VMTools Version           | 11.0.5 (build-15389592)                |
+--------------------------------------------------------------------+
| Config Guest Id           | prolinux_64Guest                       |
+--------------------------------------------------------------------+
| GuestInfo Guest Id        | other3xLinux64Guest                    |
+--------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 3.x Linux (64-bit)               |
+--------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                             |
+--------------------------------------------------------------------+
| GuestInfo Detailed Data   | bitness='64'                           |
|                           | distroName='ProLinux Server'           |
|                           | distroVersion='7.9'                    |
|                           | familyName='Linux'                     |
|                           | kernelVersion='3.10.0-1160.el7.x86_64' |
|                           | prettyName='ProLinux 7.9'              |
+--------------------------------------------------------------------+


Test Results (Total: 5, Passed: 1, Skipped: 4, Elapsed Time: 00:24:18)
+----------------------------------------------------------------------+
| ID | Name                              |   Status        | Exec Time |
+----------------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 |   Passed        | 00:20:59  |
|  2 | gosc_perl_dhcp                    | * Not Supported | 00:00:53  |
|  3 | gosc_perl_staticip                | * Not Supported | 00:00:42  |
|  4 | gosc_cloudinit_dhcp               | * Not Supported | 00:00:44  |
|  5 | gosc_cloudinit_staticip           | * Not Supported | 00:00:40  |
+----------------------------------------------------------------------+

```