### PR TITLE
Get VM info, guest config options and system info at env_setup for existing VM

### DIFF
--- a/common/esxi_get_guest_config_options.yml
+++ b/common/esxi_get_guest_config_options.yml
@@ -2,33 +2,32 @@
 # SPDX-License-Identifier: BSD-2-Clause
 ---
 # Get default VM config options for a specific guest id
-# Parameter
-#   guest_id: guest id
-#   esxi_hardware_version: ESXi hardware version
+# Parameters
+#   guest_id: The VM's guest id
+#   esxi_hardware_version: The ESXi hardware version supporting the guest id
+#   get_method: api or xml
 # Return:
-#   guest_config_options: The guest ID config options for a hardware version
+#   guest_config_options: The guest id config options for a hardware version
 # Example output:
 #  "guest_config_options": {
-#      "default_cdrom_controller": "ide",
-#      "default_cpu_number": 1,
+#      "default_cdrom_controller": "sata",
 #      "default_disk_controller": "paravirtual",
 #      "default_ethernet": "vmxnet3",
-#      "default_secure_boot": false,
+#      "default_secure_boot": true,
 #      "default_usb_controller": "",
-#      "guest_fullname": "Other 5.x Linux (64-bit)",
-#      "guest_id": "other5xLinux64Guest",
-#      "hardware_version": "vmx-21",
+#      "guest_fullname": "Red Hat Enterprise Linux 9 (64-bit)",
+#      "guest_id": "rhel9_64Guest",
+#      "hardware_version": "vmx-19",
 #      "rec_cpu_cores_per_socket": 1,
 #      "rec_cpu_socket": 1,
 #      "rec_disk_mb": 16384,
 #      "rec_firmware": "efi",
-#      "rec_memory_mb": 1024,
+#      "rec_memory_mb": 2048,
 #      "rec_persistent_memory": 8192,
-#      "rec_vram_kb": 4096,
+#      "rec_vram_kb": 8192,
+#      "support_cpu_hotadd": true,
 #      "support_disk_controller": [
-#          "lsilogic",
 #          "paravirtual",
-#          "lsilogicsas",
 #          "sata",
 #          "nvme",
 #          "ide"
@@ -39,6 +38,8 @@
 #          "sriov",
 #          "pvrdma"
 #      ],
+#      "support_for_create": true,
+#      "support_memory_hotadd": true,
 #      "support_min_persistent_mem_mb": 4,
 #      "support_persistent_memory": true,
 #      "support_secure_boot": true,
@@ -48,6 +49,7 @@
 #          "usb3"
 #      ]
 #  }
+
 - name: "Check esxi_hardware_version is set with valid value"
   ansible.builtin.assert:
     that:
@@ -55,7 +57,7 @@
       - esxi_hardware_version is match('^\d+')
     fail_msg: "Incorrect hardware version '{{ esxi_hardware_version }}'"
 
-- name: "Initialize variables about guest ID config options"
+- name: "Initialize variables about guest id config options"
   ansible.builtin.set_fact:
     guest_config_options: {}
 
@@ -74,24 +76,26 @@
   register: get_config_options_result
   ignore_errors: true
 
-- name: "Set fact of guest ID {{ guest_id }} default config options on hardware version {{ hardware_version }}"
+- name: "Set fact of guest id {{ guest_id }} default config options on hardware version {{ hardware_version }}"
   ansible.builtin.set_fact:
     guest_config_options: "{{ get_config_options_result.instance.recommended_config_options }}"
   when:
+    - get_method == 'api'
     - get_config_options_result is defined
     - get_config_options_result.instance is defined
     - get_config_options_result.instance.recommended_config_options is defined
 
 - name: "Get config options from config file"
   when: >
+    get_method == 'xml' or
     (get_config_options_result is undefined) or
     (get_config_options_result.instance is undefined) or
     (get_config_options_result.instance.recommended_config_options is undefined)
   block:
-    - name: "Initialize variables for getting guest ID default configs"
+    - name: "Initialize variables for getting guest id default configs"
       ansible.builtin.set_fact:
-        vm_config_option_esx_hw: "/etc/vmware/hostd/env/vmconfigoption-esx-hw{{ esxi_hardware_version }}.xml"
-        guest_config_options_xpath: "/ConfigRoot/ConfigurationOption/guestOSDescriptor/e[id='{{ guest_id }}']"
+        esxi_vm_config_option_file: "/etc/vmware/hostd/env/vmconfigoption-esx-hw{{ esxi_hardware_version }}.xml"
+        local_vm_config_option_file: "{{ local_cache }}/vmconfigoption-esx-hw{{ esxi_hardware_version }}.xml"
         vm_device_types:
           vim.vm.device.VirtualLsiLogicController: 'lsilogic'
           vim.vm.device.VirtualLsiLogicSASController: 'lsilogicsas'
@@ -122,165 +126,133 @@
           defaultSecureBoot: "default_secure_boot"
           supportsSecureBoot: "support_secure_boot"
           fullName: "guest_fullname"
+          vRAMSizeInKB: "rec_vram_kb"
+          supportsCpuHotAdd: "support_cpu_hotadd"
+          supportsMemoryHotAdd: "support_memory_hotadd"
+          supportedForCreate: "support_for_create"
           recommendedPersistentMemoryMB: "rec_persistent_memory"
           supportedMinPersistentMemoryMB: "support_min_persistent_mem_mb"
           persistentMemorySupported: "support_persistent_memory"
           supportsTPM20: "support_tpm_20"
+          supportedDiskControllerList: "support_disk_controller"
+          supportedEthernetCard: "support_ethernet_card"
+          supportedUSBControllerList: "support_usb_controller"
 
-    # Create a temp file to store config options
-    - include_tasks: create_temp_file_dir.yml
-      vars:
-        tmp_dir: "{{ local_cache }}"
-
-    - name: "Set fact of temp config option file"
+    - name: "Initialize VM default config options"
       ansible.builtin.set_fact:
-        tmp_config_option_file: "{{ tmp_path }}"
+        guest_config_options: >-
+          {{
+            vm_config_name.values() | zip_longest([], fillvalue='') |
+            items2dict(key_name=0, value_name=1) |
+            combine({'hardware_version': 'vmx-' ~  esxi_hardware_version})
+          }}
 
     - name: "Fetch config option file from ESXi server"
       ansible.builtin.fetch:
-        src: "{{ vm_config_option_esx_hw }}"
-        dest: "{{ tmp_config_option_file }}"
+        src: "{{ esxi_vm_config_option_file }}"
+        dest: "{{ local_vm_config_option_file }}"
         flat: true
       delegate_to: "{{ esxi_hostname }}"
 
-    - name: "Get default config option from guest OS descriptor for guest id {{ guest_id }}"
-      community.general.xml:
-        path: "{{ tmp_config_option_file }}"
-        xpath: "{{ guest_config_options_xpath }}/*"
-        content: text
-      ignore_errors: true
-      register: guest_os_descriptor
+    - name: "Set fact of overall guest config options"
+      ansible.builtin.set_fact:
+        guest_os_descriptor: >-
+          {{
+            _all_guest_config_options.ConfigRoot.ConfigurationOption.guestOSDescriptor.e |
+            selectattr('id', 'equalto', guest_id)
+          }}
+      when:
+        - _all_guest_config_options.ConfigRoot.ConfigurationOption.guestOSDescriptor.e is defined
+        - _all_guest_config_options.ConfigRoot.ConfigurationOption.guestOSDescriptor.e | length > 0
+      vars:
+        _all_guest_config_options: "{{ lookup('file', local_vm_config_option_file) | ansible.utils.from_xml }}"
 
-    - name: "Set facts of guest OS config options"
-      when: not guest_os_descriptor.failed
-      block:
-        - name: "Initialize VM default config options"
-          ansible.builtin.set_fact:
-            guest_config_options: >-
-              {{
-                vm_config_name.values() | zip_longest([]) |
-                items2dict(key_name=0, value_name=1) |
-                combine({'hardware_version': 'vmx-' ~  esxi_hardware_version})
-              }}
+    - name: "Check guest id {{ guest_id }} has guest config options on hardware version {{ esxi_hardware_version }}"
+      ansible.builtin.assert:
+        that:
+          - guest_os_descriptor | length > 0
+        fail_msg: >-
+          Failed to find guest config options for guest id {{ guest_id }} with
+          hardware version {{ esxi_hardware_version }}
 
-        - name: "Set fact of guest OS default config options"
-          ansible.builtin.set_fact:
-            guest_default_configs: >-
-              {{
-                guest_os_descriptor.matches |
-                map('dict2items') |
-                flatten |
-                selectattr('key', 'in', vm_config_name.keys()) |
-                items2dict
-              }}
+    - name: "Set fact for VM default config with guest id {{ guest_id }}"
+      ansible.builtin.set_fact:
+        guest_config_options: >-
+          {{
+            guest_config_options |
+            combine({vm_config_name[item.key]: (_value is match('\d+')) | ternary(_value | int, _value) })
+          }}
+      vars:
+        _value: >-
+           {%- if item.value in ['true', 'false'] -%}{{ item.value | bool }}
+           {%- elif item.value in vm_device_types -%}{{ vm_device_types[item.value] }}
+           {%- elif item.key == 'fullName' and 'Arm' in item.value -%}{{ item.value | replace(' Arm', '') }}
+           {%- else -%}{{ item.value }}
+           {%- endif -%}
+      when:
+        - item.key in vm_config_name
+        - item.value | type_debug not in ["list", "dict"]
+      with_dict: "{{ guest_os_descriptor[0] }}"
 
-        - name: "Set fact for VM default config with guest id {{ guest_id }}"
-          ansible.builtin.set_fact:
-            guest_config_options: >-
-              {{
-                guest_config_options
-                | combine({vm_config_name[item.key]:
-                           vm_device_types[item.value] if item.value in vm_device_types else item.value})
-              }}
-          with_dict: "{{ guest_default_configs }}"
+    - name: "Set fact for VM default config with guest id {{ guest_id }}"
+      ansible.builtin.set_fact:
+        guest_config_options: >-
+          {{
+            guest_config_options |
+            combine({'rec_vram_kb': guest_os_descriptor[0].vRAMSizeInKB.defaultValue | int})
+          }}
+      when:
+        - guest_os_descriptor[0].vRAMSizeInKB.defaultValue is defined
+        - guest_os_descriptor[0].vRAMSizeInKB.defaultValue is match('\d+')
 
-        - name: "Get default video RAM size in KB for guest id {{ guest_id }}"
-          community.general.xml:
-            path: "{{ tmp_config_option_file }}"
-            xpath: "{{ guest_config_options_xpath }}/vRAMSizeInKB/defaultValue"
-            content: text
-          register: guest_vram_size
-          ignore_errors: true
+    # If the supported device list has only one item,  the 'e' element will be a dictionary
+    # If the supported device list has more than one item, the 'e' element will be a list
+    - name: "Set supported device lists for guest id {{ guest_id }}"
+      ansible.builtin.set_fact:
+        guest_config_options: >-
+          {{
+            guest_config_options |
+            combine({
+                     vm_config_name[item]:
+                     _supported_device_list | map('extract', vm_device_types) | list
+                    })
+           }}
+      vars:
+        _supported_device_list: >-
+           {{
+             (guest_os_descriptor[0][item].e | type_debug == 'dict') |
+             ternary([guest_os_descriptor[0][item].e['#text']],
+                     guest_os_descriptor[0][item].e |
+                     selectattr('#text', 'defined') |
+                     map(attribute='#text'))
+           }}
+      when:
+        - guest_os_descriptor[0][item].e is defined
+        - guest_os_descriptor[0][item].e | length > 0
+      with_items:
+        - "supportedDiskControllerList"
+        - "supportedEthernetCard"
+        - "supportedUSBControllerList"
 
-        - name: "Set default video RAM size in KB for guest id {{ guest_id }}"
-          ansible.builtin.set_fact:
-            guest_config_options: "{{ guest_config_options | combine({'rec_vram_kb': guest_vram_size.matches[0].defaultValue}) }}"
-          when:
-            - guest_vram_size is defined
-            - guest_vram_size.matches is defined
-            - guest_vram_size.matches | length > 0
-
-        - name: "Get supported disk controllers for guest id {{ guest_id }}"
-          community.general.xml:
-            path: "{{ tmp_config_option_file }}"
-            xpath: "{{ guest_config_options_xpath }}/supportedDiskControllerList/e"
-            content: text
-          register: guest_supported_disk_ctrls
-          ignore_errors: true
-
-        - name: "Set supported disk controllers for guest id {{ guest_id }}"
-          ansible.builtin.set_fact:
-            guest_config_options: >-
-              {{
-                guest_config_options
-                | combine({
-                     'support_disk_controller':
-                       guest_supported_disk_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                        })
-               }}
-          when:
-            - guest_supported_disk_ctrls is defined
-            - guest_supported_disk_ctrls.matches is defined
-            - guest_supported_disk_ctrls.matches | length > 0
-
-        - name: "Get supported network adapters for guest id {{ guest_id }}"
-          community.general.xml:
-            path: "{{ tmp_config_option_file }}"
-            xpath: "{{ guest_config_options_xpath }}/supportedEthernetCard/e"
-            content: text
-          register: guest_supported_ethernet_card
-          ignore_errors: true
-
-        - name: "Set supported network adapters for guest id {{ guest_id }}"
-          ansible.builtin.set_fact:
-            guest_config_options: >-
-              {{
-                guest_config_options
-                | combine({
-                     'support_ethernet_card':
-                       guest_supported_ethernet_card.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                          })
-               }}
-          when:
-            - guest_supported_ethernet_card is defined
-            - guest_supported_ethernet_card.matches is defined
-            - guest_supported_ethernet_card.matches | length > 0
-
-        - name: "Get supported USB controllers for guest id {{ guest_id }}"
-          community.general.xml:
-            path: "{{ tmp_config_option_file }}"
-            xpath: "{{ guest_config_options_xpath }}/supportedUSBControllerList/e"
-            content: text
-          register: guest_supported_usb_ctrls
-          ignore_errors: true
-
-        - name: "Set supported USB controllers for guest id {{ guest_id }}"
-          ansible.builtin.set_fact:
-            guest_config_options: >-
-              {{
-                guest_config_options
-                | combine({
-                     'support_usb_controller':
-                       guest_supported_usb_ctrls.matches | map(attribute='e') | map('extract', vm_device_types) | list
-                          })
-               }}
-          when:
-            - guest_supported_usb_ctrls is defined
-            - guest_supported_usb_ctrls.matches is defined
-            - guest_supported_usb_ctrls.matches | length > 0
-
-    - name: "Remove temporary config option file"
+    - name: "Remove VM config option file at local cache"
       ansible.builtin.file:
-        path: "{{ tmp_config_option_file }}"
+        path: "{{ local_vm_config_option_file }}"
         state: absent
 
 - name: "Set default CPU number for VM with guest id {{ guest_id }}"
   ansible.builtin.set_fact:
-    guest_config_options: "{{ guest_config_options | combine({'default_cpu_number': (guest_config_options.rec_cpu_cores_per_socket | int) * (guest_config_options.rec_cpu_socket | int) }) }}"
+    guest_config_options: >-
+      {{
+        guest_config_options |
+        combine({
+                 'default_cpu_number':
+                 (guest_config_options.rec_cpu_cores_per_socket | int) * (guest_config_options.rec_cpu_socket | int)
+                })
+       }}
   when:
-    - guest_config_options.rec_cpu_cores_per_socket is defined
+    - guest_config_options.rec_cpu_cores_per_socket | default('')
     - guest_config_options.rec_cpu_cores_per_socket | int >= 1
-    - guest_config_options.rec_cpu_socket is defined
+    - guest_config_options.rec_cpu_socket | default('')
     - guest_config_options.rec_cpu_socket | int >= 1
 
 - name: "Print guest id {{ guest_id }} config options on hardware version {{ esxi_hardware_version }}"

--- a/env_setup/existing_vm_setup.yml
+++ b/env_setup/existing_vm_setup.yml
@@ -10,11 +10,28 @@
   include_tasks: ../common/vm_cleanup_snapshot.yml
   when: cleanup_old_snapshots | bool
 
+- name: "Check base snapshot existence and/or revert to it"
+  include_tasks: ../common/base_snapshot_check_revert.yml
+
+- name: "Check VM settings"
+  include_tasks: ../common/check_vm_settings.yml
+
 - name: "Get existing VM info"
   include_tasks: ../common/vm_get_vm_info.yml
 
 - name: "Get VM's power state"
   include_tasks: ../common/vm_get_power_state.yml
+
+# Sometimes after reverting snapshot on FreeBSD VM, its network is not reachable.
+# Here restarts it to work around the network issue
+- name: "Reset FreeBSD VM to update network after reverting to base snapshot"
+  include_tasks: ../common/vm_set_power_state.yml
+  vars:
+    vm_power_state_set: "restarted"
+  when:
+    - base_snapshot_exists
+    - vm_power_state_get == "poweredOn"
+    - vm_guest_id is search('freebsd')
 
 - name: "Power on VM"
   include_tasks: ../common/vm_set_power_state.yml
@@ -24,3 +41,27 @@
 
 - name: "Wait for VM primary network adapter has MAC address"
   include_tasks: ../common/vm_wait_primary_nic_mac.yml
+
+- name: "Get '{{ vm_guest_id }}' guest config options with VM hardware version '{{ vm_hardware_version }}'"
+  include_tasks: ../common/esxi_get_guest_config_options.yml
+  vars:
+    guest_id: "{{ vm_guest_id }}"
+    esxi_hardware_version: "{{ vm_hardware_version_num }}"
+
+- name: "Get Linux system info"
+  when: vm_guest_id is not match('win.*')
+  block:
+    - name: "Get VM guest IP"
+      include_tasks: ../common/update_inventory.yml
+
+    - name: "Get Linux guest OS system info"
+      include_tasks: ../linux/utils/get_linux_system_info.yml
+
+- name: "Get Windows system info"
+  when: vm_guest_id is match('win.*')
+  block:
+    - name: "Get VM guest IP"
+      include_tasks: ../windows/utils/win_update_inventory.yml
+
+    - name: "Get Windows guest OS system info"
+      include_tasks: ../windows/utils/get_windows_system_info.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -89,6 +89,12 @@
     - (hardware_version == "latest" or
        (vm_hardware_version_num | int < hardware_version | int))
 
+- name: "Get '{{ vm_guest_id }}' guest config options with VM hardware version '{{ vm_hardware_version }}'"
+  include_tasks: ../common/esxi_get_guest_config_options.yml
+  vars:
+    guest_id: "{{ vm_guest_id }}"
+    esxi_hardware_version: "{{ vm_hardware_version_num }}"
+
 - name: "Warning about unknown guest OS type"
   ansible.builtin.debug:
     msg: >-
@@ -122,23 +128,6 @@
       vars:
         vm_serial_backing: "{{ vm_serial_file_backing }}"
 
-
-    # The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
-    - name: "Remove existing CDROMs"
-      include_tasks: ../../common/vm_configure_cdrom.yml
-      vars:
-        cdrom_type: client
-        cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
-        cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
-        cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
-        cdrom_state: absent
-      with_items: "{{ vm_existing_cdrom_list }}"
-      loop_control:
-        loop_var: vm_cdrom
-      when:
-        - guest_os_ansible_distribution == "Ubuntu"
-        - vm_existing_cdrom_list is defined
-        - vm_existing_cdrom_list | length > 0
 
 - name: "Power on VM"
   include_tasks: ../../common/vm_set_power_state.yml

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -128,6 +128,9 @@
   include_tasks: ../../common/vm_get_cdrom_devices.yml
 
 - name: "Disconnect all ISOs from VM"
+  when:
+    - guest_os_ansible_distribution != "Ubuntu"
+    - cdrom_device_list | length > 0
   block:
     - name: "Change VM's CDROM to client device"
       include_tasks: ../../common/vm_configure_cdrom.yml
@@ -150,8 +153,21 @@
         cdrom_unit_num: "{{ vm_cdrom_unit_num }}"
         cdrom_state: absent
       when: cdrom_device_list | length > vm_existing_cdrom_list | length
+
+# The workaround "Remove CDROM" for issue: https://bugs.launchpad.net/cloud-init/+bug/1992509
+- name: "Remove all CDROM devices on Ubuntu VM"
+  include_tasks: ../../common/vm_configure_cdrom.yml
+  vars:
+    cdrom_type: client
+    cdrom_controller_type: "{{ vm_cdrom.controller_label.split()[0] | lower }}"
+    cdrom_controller_num: "{{ vm_cdrom.bus_num }}"
+    cdrom_unit_num: "{{ vm_cdrom.unit_num }}"
+    cdrom_state: absent
+  with_items: "{{ cdrom_device_list }}"
+  loop_control:
+    loop_var: vm_cdrom
   when:
-    - cdrom_device_list is defined
+    - guest_os_ansible_distribution == "Ubuntu"
     - cdrom_device_list | length > 0
 
 - name: "Delete uploaded cloud-init seed ISO from ESXi datastore"

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -8,59 +8,34 @@
 - name: "Set current test case index, name and log folder"
   include_tasks: ../../common/set_current_testcase_facts.yml
 
-- name: "Check base snapshot existence and/or revert to it"
-  include_tasks: ../../common/base_snapshot_check_revert.yml
-
-- name: "Check VM settings"
-  include_tasks: ../../common/check_vm_settings.yml
-  when: vm_settings_checked is undefined
-
-- name: "Get VM info after reverting to base snapshot"
+- name: "Set VM in a clean mode"
   when:
-    - not new_vm
-    - base_snapshot_exists | bool
-    - vm_info_retrieved is undefined or not vm_info_retrieved
+    - vm_under_test is defined
+    - vm_under_test
   block:
-    - name: "Get VM info at base snapshot"
-      include_tasks: ../../common/vm_get_vm_info.yml
+    - name: "If base snapshot exists, revert VM to base snapshot"
+      include_tasks: ../../common/base_snapshot_check_revert.yml
 
-    - name: "Set fact that VM info at base snapshot retrieved"
-      ansible.builtin.set_fact:
-        vm_info_retrieved: true
-
-# Sometimes after reverting snapshot on FreeBSD VM, its network is not reachable.
-# Here restarts it to work around the network issue
-- name: "Reset FreeBSD VM to update network after reverting to base snapshot"
-  include_tasks: ../../common/vm_set_power_state.yml
-  vars:
-    vm_power_state_set: "restarted"
-  when:
-    - base_snapshot_exists
-    - guest_os_ansible_distribution is defined
-    - guest_os_ansible_distribution == 'FreeBSD'
-
-- name: "Get '{{ vm_guest_id }}' guest config options with VM hardware version '{{ vm_hardware_version_num }}'"
-  when: guest_options_retrieved is undefined or not guest_options_retrieved
-  block:
-    - name: "Get VM guest options"
-      include_tasks: ../../common/esxi_get_guest_config_options.yml
+    # Sometimes after reverting snapshot on FreeBSD VM, its network is not reachable.
+    # Here restarts it to work around the network issue
+    - name: "Reset FreeBSD VM to update network after reverting to base snapshot"
+      include_tasks: ../../common/vm_set_power_state.yml
       vars:
-        guest_id: "{{ vm_guest_id }}"
-        esxi_hardware_version: "{{ vm_hardware_version_num }}"
+        vm_power_state_set: "restarted"
+      when:
+        - base_snapshot_exists
+        - (guest_os_ansible_distribution is defined and guest_os_ansible_distribution == 'FreeBSD') or
+          (vm_guest_id is search('freebsd'))
 
-    - name: "Set fact of VM guest options retrieved"
-      ansible.builtin.set_fact:
-        guest_options_retrieved: true
+- name: "Set fact that VM is under testing"
+  ansible.builtin.set_fact:
+    vm_under_test: true
 
 - name: "Get VM guest IP"
   include_tasks: ../../common/update_inventory.yml
 
 - name: "Print VM guest IP address"
   ansible.builtin.debug: var=vm_guest_ip
-
-- name: "Get guest OS system info"
-  include_tasks: ../utils/get_linux_system_info.yml
-  when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
 - name: "Get VMware Tools status"
   include_tasks: ../../common/vm_get_vmtools_status.yml

--- a/windows/deploy_vm/deploy_vm_from_ova.yml
+++ b/windows/deploy_vm/deploy_vm_from_ova.yml
@@ -52,6 +52,12 @@
 - name: "Get VM info"
   include_tasks: ../../common/vm_get_vm_info.yml
 
+- name: "Get '{{ vm_guest_id }}' guest config options with VM hardware version '{{ vm_hardware_version }}'"
+  include_tasks: ../common/esxi_get_guest_config_options.yml
+  vars:
+    guest_id: "{{ vm_guest_id }}"
+    esxi_hardware_version: "{{ vm_hardware_version_num }}"
+
 #- name: "Get VM's primary network adapter MAC address"
 #  include_tasks: ../../common/vm_wait_primary_nic_mac.yml
 # - include_tasks: ../../common/vm_get_ip_from_vmtools.yml

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -13,50 +13,16 @@
 
 - name: "Check base snapshot existence and/or revert to it"
   include_tasks: ../../common/base_snapshot_check_revert.yml
-
-- name: "Check VM settings"
-  include_tasks: ../../common/check_vm_settings.yml
-  when: vm_settings_checked is undefined
-
-- name: "Get VM info after reverting to base snapshot"
   when:
-    - not new_vm
-    - base_snapshot_exists | bool
-    - vm_info_retrieved is undefined or not vm_info_retrieved
-  block:
-    - name: "Get VM info at base snapshot"
-      include_tasks: ../../common/vm_get_vm_info.yml
+    - vm_under_test is defined
+    - vm_under_test
 
-    - name: "Set fact that VM info at base snapshot retrieved"
-      ansible.builtin.set_fact:
-        vm_info_retrieved: true
+- name: "Set fact that VM is under testing"
+  ansible.builtin.set_fact:
+    vm_under_test: true
 
-- name: "Get '{{ vm_guest_id }}' guest config options with VM hardware version '{{ vm_hardware_version_num }}'"
-  when: guest_options_retrieved is undefined or not guest_options_retrieved
-  block:
-    - name: "Get VM guest options"
-      include_tasks: ../../common/esxi_get_guest_config_options.yml
-      vars:
-        guest_id: "{{ vm_guest_id }}"
-        esxi_hardware_version: "{{ vm_hardware_version_num }}"
-
-    - name: "Set fact of VM guest options retrieved"
-      ansible.builtin.set_fact:
-        guest_options_retrieved: true
-
-- name: "Get VM guest IP"
-  include_tasks: ../../common/vm_get_ip.yml
-  vars:
-    vm_get_ip_timeout: 600
-
-- name: "Check Windows winrm is connectable"
-  include_tasks: ../utils/win_check_winrm.yml
-
-- name: "Add Windows host to in-memory inventory"
-  include_tasks: ../utils/add_windows_host.yml
-
-- name: "Print VM guest IP address"
-  ansible.builtin.debug: var=vm_guest_ip
+- name: "Refresh VM guest IP in the in-memory inventory hosts info"
+  include_tasks: ../utils/win_update_inventory.yml
 
 # Windows Update will cause OS poweroff or restart taking a long time,
 # or GOSC test cases failure, here try to pause Windows Update 7 days
@@ -90,10 +56,6 @@
   when:
     - skip_test_no_vmtools is defined
     - skip_test_no_vmtools
-
-- name: "Get guest OS system info"
-  include_tasks: ../utils/get_windows_system_info.yml
-  when: guest_os_system_info_retrieved is undefined or not guest_os_system_info_retrieved
 
 - name: "Get VM guest info including guest id, full name, family and detailed data"
   include_tasks: ../../common/vm_get_guest_info.yml


### PR DESCRIPTION
Some information only needs to get once at test setup for existing. This fix is to move tasks to get such information from test setup to env setup.