### PR TITLE
Fix the failure of configuring vm when ova_path is defined

### DIFF
--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -29,6 +29,7 @@
   when:
     - guest_os_python_version is version('3.0.0', '>=')
     - guest_os_ansible_pkg_mgr is match('yum|dnf|zypper')
+    - ova_path is undefined
 
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"

--- a/linux/utils/config_repos.yml
+++ b/linux/utils/config_repos.yml
@@ -14,7 +14,9 @@
       - os_installation_iso_list | type_debug == 'list'
       - os_installation_iso_list | length >= 1
     fail_msg: "'os_installation_iso_list' must be set with a list of installation ISO image(s) of {{ vm_guest_os_distribution }}"
-  when: guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'ProLinux']
+  when:
+    - guest_os_ansible_distribution in ['SLES', 'SLED', 'RedHat', 'ProLinux']
+    - ova_path is undefined
 
 - name: "Disable all existing repositories on {{ vm_guest_os_distribution }}"
   include_tasks: enable_disable_repos.yml


### PR DESCRIPTION
When os_installation_iso_list is undefined and ova_path is defined (e.g.: /mnt/ovf/RHEL-Server-10.0/RHEL-Server-10.0.ovf), configuring guest vm will fail in the following tasks:
1. "os_installation_iso_list | length >= 1" check in linux/utils/config_repos.yml:10
2. "dnf install -y python3*-rpm" in linux/utils/install_uninstall_package.yml:129. 

So update scripts to skip these tasks when ova_path is defined. Testing done:
```
+------------------------------------------+
| ID | Name           | Status | Exec Time |
+------------------------------------------+
|  1 | vm_pre_config  | Passed | 00:00:05  |
|  2 | deploy_vm_ova  | Passed | 00:05:13  |
|  3 | vmlibrary_main | Passed | 01:08:15  |
+------------------------------------------+
```