### PR TITLE
Install xmlsec1-devel in FusionOS and Kylin for VGAuthService

### DIFF
--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -30,6 +30,13 @@
     - guest_os_python_version is version('3.0.0', '>=')
     - guest_os_ansible_pkg_mgr is search('yum|dnf|zypper')
 
+- name: "Reconfigure xmlsec1-devel on {{ vm_guest_os_distribution }}"
+  include_tasks: ../utils/install_uninstall_package.yml
+  vars:
+    package_list: ["xmlsec1-devel"]
+    package_state: "latest"
+  when: guest_os_ansible_distribution is match('^(FusionOS|(Kylin.*))$')
+
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
   block:


### PR DESCRIPTION
VGAuthService isn't running after installing new open-vm-tools in FusionOS and Kylin. Fix this issue with xmlsec1-devel.

Testing done:
```
+------------------------------------------------------------------------------------+
| Guest OS Distribution     | Kylin Linux Advanced Server 10 x86_64                  |
+------------------------------------------------------------------------------------+
| GUI Installed             | True (LIGHTDM x11)                                     |
+------------------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                                 |
+------------------------------------------------------------------------------------+
| VMTools Version           | 13.0.0 (build-24696409)                                |
+------------------------------------------------------------------------------------+
| Config Guest Id           | kylinlinux_64Guest                                     |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | kylinlinux_64Guest                                     |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Kylinlinux (64-bit)                                    |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                             |
+------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                     |
|                           | bitness='64'                                           |
|                           | distroAddlVersion='V10 (Halberd)'                      |
|                           | distroName='Kylin Linux Advanced Server'               |
|                           | distroVersion='V10'                                    |
|                           | familyName='Linux'                                     |
|                           | kernelVersion='4.19.90-89.11.v2401.ky10.x86_64'        |
|                           | prettyName='Kylin Linux Advanced Server V10 (Halberd)' |
+------------------------------------------------------------------------------------+

Test Results (Total: 32, Passed: 27, Skipped: 5, Elapsed Time: 01:58:26)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:10:01  |
| 02 | check_inbox_driver                   |   Passed        | 00:02:40  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:03:59  |
| 04 | ovt_verify_status                    |   Passed        | 00:02:11  |
| 05 | vgauth_check_service                 |   Passed        | 00:00:42  |
| 06 | host_verify_saml_token               |   Passed        | 00:01:33  |
| 07 | check_ip_address                     |   Passed        | 00:00:43  |
| 08 | check_os_fullname                    |   Passed        | 00:01:08  |
| 09 | stat_balloon                         |   Passed        | 00:00:39  |
| 10 | stat_hosttime                        |   Passed        | 00:00:41  |
| 11 | device_list                          |   Passed        | 00:02:11  |
| 12 | power_operation_scripts              |   Passed        | 00:13:41  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:00:53  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:05:25  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:04:02  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:06:23  |
| 17 | check_efi_firmware                   |   Passed        | 00:00:40  |
| 18 | secureboot_enable_disable            | * Not Supported | 00:00:39  |
| 19 | e1000e_network_device_ops            |   Passed        | 00:03:19  |
| 20 | vmxnet3_network_device_ops           |   Passed        | 00:02:33  |
| 21 | pvrdma_network_device_ops            |   Passed        | 00:07:00  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:00:39  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:00:39  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:00:39  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:00:40  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:05:27  |
| 27 | lsilogic_vhba_device_ops             |   Passed        | 00:13:25  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed        | 00:05:27  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:05:42  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:05:26  |
| 31 | nvdimm_cold_add_remove               |   Passed        | 00:05:53  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:02:24  |
+-------------------------------------------------------------------------+
```

```
+------------------------------------------------------------------------------------+
| Guest OS Distribution     | FusionOS 22.0.4 x86_64                                 |
+------------------------------------------------------------------------------------+
| GUI Installed             | False                                                  |
+------------------------------------------------------------------------------------+
| CloudInit Version         | 19.4                                                   |
+------------------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                                 |
+------------------------------------------------------------------------------------+
| VMTools Version           | 13.0.0 (build-24696409)                                |
+------------------------------------------------------------------------------------+
| Config Guest Id           | fusionos_64Guest                                       |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | fusionos_64Guest                                       |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | FusionOS (64-bit)                                      |
+------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                             |
+------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                     |
|                           | bitness='64'                                           |
|                           | distroAddlVersion='22'                                 |
|                           | distroName='FusionOS'                                  |
|                           | distroVersion='22.0.4'                                 |
|                           | familyName='Linux'                                     |
|                           | kernelVersion='4.19.90-2212.2.0.0181.u89.fos22.x86_64' |
|                           | prettyName='FusionOS 22'                               |
+------------------------------------------------------------------------------------+

Test Results (Total: 32, Passed: 25, Skipped: 7, Elapsed Time: 02:03:35)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:06:51  |
| 02 | check_inbox_driver                   |   Passed        | 00:02:53  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:04:53  |
| 04 | ovt_verify_status                    |   Passed        | 00:00:49  |
| 05 | vgauth_check_service                 |   Passed        | 00:16:53  |
| 06 | host_verify_saml_token               |   Passed        | 00:01:37  |
| 07 | check_ip_address                     |   Passed        | 00:00:44  |
| 08 | check_os_fullname                    |   Passed        | 00:01:08  |
| 09 | stat_balloon                         |   Passed        | 00:00:37  |
| 10 | stat_hosttime                        |   Passed        | 00:00:47  |
| 11 | device_list                          |   Passed        | 00:02:28  |
| 12 | power_operation_scripts              |   Passed        | 00:14:32  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:09  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:05:26  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:04:33  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:06:52  |
| 17 | check_efi_firmware                   |   Passed        | 00:00:43  |
| 18 | secureboot_enable_disable            | * Not Supported | 00:00:45  |
| 19 | e1000e_network_device_ops            |   Passed        | 00:03:59  |
| 20 | vmxnet3_network_device_ops           |   Passed        | 00:03:01  |
| 21 | pvrdma_network_device_ops            |   Passed        | 00:08:29  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:00:46  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:00:45  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:00:52  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:00:51  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:06:06  |
| 27 | lsilogic_vhba_device_ops             | * Not Supported | 00:00:52  |
| 28 | lsilogicsas_vhba_device_ops          | * Not Supported | 00:00:45  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:06:22  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:06:21  |
| 31 | nvdimm_cold_add_remove               |   Passed        | 00:06:30  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:02:59  |
+-------------------------------------------------------------------------+
```