### PR TITLE
[Linux] Fix autoinstall and repo for Kylin Linux

### DIFF
--- a/autoinstall/Kylin/Server/10/ks.cfg
+++ b/autoinstall/Kylin/Server/10/ks.cfg
@@ -56,7 +56,7 @@ libibverbs-utils
 perftest
 %end
 
-%addon com_redhat_kdump --enable --reserve-mb='auto'
+%addon com_redhat_kdump --enable --reserve-mb='128'
 %end
 
 %anaconda

--- a/linux/utils/config_repos.yml
+++ b/linux/utils/config_repos.yml
@@ -21,7 +21,7 @@
   vars:
     repo_state: "disabled"
   when: >-
-    guest_os_ansible_distribution is match('^(RedHat|ProLinux|(Kylin.*))$') or
+    guest_os_ansible_distribution in ['RedHat', 'ProLinux'] or
     guest_os_family == 'Suse'
 
 # If os_installation_iso_list is set for openSUSE, AlmaLinux, Rocky, CentOS, OracleLinux, MIRACLE LINUX and etc,

--- a/linux/utils/list_repos.yml
+++ b/linux/utils/list_repos.yml
@@ -19,7 +19,7 @@
   block:
     - name: "Remove unavailable online repositories on {{ vm_guest_os_distribution }}"
       ansible.builtin.shell: |-
-        repo_files=`grep -lE 'prolinux-repo.tmaxos.com|update.cs2c.com.cn:8080' /etc/yum.repos.d/*.repo`;
+        repo_files=`grep -l prolinux-repo.tmaxos.com /etc/yum.repos.d/*.repo`;
         if [ "$repo_files" != "" ]; then
             rm -f $repo_files;
         fi

--- a/linux/utils/list_repos.yml
+++ b/linux/utils/list_repos.yml
@@ -25,7 +25,7 @@
         fi
       delegate_to: "{{ vm_guest_ip }}"
       ignore_errors: true
-      when: guest_os_ansible_distribution is match('^(ProLinux|(Kylin.*))$')
+      when: guest_os_ansible_distribution == 'ProLinux'
 
     - name: "List all repositories on {{ vm_guest_os_distribution }}"
       ansible.builtin.shell: "{{ package_manager_cmd }} {{ package_manager_opts }} | grep -E 'Repo-(id|name|status|mirrors|baseurl|filename)'"


### PR DESCRIPTION
Fixed the following issues for Kylin Linux Server:
1. Invalid value auto for ----reserve-mb" in autoinstall
2. Keep the default online repo for Kylin

Testing done:
```
VM information:
+-----------------------------------------------------------------------------+
| Guest OS Distribution     | Kylin Linux Advanced Server 10 x86_64           |
+-----------------------------------------------------------------------------+
| GUI Installed             | True                                            |
+-----------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                          |
+-----------------------------------------------------------------------------+
| VMTools Version           | 11.2.5 (build-17337674)                         |
+-----------------------------------------------------------------------------+
| Config Guest Id           | kylinlinux_64Guest                              |
+-----------------------------------------------------------------------------+
| GuestInfo Guest Id        | other4xLinux64Guest                             |
+-----------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Other 4.x Linux (64-bit)                        |
+-----------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                      |
+-----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | bitness='64'                                    |
|                           | distroName='Kylin'                              |
|                           | distroVersion='V10'                             |
|                           | familyName='Linux'                              |
|                           | kernelVersion='4.19.90-89.11.v2401.ky10.x86_64' |
|                           | prettyName='Kylin V10'                          |
+-----------------------------------------------------------------------------+


Test Results (Total: 32, Passed: 26, Skipped: 6, Elapsed Time: 02:00:13)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:09:56  |
| 02 | check_inbox_driver                   |   Passed        | 00:01:38  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:04:05  |
| 04 | ovt_verify_status                    |   Passed        | 00:02:11  |
| 05 | vgauth_check_service                 |   Passed        | 00:00:50  |
| 06 | host_verify_saml_token               | * Not Supported | 00:00:41  |
| 07 | check_ip_address                     |   Passed        | 00:00:46  |
| 08 | check_os_fullname                    |   Passed        | 00:01:01  |
| 09 | stat_balloon                         |   Passed        | 00:00:43  |
| 10 | stat_hosttime                        |   Passed        | 00:00:41  |
| 11 | device_list                          |   Passed        | 00:02:12  |
| 12 | power_operation_scripts              |   Passed        | 00:13:52  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:05  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:05:15  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:04:14  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:06:15  |
| 17 | check_efi_firmware                   |   Passed        | 00:00:47  |
| 18 | secureboot_enable_disable            | * Not Supported | 00:00:37  |
| 19 | e1000e_network_device_ops            |   Passed        | 00:03:30  |
| 20 | vmxnet3_network_device_ops           |   Passed        | 00:02:38  |
| 21 | pvrdma_network_device_ops            |   Passed        | 00:07:36  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:00:39  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:00:44  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:00:37  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:00:45  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:05:56  |
| 27 | lsilogic_vhba_device_ops             |   Passed        | 00:13:50  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed        | 00:05:38  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:05:56  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:05:42  |
| 31 | nvdimm_cold_add_remove               |   Passed        | 00:06:09  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:02:38  |
+-------------------------------------------------------------------------+
```