### PR TITLE
Enable ntpClient firewall rule after starting ntpd service

### DIFF
--- a/linux/host_verify_saml_token/set_vsphere_ntp_servers.yml
+++ b/linux/host_verify_saml_token/set_vsphere_ntp_servers.yml
@@ -36,23 +36,6 @@
       vars:
         esxi_ntp_servers: "{{ vsphere_ntp_servers }}"
 
-# Set firewall rule for NTP traffic if it is not enabled
-- name: "Get firewall rule for NTP traffic on ESXi server"
-  include_tasks: ../../common/esxi_get_firewall_rule.yml
-  vars:
-    esxi_firewall_rule_name: "ntpClient"
-
-- name: "Enable firewall rule for NTP traffic on ESXi server"
-  include_tasks: ../../common/esxi_set_firewall_rule.yml
-  vars:
-    rule_name: "ntpClient"
-    rule_enabled: true
-  when: >-
-    esxi_firewall_rule_info.enabled is undefined or
-    not esxi_firewall_rule_info.enabled or
-    esxi_firewall_rule_info.allowed_hosts.all_ip is undefined or
-    not esxi_firewall_rule_info.allowed_hosts.all_ip
-
 # Start ntpd service if it is not started
 - name: "Get 'ntpd' service info on ESXi server"
   include_tasks: ../../common/esxi_get_service_info.yml
@@ -71,3 +54,22 @@
     esxi_service_state: "{{ esxi_service_running | ternary('unchanged', 'start') }}"
     esxi_service_policy: "on"
   when: (not esxi_service_running) or (not esxi_service_policy_on)
+
+# Get firewall rule for NTP traffic
+- name: "Get firewall rule for NTP traffic on ESXi server"
+  include_tasks: ../../common/esxi_get_firewall_rule.yml
+  vars:
+    esxi_firewall_rule_name: "ntpClient"
+
+# The firewall rule of ntpClient is owned by system service, which can be set
+# after the service is running.
+- name: "Enable firewall rule to allower all NTP traffic on ESXi server"
+  include_tasks: ../../common/esxi_set_firewall_rule.yml
+  vars:
+    rule_name: "ntpClient"
+    rule_enabled: true
+  when: >-
+    esxi_firewall_rule_info.enabled is undefined or
+    not esxi_firewall_rule_info.enabled or
+    esxi_firewall_rule_info.allowed_hosts.all_ip is undefined or
+    not esxi_firewall_rule_info.allowed_hosts.all_ip

--- a/linux/host_verify_saml_token/set_vsphere_ntp_servers.yml
+++ b/linux/host_verify_saml_token/set_vsphere_ntp_servers.yml
@@ -63,7 +63,7 @@
 
 # The firewall rule of ntpClient is owned by system service, which can be set
 # after the service is running.
-- name: "Enable firewall rule to allower all NTP traffic on ESXi server"
+- name: "Enable firewall rule to allow all NTP traffic on ESXi server"
   include_tasks: ../../common/esxi_set_firewall_rule.yml
   vars:
     rule_name: "ntpClient"


### PR DESCRIPTION
`ntpClient` firewall rule is owned by system service `ntpd`. It cannot be enabled when `ntpd` service is not running.