### PR TITLE
Update the local and online repos for Kylin Linux

### DIFF
--- a/linux/utils/add_local_dvd_repo.yml
+++ b/linux/utils/add_local_dvd_repo.yml
@@ -95,7 +95,7 @@
 
 - name: "Set the local DVD repository name"
   ansible.builtin.set_fact:
-    dvd_repo_name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_DVD"
+    dvd_repo_name: "{{ guest_os_ansible_distribution.split(' ')[0] }}_{{ guest_os_ansible_distribution_ver }}_DVD"
 
 # Add repository from CDROM for RedHat and Suse family OS
 - name: "Add repositories from CDROM for {{ vm_guest_os_distribution }}"

--- a/linux/utils/config_repos.yml
+++ b/linux/utils/config_repos.yml
@@ -21,7 +21,7 @@
   vars:
     repo_state: "disabled"
   when: >-
-    guest_os_ansible_distribution in ['RedHat', 'ProLinux'] or
+    guest_os_ansible_distribution.split(' ')[0] in ['RedHat', 'ProLinux', 'Kylin'] or
     guest_os_family == 'Suse'
 
 # If os_installation_iso_list is set for openSUSE, AlmaLinux, Rocky, CentOS, OracleLinux, MIRACLE LINUX and etc,

--- a/linux/utils/config_repos.yml
+++ b/linux/utils/config_repos.yml
@@ -21,7 +21,7 @@
   vars:
     repo_state: "disabled"
   when: >-
-    guest_os_ansible_distribution.split(' ')[0] in ['RedHat', 'ProLinux', 'Kylin'] or
+    guest_os_ansible_distribution is match('^(RedHat|ProLinux|(Kylin.*))$') or
     guest_os_family == 'Suse'
 
 # If os_installation_iso_list is set for openSUSE, AlmaLinux, Rocky, CentOS, OracleLinux, MIRACLE LINUX and etc,

--- a/linux/utils/list_repos.yml
+++ b/linux/utils/list_repos.yml
@@ -19,13 +19,13 @@
   block:
     - name: "Remove unavailable online repositories on {{ vm_guest_os_distribution }}"
       ansible.builtin.shell: |-
-        repo_files=`grep -l prolinux-repo.tmaxos.com /etc/yum.repos.d/*.repo`;
+        repo_files=`grep -lE 'prolinux-repo.tmaxos.com|update.cs2c.com.cn:8080' /etc/yum.repos.d/*.repo`;
         if [ "$repo_files" != "" ]; then
             rm -f $repo_files;
         fi
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
-      when: guest_os_ansible_distribution == 'ProLinux'
+      when: guest_os_ansible_distribution.split(' ')[0] in ['ProLinux', 'Kylin']
 
     - name: "List all repositories on {{ vm_guest_os_distribution }}"
       ansible.builtin.shell: "{{ package_manager_cmd }} {{ package_manager_opts }} | grep -E 'Repo-(id|name|status|mirrors|baseurl|filename)'"

--- a/linux/utils/list_repos.yml
+++ b/linux/utils/list_repos.yml
@@ -25,7 +25,7 @@
         fi
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
-      when: guest_os_ansible_distribution.split(' ')[0] in ['ProLinux', 'Kylin']
+      when: guest_os_ansible_distribution is match('^(ProLinux|(Kylin.*))$')
 
     - name: "List all repositories on {{ vm_guest_os_distribution }}"
       ansible.builtin.shell: "{{ package_manager_cmd }} {{ package_manager_opts }} | grep -E 'Repo-(id|name|status|mirrors|baseurl|filename)'"


### PR DESCRIPTION
Update the local DVD repository name and disable the unavailable online repo for Kylin.

Testing done:
```
VM information:
+----------------------------------------------------------------------+
| Name                      | cycle_kylinserver_10.1                   |
+----------------------------------------------------------------------+
| Guest OS Distribution     | Kylin Linux Advanced Server 10 x86_64    |
+----------------------------------------------------------------------+
| GUI Installed             | True                                     |
+----------------------------------------------------------------------+
| CloudInit Version         |                                          |
+----------------------------------------------------------------------+
| Hardware Version          | vmx-22                                   |
+----------------------------------------------------------------------+
| VMTools Version           | 11.2.5 (build-17337674)                  |
+----------------------------------------------------------------------+
| Config Guest Id           | kylinlinux_64Guest                       |
+----------------------------------------------------------------------+
| Guest Short Name          |                                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Id        | other4xLinux64Guest                      |
+----------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 4.x Linux (64-bit)                 |
+----------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                               |
+----------------------------------------------------------------------+
| GuestInfo Detailed Data   | bitness='64'                             |
|                           | distroName='Kylin'                       |
|                           | distroVersion='V10'                      |
|                           | familyName='Linux'                       |
|                           | kernelVersion='4.19.90-21.2.ky10.x86_64' |
|                           | prettyName='Kylin V10'                   |
+----------------------------------------------------------------------+

Test Results (Total: 32, Passed: 26, Skipped: 6, Elapsed Time: 02:46:16)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:17:21  |
| 02 | check_inbox_driver                   |   Passed        | 00:02:07  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:21:21  |
| 04 | ovt_verify_status                    |   Passed        | 00:02:45  |
| 05 | vgauth_check_service                 |   Passed        | 00:00:50  |
| 06 | host_verify_saml_token               | * Not Supported | 00:00:36  |
| 07 | check_ip_address                     |   Passed        | 00:00:44  |
| 08 | check_os_fullname                    |   Passed        | 00:01:18  |
| 09 | stat_balloon                         |   Passed        | 00:00:38  |
| 10 | stat_hosttime                        |   Passed        | 00:00:41  |
| 11 | device_list                          |   Passed        | 00:02:32  |
| 12 | power_operation_scripts              |   Passed        | 00:17:01  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:12  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:05:35  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:05:03  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:07:51  |
| 17 | check_efi_firmware                   |   Passed        | 00:00:44  |
| 18 | secureboot_enable_disable            | * Not Supported | 00:00:46  |
| 19 | e1000e_network_device_ops            |   Passed        | 00:04:01  |
| 20 | vmxnet3_network_device_ops           |   Passed        | 00:03:02  |
| 21 | pvrdma_network_device_ops            |   Passed        | 00:11:27  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:00:49  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:00:49  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:00:47  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:00:51  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:07:55  |
| 27 | lsilogic_vhba_device_ops             |   Passed        | 00:10:09  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed        | 00:07:43  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:09:37  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:07:50  |
| 31 | nvdimm_cold_add_remove               |   Passed        | 00:07:37  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:03:13  |
+-------------------------------------------------------------------------+
```