### PR TITLE
[Linux] Correct guest_os_ansible_distribution for RHCOS

### DIFF
--- a/linux/utils/get_linux_system_info.yml
+++ b/linux/utils/get_linux_system_info.yml
@@ -31,8 +31,8 @@
   ansible.builtin.set_fact:
     guest_os_ansible_distribution: "RHCOS"
   when:
-    - guest_os_release.ID is defined
-    - guest_os_release.ID == 'rhcos'
+    - guest_os_release.NAME is defined
+    - guest_os_release.NAME == "Red Hat Enterprise Linux CoreOS"
 
 - name: "Correct OS distribution version for Miracle Linux 8.x"
   ansible.builtin.set_fact:


### PR DESCRIPTION
The content of /etc/os-release was changed in rhcos-4.19.0-GA-64bit. This fix is to correct RHCOS distribution name according to /etc/os-release.

Below is the /etc/os-release in rhcos-4.18.1-GA-64bit, and the ID is 'rhcos'
```
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="418.94.202501221327-0"
VERSION_ID="4.18"
VARIANT="CoreOS"
VARIANT_ID=coreos
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 418.94.202501221327-0"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos::coreos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
REDHAT_BUGZILLA_PRODUCT_VERSION="4.18"
REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
REDHAT_SUPPORT_PRODUCT_VERSION="4.18"
OPENSHIFT_VERSION="4.18"
RHEL_VERSION=9.4
OSTREE_VERSION="418.94.202501221327-0"
```
But in rhcos-4.19.0-GA-64bit, the ID became to 'rhel'.
```
NAME="Red Hat Enterprise Linux CoreOS"
VERSION="9.6.20250523-0 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.6"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20250523-0 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.6
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
OSTREE_VERSION='9.6.20250523-0'
VARIANT=CoreOS
VARIANT_ID=coreos
```

```
VM information:
+------------------------------------------------------------------------------------------------+
| Name                      | test_vm                                                            |
+------------------------------------------------------------------------------------------------+
| Guest OS Distribution     | RHCOS 9.6 x86_64                                                   |
+------------------------------------------------------------------------------------------------+
| IP                        | 10.161.96.184                                                      |
+------------------------------------------------------------------------------------------------+
| GUI Installed             | False                                                              |
+------------------------------------------------------------------------------------------------+
| CloudInit Version         |                                                                    |
+------------------------------------------------------------------------------------------------+
| Hardware Version          | vmx-15                                                             |
+------------------------------------------------------------------------------------------------+
| VMTools Version           | 12.5.0 (build-24276846)                                            |
+------------------------------------------------------------------------------------------------+
| Config Guest Id           | rhel8_64Guest                                                      |
+------------------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | rhel8_64Guest                                                      |
+------------------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Red Hat Enterprise Linux 8 (64-bit)                                |
+------------------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                         |
+------------------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                                 |
|                           | bitness='64'                                                       |
|                           | cpeString='cpe:/o:redhat:enterprise_linux:9::baseos'               |
|                           | distroAddlVersion='9.6.20250523-0 (Plow)'                          |
|                           | distroName='Red Hat Enterprise Linux CoreOS'                       |
|                           | distroVersion='9.6'                                                |
|                           | familyName='Linux'                                                 |
|                           | kernelVersion='5.14.0-570.17.1.el9_6.x86_64'                       |
|                           | prettyName='Red Hat Enterprise Linux CoreOS 9.6.20250523-0 (Plow)' |
+------------------------------------------------------------------------------------------------+

Test Results (Total: 1, Skipped: 1, Elapsed Time: 00:01:09)
+-----------------------------------------------------------+
| ID | Name                   |   Status        | Exec Time |
+-----------------------------------------------------------+
|  1 | ovt_verify_pkg_install | * Not Supported | 00:00:56  |
+-----------------------------------------------------------+
```