### PR TITLE
[FreeBSD] Add configure option about fuse for installing open-vm-tools from source

### DIFF
--- a/linux/open_vm_tools/install_ovt_from_source.yml
+++ b/linux/open_vm_tools/install_ovt_from_source.yml
@@ -29,12 +29,17 @@
   vars:
     _ovt_build_config: "{{ lookup('file', ovt_build_config_file_path) | from_yaml }}"
 
-- name: "Add '--without-x' option to configure because {{ vm_guest_os_distribution }} doesn't have GTK3"
+- name: "Add '--without-x' configure option because {{ vm_guest_os_distribution }} doesn't have GTK3"
   ansible.builtin.set_fact:
     ovt_configure_options: "{{ ovt_configure_options | union(['--without-x']) }}"
   when:
     - guest_os_ansible_system == 'linux'
     - ovt_dependencies | select('search', 'gtk[^0-9]*3') | length < 2
+
+- name: "Add '--with-fuse=fuse' configure option on {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    ovt_configure_options: "{{ ovt_configure_options | union(['--with-fuse=fuse']) }}"
+  when: guest_os_ansible_system == 'freebsd'
 
 - name: "Check open-vm-tools dependencies are not empty"
   ansible.builtin.assert:

--- a/linux/open_vm_tools/templates/freebsd_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/freebsd_ovt_build_config.tmpl
@@ -23,6 +23,7 @@ dependencies:
   - doxygen
   - cunit
   - libICE
+  - fusefs-libs
 configure_options:
   - "--disable-vgauth"
   - "--disable-deploypkg"


### PR DESCRIPTION
If FreeBSD has fuse2 and fuse3 at the same time, open-vm-tools source configure will fail due to incorrect fuse header file

```
cc -DPACKAGE_NAME=\"open-vm-tools\" -DPACKAGE_TARNAME=\"open-vm-tools\" -DPACKAGE_VERSION=\"13.1.0\" -DPACKAGE_STRING=\"open-vm-tools\ 13.1.0\" -DPACKAGE_BUGREPORT=\"[open-vm-tools-devel@lists.sourceforge.net](mailto:open-vm-tools-devel@lists.sourceforge.net)\" -DPACKAGE_URL=\"\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DHAVE_SYS_TIME_H=1 -DSTDC_HEADERS=1 -DPACKAGE=\"open-vm-tools\" -DVERSION=\"13.1.0\" -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_FUSE3=1 -DFUSE_USE_VERSION=35 -DHAVE_X11_SM_SMLIB_H=1 -DHAVE_X11_ICE_ICELIB_H=1 -DHAVE_X11_EXTENSIONS_XCOMPOSITE_H=1 -DHAVE_DLOPEN=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_WCHAR_H=1 -DHAVE_SYS_PARAM_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_USER_H=1 -DHAVE__BOOL=1 -DHAVE_STDBOOL_H=1 -DHAVE_STRUCT_STAT_ST_RDEV=1 -DTIME_WITH_SYS_TIME=1 -DNO_XSM=1 -DNO_XCOMPOSITE=1 -I.    -I/root/ovt_source_20250716040327/open-vm-tools-13.1.0-24853115/lib/include -I/root/ovt_source_20250716040327/open-vm-tools-13.1.0-24853115/lib/include  -DUSING_AUTOCONF=1 -DOPEN_VM_TOOLS -I/usr/local/include  -I/usr/local/include -DNO_ICU -DVMX86_TOOLS -I/usr/local/include/fuse3 -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include -g -O2 -Wall -Werror -Wno-pointer-sign -Wno-unused-value -fno-strict-aliasing -Wno-unknown-pragmas -Wno-uninitialized -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -MT bdhandler.o -MD -MP -MF .deps/bdhandler.Tpo -c -o bdhandler.o bdhandler.c
In file included from bdhandler.c:31:
In file included from ./module.h:45:
In file included from ./fsutil.h:33:
In file included from /usr/local/include/fuse.h:9:
In file included from /usr/local/include/fuse/fuse.h:26:
/usr/local/include/fuse/fuse_common.h:33:2: error: Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
   33 | #error Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
      |  ^
1 error generated.
*** Error code 1
```

This fix added `fusefs-libs` dependency and configure option `--with-fuse=fuse` so that it can always use fuse2 for building open-vm-tools