### PR TITLE
[Linux] Fix guest OS CPU number and cores per socket for ARM

### DIFF
--- a/linux/utils/get_cpu_info.yml
+++ b/linux/utils/get_cpu_info.yml
@@ -1,26 +1,31 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- name: "Initialize the fact of cpu information"
+- name: "Initialize facts of CPU number and cores per socket in guest OS"
   ansible.builtin.set_fact:
     guest_cpu_num: ""
     guest_cpu_cores: ""
 
-- name: "Get CPU info for {{ guest_os_ansible_distribution }}"
-  when: guest_os_family != "FreeBSD"
+- name: "Get CPU info on {{ vm_guest_os_ansible_distribution }}"
+  when: guest_os_ansible_system == "linux"
   block:
-    - name: "Get system processor information"
-      include_tasks: ../../common/get_system_info.yml
-      vars:
-        filter: "ansible_processor*"
+    - name: "Get CPU number and cores per socket in guest OS"
+      ansible.builtin.shell: "lscpu | grep -e '^CPU(s)' -e '^Core(s) per socket'"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: lscpu_result
 
-    - name: "Set the fact of CPU number and cores in guest"
+    - name: "Set fact of CPU number and cores per socket in guest OS"
       ansible.builtin.set_fact:
-        guest_cpu_num: "{{ guest_system_info.ansible_processor_vcpus }}"
-        guest_cpu_cores: "{{ guest_system_info.ansible_processor_cores }}"
+        guest_cpu_num: "{{ guest_cpu_details['CPU(s)'] | default('') }}"
+        guest_cpu_cores: "{{ guest_cpu_details['Core(s) per socket'] | default('') }}"
+      vars:
+        guest_cpu_details: "{{ lscpu_result.stdout | from_yaml }}"
+      when:
+        - lscpu_result.stdout is defined
+        - lscpu_result.stdout
 
-- name: "Get CPU info for FreeBSD"
-  when: guest_os_family == "FreeBSD"
+- name: "Get CPU info on {{ vm_guest_os_ansible_distribution }}"
+  when: guest_os_ansible_system == "freebsd"
   block:
     - name: "Get number of CPUs"
       ansible.builtin.command: "sysctl -n hw.ncpu"
@@ -44,4 +49,4 @@
         guest_cpu_cores: "{{ get_cpu_cores_results.stdout.split(':')[-1].split('core')[0].split()[-1] }}"
 
 - ansible.builtin.debug:
-    msg: "Guest OS has {{ guest_cpu_num }} CPU, and {{ guest_cpu_cores }} core(s) per socket"
+    msg: "Guest OS has {{ guest_cpu_num }} CPU(s), and {{ guest_cpu_cores }} core(s) per socket"

--- a/linux/utils/get_cpu_info.yml
+++ b/linux/utils/get_cpu_info.yml
@@ -48,5 +48,6 @@
         guest_cpu_num: "{{ get_ncpu_results.stdout }}"
         guest_cpu_cores: "{{ get_cpu_cores_results.stdout.split(':')[-1].split('core')[0].split()[-1] }}"
 
-- ansible.builtin.debug:
+- name: "Display guest OS CPU numbers and cores per socket"
+  ansible.builtin.debug:
     msg: "Guest OS has {{ guest_cpu_num }} CPU(s), and {{ guest_cpu_cores }} core(s) per socket"


### PR DESCRIPTION
Due to Ansible module issue https://github.com/ansible/ansible/issues/78092, CPU information is not correct in ansible facts when the VM is running on ARM server. This fix used `lscpu` command to get CPU numbers and cores per socket in guest OS.

```
+-----------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='Arm'                  |
|                           | bitness='64'                        |
|                           | distroAddlVersion='5.0'             |
|                           | distroName='VMware Photon OS'       |
|                           | distroVersion='5.0'                 |
|                           | familyName='Linux'                  |
|                           | kernelVersion='6.1.10-10.ph5-esx'   |
|                           | prettyName='VMware Photon OS/Linux' |
+-----------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:18:05)
+-----------------------------------------------------+
| ID | Name                      | Status | Exec Time |
+-----------------------------------------------------+
|  1 | cpu_multicores_per_socket | Passed | 00:15:28  |
+-----------------------------------------------------+
```