### PR TITLE
Add vSphere hosts into inventory before SSH to vSphere server

### DIFF
--- a/env_setup/env_setup.yml
+++ b/env_setup/env_setup.yml
@@ -21,6 +21,9 @@
     - name: "Set hostname of Ansible module connecting"
       include_tasks: ../common/set_vmware_module_hostname.yml
 
+    - name: "Add vSphere hosts into memory inventory"
+      include_tasks: ../common/add_vsphere_hosts_in_inventory.yml
+
     - name: "Check VM existence"
       include_tasks: ../common/vm_check_exist.yml
 
@@ -74,9 +77,6 @@
       when:
         - new_vm
         - vm_deploy_method == "iso"
-
-    - name: "Add vSphere hosts into memory inventory"
-      include_tasks: ../common/add_vsphere_hosts_in_inventory.yml
 
     - name: "Enable guest IP hack on ESXi host to get IP address of VM without VMware Tools available"
       include_tasks: ../common/esxi_enable_guest_ip_hack.yml


### PR DESCRIPTION
`esxi_get_guest_config_options.yml` requires to SSH to ESXi server on ESXi 7.0.x.  So vSphere hosts must be added before `set_default_vm_vars.yml` in which `esxi_get_guest_config_options.yml` will be executed.