### PR TITLE
[Linux] Add LSILogicSAS known issue and workaround for SLES 16

### DIFF
--- a/linux/vhba_hot_add_remove/handle_lsilogicsas_known_issue.yml
+++ b/linux/vhba_hot_add_remove/handle_lsilogicsas_known_issue.yml
@@ -4,13 +4,17 @@
 # Handle LSI Logic SAS SCSI known issues
 #
 - name: "Handle LSI Logic SAS SCSI known issue on {{ vm_guest_os_distribution }}"
-  when: guest_os_ansible_distribution == "Ubuntu"
+  when: >-
+    guest_os_ansible_distribution == "Ubuntu" or
+    (guest_os_ansible_distribution == "SLES" and
+     guest_os_ansible_distribution_major_ver | int >= 16)
   block:
     - name: "Known issue - workaround of detecting LSI Logic SAS SCSI device changes"
       ansible.builtin.debug:
         msg:
           - "Guest OS can't detect hot added disk attached to LSI Logic SAS SCSI controller. Ignore this known issue."
-          - "Reboot guest OS to detect LSI Logic SAS SCSI device changes as a workaround"
+          - "Reboot guest OS to detect LSI Logic SAS SCSI device changes as a workaround."
+          - "Please refer to https://knowledge.broadcom.com/external/article?articleId=399003."
       tags:
         - known_issue
 


### PR DESCRIPTION
Test case lsilogicsas_vhba_device_ops failed occasionally because the guest OS cannot recognize the new disk hot added to an existing lsilogicsas controller. It is a Linux kernel issue like Ubuntu. This fix is to mark it as known issue on SLES 16.0 or later and reboot the guest OS to recognize the disk as a workaround.