### PR TITLE
[Linux] Fix secure boot state checking in guest OS

### DIFF
--- a/linux/secureboot_enable_disable/check_secureboot_state.yml
+++ b/linux/secureboot_enable_disable/check_secureboot_state.yml
@@ -1,0 +1,35 @@
+# Copyright 2025 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Check secure boot state in guest OS after secure boot is
+# enabled or disabled on VM
+#
+- name: "Initialize fact of secure boot state in guest OS"
+  ansible.builtin.set_fact:
+    guest_secureboot_state: ""
+
+- name: "Get dmesg after secure boot is {{ vm_secureboot_state }}"
+  include_tasks: ../utils/collect_dmesg.yml
+  vars:
+    dmesg_output_file_name: "dmesg_after_secureboot_{{ vm_secureboot_state }}.log"
+
+- name: "Set fact of secure boot state in guest OS after secure boot is {{ vm_secureboot_state }}"
+  ansible.builtin.set_fact:
+    guest_secureboot_state: "{{ (secureboot_match | length == 1) | ternary(secureboot_match[0], '') }}"
+  vars:
+    secureboot_match: >-
+      {{
+        dmesg_cmd_result.stdout | default('') |
+        regex_search('secure *boot.*(enabled|disabled)', '\1', ignorecase=True)
+      }}
+
+- name: "Check secure boot in guest OS is {{ vm_secureboot_state }}"
+  ansible.builtin.assert:
+    that:
+      - guest_secureboot_state | lower == vm_secureboot_state
+    fail_msg: >-
+      After secure boot is {{ vm_secureboot_state }} on VM, the secure boot state in guest OS
+      is {{ guest_secureboot_state }}, not as expected {{ vm_secureboot_state }}.
+    success_msg: >-
+      After secure boot is {{ vm_secureboot_state }} on VM, the secure boot state in guest OS
+      is {{ guest_secureboot_state }}.

--- a/linux/secureboot_enable_disable/secureboot_enable_disable.yml
+++ b/linux/secureboot_enable_disable/secureboot_enable_disable.yml
@@ -71,7 +71,7 @@
               - boot_facts.vm_boot_info.current_secure_boot_enabled is defined
               - boot_facts.vm_boot_info.current_secure_boot_enabled
             fail_msg: "Failed to enable secure boot on VM"
-            success_msg: "VM current secure boot is enabled"
+            success_msg: "Successfully enabled secure boot on VM"
 
         - name: "Power on VM"
           include_tasks: ../../common/vm_set_power_state.yml
@@ -89,23 +89,17 @@
             vm_wait_log_retries: 1
             vm_wait_log_ignore_errors: true
 
-        - name: "Get messages in dmesg ring buffer after secure boot is enabled"
-          include_tasks: ../utils/collect_dmesg.yml
+        - name: "Not found 'Image APPROVED' in vmware.log"
+          ansible.builtin.fail:
+            msg: >-
+              Test failed because there is no keyword 'Image APPROVED' in VM's
+              vmware.log when secure boot is enabled
+          when: not vm_wait_log_msg_success
+
+        - name: "Check secure boot state in guest OS after secure boot is enabled"
+          include_tasks: check_secureboot_state.yml
           vars:
-            dmesg_output_file_name: "dmesg_after_secureboot_enabled.log"
-
-        - name: "Set fact of guest OS secure boot state after secure boot is enabled"
-          ansible.builtin.set_fact:
-            guest_secureboot_state: "{{ dmesg_cmd_result.stdout | default('') |
-                                        regex_search('Secure boot (enabled|disabled)', ignorecase=True) |
-                                        regex_replace('Secure boot ', '', ignorecase=True) | lower }}"
-
-        - name: "Set fact of secure boot enable test result"
-          ansible.builtin.set_fact:
-            secureboot_enabled_pass: true
-          when:
-            - vm_wait_log_msg_success
-            - guest_secureboot_state == 'enabled'
+            vm_secureboot_state: "enabled"
 
         # Disable secureboot
         - name: "Shutdown guest OS"
@@ -122,7 +116,7 @@
               - boot_facts.vm_boot_info.current_secure_boot_enabled is defined
               - not boot_facts.vm_boot_info.current_secure_boot_enabled
             fail_msg: "Failed to disable secure boot on VM"
-            success_msg: "VM current secure boot is disabled"
+            success_msg: "Successfully disabled secure boot on VM"
 
         - name: "Power on VM after disabling secure boot"
           include_tasks: ../../common/vm_set_power_state.yml
@@ -132,28 +126,10 @@
         - name: "Update inventory"
           include_tasks: ../../common/update_inventory.yml
 
-        - name: "Get messages in dmesg ring buffer after secure boot is disabled"
-          include_tasks: ../utils/collect_dmesg.yml
+        - name: "Check secure boot state in guest OS after secure boot is disabled"
+          include_tasks: check_secureboot_state.yml
           vars:
-            dmesg_output_file_name: "dmesg_after_secureboot_disabled.log"
-
-        - name: "Set fact of guest OS secure boot state after secure boot is disabled"
-          ansible.builtin.set_fact:
-            guest_secureboot_state: "{{ dmesg_cmd_result.stdout | default('') |
-                                        regex_search('Secure boot (enabled|disabled)', ignorecase=True) |
-                                        regex_replace('Secure boot ', '', ignorecase=True) | lower }}"
-
-        - name: "Set fact of secure boot disable test result"
-          ansible.builtin.set_fact:
-            secureboot_disabled_pass: true
-          when: guest_secureboot_state == 'disabled'
-
-        - name: "Check secure boot enable and disable test results"
-          ansible.builtin.assert:
-            that:
-              - secureboot_enabled_pass and secureboot_disabled_pass
-            fail_msg: "Enable secureboot result: {{ secureboot_enabled_pass }}, disable secureboot result: {{ secureboot_disabled_pass }}"
-            success_msg: "Enable secureboot result: {{ secureboot_enabled_pass }}, disable secureboot result: {{ secureboot_disabled_pass }}"
+            vm_secureboot_state: "disabled"
       rescue:
         - name: "Collect Linux guest OS information for triage"
           include_tasks: ../setup/linux_test_rescue.yml


### PR DESCRIPTION
The message about secure boot state on SLES for ARM is different from SLES for x86:

SLES for ARM
```
[    0.079250] [      T1] ima: secureboot mode disabled
```
```
[    0.065112] [      T1] ima: secureboot mode enabled
```
SLES for x86
```
[    0.000000] [      T0] secureboot: Secure boot disabled
```
```
[    0.000000] [      T0] secureboot: Secure boot enabled
```
Tested passed on Linux for ARM and Linux for x86
```
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='Arm'                             |
|                           | bitness='64'                                   |
|                           | distroAddlVersion='24.04.2 LTS (Noble Numbat)' |
|                           | distroName='Ubuntu'                            |
|                           | distroVersion='24.04'                          |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.8.0-60-generic'               |
|                           | prettyName='Ubuntu 24.04.2 LTS'                |
+----------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:12:19)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | secureboot_enable_disable | Passed | 00:09:40  |
+-----------------------------------------------------+
```

````
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='Arm'                             |
|                           | bitness='64'                                   |
|                           | cpeString='cpe:/o:suse:sles:16:16.0'           |
|                           | distroAddlVersion='16.0 Beta4'                 |
|                           | distroName='SLES'                              |
|                           | distroVersion='16.0'                           |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.12.0-160000.11-default'       |
|                           | prettyName='SUSE Linux Enterprise Server 16.0' |
+----------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:11:36)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | secureboot_enable_disable | Passed | 00:09:17  |
+-----------------------------------------------------+
````

```
+--------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                           |
|                           | bitness='64'                                 |
|                           | cpeString='cpe:/o:rocky:rocky:9::baseos'     |
|                           | distroAddlVersion='9.6 (Blue Onyx)'          |
|                           | distroName='Rocky Linux'                     |
|                           | distroVersion='9.6'                          |
|                           | familyName='Linux'                           |
|                           | kernelVersion='5.14.0-570.17.1.el9_6.x86_64' |
|                           | prettyName='Rocky Linux 9.6 (Blue Onyx)'     |
+--------------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:04:59)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | secureboot_enable_disable | Passed | 00:04:45  |
+-----------------------------------------------------+
```