### PR TITLE
[Linux] Skip to enable cloud-init services with bad settings for cloud-init GOSC

### DIFF
--- a/linux/utils/enable_disable_cloudinit_cfg.yml
+++ b/linux/utils/enable_disable_cloudinit_cfg.yml
@@ -53,9 +53,23 @@
               - service_facts_result.ansible_facts.services | length > 0
             fail_msg: "Failed to get guest OS services"
 
-        - name: "Get all cloud-init services on {{ vm_guest_os_distribution }}"
+        - name: "Get cloud-init services settings"
+          ansible.builtin.shell: "systemctl -p ExecStart,ExecStop show {{ service_name }}"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: get_services_status
+          with_items: "{{ service_facts_result.ansible_facts.services.keys() | select('match', 'cloud-.*.service') }}"
+          loop_control:
+            loop_var: service_name
+
+        - name: "Set fact of cloud-init services with valid settings on {{ vm_guest_os_distribution }}"
           ansible.builtin.set_fact:
-            cloud_init_services: "{{ service_facts_result.ansible_facts.services.keys() | select('match', 'cloud-.*.service') }}"
+            cloud_init_services: >-
+              {{
+                get_services_status.results |
+                selectattr('stdout', 'defined') |
+                rejectattr('stdout', 'equalto', '') |
+                map(attribute='service_name')
+              }}
 
         - name: "Stop cloud-init services"
           ansible.builtin.shell: "systemctl stop {{ service_name }}"


### PR DESCRIPTION
SLES 16 cloud-init has two empty service files: cloud-init-main.service and cloud-init-network.service. These two services cannot be enabled and started because they don't have `ExecStart` or `ExecStop` settings in their service files.

This fix is to filter out and enable cloud-init services with valid service settings only before cloud-init GOSC.

```
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                             |
|                           | bitness='64'                                   |
|                           | cpeString='cpe:/o:suse:sles:16:16.0'           |
|                           | distroAddlVersion='16.0 Snapshot-202506-1'     |
|                           | distroName='SLES'                              |
|                           | distroVersion='16.0'                           |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.12.0-160000.18-default'       |
|                           | prettyName='SUSE Linux Enterprise Server 16.0' |
+----------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 2, Elapsed Time: 00:13:24)
+---------------------------------------------------+
| ID | Name                    | Status | Exec Time |
+---------------------------------------------------+
|  1 | gosc_cloudinit_dhcp     | Passed | 00:05:58  |
|  2 | gosc_cloudinit_staticip | Passed | 00:06:29  |
+---------------------------------------------------+
```