### PR TITLE
[Linux] Skip stat_balloon test case when there is no vmw_balloon driver

### DIFF
--- a/linux/stat_balloon/stat_balloon.yml
+++ b/linux/stat_balloon/stat_balloon.yml
@@ -23,7 +23,7 @@
           vars:
             module_name: "vmw_balloon"
 
-        - name: "Skip test case due to no 'vmw_balloon' module"
+        - name: "Skip test case"
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: >-


### PR DESCRIPTION
Check `vmw_balloon` driver before testing `stat_balloon`. If the driver is missing, skip the test case.

```
TASK [Skip testcase: stat_balloon, reason: Not Supported] *******************************************************************************************************************************************************************************************************************************
task path: /home/qiz/workspace/ansible-vsphere-gos-validation/common/skip_test_case.yml:26
ok: [localhost] => {
    "msg": "Skip test case 'stat_balloon' because there is no 'vmw_balloon' module on RedHat 10.0 aarch64."
}
META: ending play for localhost
```

```
+-----------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='Arm'                                    |
|                           | bitness='64'                                          |
|                           | cpeString='cpe:/o:redhat:enterprise_linux:10::baseos' |
|                           | distroAddlVersion='10.0 (Coughlan)'                   |
|                           | distroName='Red Hat Enterprise Linux'                 |
|                           | distroVersion='10.0'                                  |
|                           | familyName='Linux'                                    |
|                           | kernelVersion='6.12.0-55.9.1.el10_0.aarch64'          |
|                           | prettyName='Red Hat Enterprise Linux 10.0 (Coughlan)' |
+-----------------------------------------------------------------------------------+

Test Results (Total: 1, Skipped: 1, Elapsed Time: 00:11:11)
+-------------------------------------------------+
| ID | Name         |   Status        | Exec Time |
+-------------------------------------------------+
|  1 | stat_balloon | * Not Supported | 00:04:05  |
+-------------------------------------------------+
```

```
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                             |
|                           | bitness='64'                                   |
|                           | cpeString='cpe:/o:suse:sles:16:16.0'           |
|                           | distroAddlVersion='16.0 RC1'                   |
|                           | distroName='SLES'                              |
|                           | distroVersion='16.0'                           |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.12.0-160000.16-default'       |
|                           | prettyName='SUSE Linux Enterprise Server 16.0' |
+----------------------------------------------------------------------------+


Test Results (Total: 1, Passed: 1, Elapsed Time: 00:02:11)
+----------------------------------------+
| ID | Name         | Status | Exec Time |
+----------------------------------------+
|  1 | stat_balloon | Passed | 00:01:58  |
+----------------------------------------+
```