### PR TITLE
[Linux] Update APT sources for archived Debian release

### DIFF
--- a/linux/utils/add_official_apt_sources.yml
+++ b/linux/utils/add_official_apt_sources.yml
@@ -16,11 +16,47 @@
   when: guest_os_ansible_distribution == "Ubuntu"
 
 - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
-  ansible.builtin.set_fact:
-    apt_sources:
-      - "deb http://deb.debian.org/debian/ {{ guest_os_ansible_distribution_release }} main"
-      - "deb http://deb.debian.org/debian/ {{ guest_os_ansible_distribution_release }} main contrib"
   when: guest_os_ansible_distribution == "Debian"
+  block:
+    - name: "Check APT sources for Debian {{ guest_os_ansible_distribution_release }}"
+      ansible.builtin.uri:
+        url: "{{ item }}/dists/{{ guest_os_ansible_distribution_release }}"
+        follow_redirects: "safe"
+        method: "HEAD"
+      ignore_errors: true
+      register: check_apt_sources
+      no_log: true
+      with_items:
+        - "http://deb.debian.org/debian"
+        - "https://archive.debian.org/debian-archive/debian"
+
+    - name: "Display the result of checking APT sources for Debian {{ guest_os_ansible_distribution_release }}"
+      ansible.builtin.debug: var=check_apt_sources
+      when: enable_debug
+
+    - name: "Set fact of available APT sources for Debian {{ guest_os_ansible_distribution_release }}"
+      ansible.builtin.set_fact:
+        debian_apt_sources: "{{ check_apt_sources.results | selectattr('status', 'equalto', 200) | map(attribute='item') }}"
+      when:
+        - check_apt_sources.results is defined
+        - check_apt_sources.results | length > 0
+
+    - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        apt_sources:
+          - "deb {{ debian_apt_sources[0] }} {{ guest_os_ansible_distribution_release }} main"
+          - "deb {{ debian_apt_sources[0] }} {{ guest_os_ansible_distribution_release }} main contrib"
+      when:
+        - debian_apt_sources is defined
+        - debian_apt_sources | length > 0
+
+    # Comment out existing APT sources
+    - name: "Comment out existing APT sources"
+      ansible.builtin.replace:
+        path: "{{ apt_sources_list }}"
+        regexp: "^( *deb .*)"
+        replace: "#\\1"
+      delegate_to: "{{ vm_guest_ip }}"
 
 - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
   when: guest_os_ansible_distribution == "Pardus GNU/Linux"

--- a/linux/utils/add_official_apt_sources.yml
+++ b/linux/utils/add_official_apt_sources.yml
@@ -41,14 +41,19 @@
         - check_apt_sources.results is defined
         - check_apt_sources.results | length > 0
 
+    - name: "Check there is at least one accessible APT source for Debian {{ guest_os_ansible_distribution_release }}"
+      ansible.builtin.assert:
+        that:
+          - debian_apt_sources is defined
+          - debian_apt_sources | length > 0
+        fail_msg: >-
+          Not found any accessible APT source for Debian {{ guest_os_ansible_distribution_release }}
+
     - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
       ansible.builtin.set_fact:
         apt_sources:
           - "deb {{ debian_apt_sources[0] }} {{ guest_os_ansible_distribution_release }} main"
           - "deb {{ debian_apt_sources[0] }} {{ guest_os_ansible_distribution_release }} main contrib"
-      when:
-        - debian_apt_sources is defined
-        - debian_apt_sources | length > 0
 
     # Comment out existing APT sources
     - name: "Comment out existing APT sources"


### PR DESCRIPTION
Debian 10 APT sources are archived. This fix added Debian APT sources checking before using it.

```
TASK [Set fact of available APT sources for Debian buster] *********************
task path: /home/worker/workspace/Ansible_Cycle_Debian_10.x_64bit-263/ansible-vsphere-gos-validation/linux/utils/add_official_apt_sources.yml:37
ok: [localhost] => {
    "ansible_facts": {
        "debian_apt_sources": [
            "https://archive.debian.org/debian-archive/debian"
        ]
    },
    "changed": false
}

TASK [Set fact of official APT sources on Debian 10.13 x86_64] *****************
task path: /home/worker/workspace/Ansible_Cycle_Debian_10.x_64bit-263/ansible-vsphere-gos-validation/linux/utils/add_official_apt_sources.yml:44
ok: [localhost] => {
    "ansible_facts": {
        "apt_sources": [
            "deb https://archive.debian.org/debian-archive/debian buster main",
            "deb https://archive.debian.org/debian-archive/debian buster main contrib"
        ]
    },
    "changed": false
}
```

```
| GuestInfo Detailed Data   | architecture='X86'                        |
|                           | bitness='64'                              |
|                           | distroAddlVersion='10 (buster)'           |
|                           | distroName='Debian GNU/Linux'             |
|                           | distroVersion='10'                        |
|                           | familyName='Linux'                        |
|                           | kernelVersion='4.19.0-21-amd64'           |
|                           | prettyName='Debian GNU/Linux 10 (buster)' |
+-----------------------------------------------------------------------+


Test Results (Total: 31, Passed: 27, Skipped: 4, Elapsed Time: 02:36:06)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:26:39  |
| 02 | ovt_verify_pkg_install               |   Passed        | 00:06:45  |
| 03 | ovt_verify_status                    |   Passed        | 00:02:57  |
| 04 | vgauth_check_service                 |   Passed        | 00:00:57  |
| 05 | host_verify_saml_token               |   Passed        | 00:02:15  |
| 06 | check_ip_address                     |   Passed        | 00:01:01  |
| 07 | check_os_fullname                    |   Passed        | 00:01:27  |
| 08 | stat_balloon                         |   Passed        | 00:01:01  |
| 09 | stat_hosttime                        |   Passed        | 00:00:49  |
| 10 | device_list                          |   Passed        | 00:02:41  |
| 11 | power_operation_scripts              |   Passed        | 00:18:06  |
| 12 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:23  |
| 13 | memory_hot_add_basic                 |   Passed        | 00:05:28  |
| 14 | cpu_hot_add_basic                    |   Passed        | 00:04:50  |
| 15 | cpu_multicores_per_socket            |   Passed        | 00:07:54  |
| 16 | check_efi_firmware                   |   Passed        | 00:00:54  |
| 17 | secureboot_enable_disable            |   Passed        | 00:04:35  |
| 18 | e1000e_network_device_ops            |   Passed        | 00:03:58  |
| 19 | vmxnet3_network_device_ops           |   Passed        | 00:02:59  |
| 20 | pvrdma_network_device_ops            | * Not Supported | 00:00:55  |
| 21 | gosc_perl_dhcp                       |   Passed        | 00:05:40  |
| 22 | gosc_perl_staticip                   |   Passed        | 00:05:20  |
| 23 | gosc_cloudinit_dhcp                  | * Not Supported | 00:01:51  |
| 24 | gosc_cloudinit_staticip              | * Not Supported | 00:01:51  |
| 25 | paravirtual_vhba_device_ops          |   Passed        | 00:06:55  |
| 26 | lsilogic_vhba_device_ops             |   Passed        | 00:09:23  |
| 27 | lsilogicsas_vhba_device_ops          |   Passed        | 00:07:28  |
| 28 | sata_vhba_device_ops                 |   Passed        | 00:07:33  |
| 29 | nvme_vhba_device_ops                 |   Passed        | 00:07:01  |
| 30 | nvdimm_cold_add_remove               | * Not Supported | 00:00:49  |
| 31 | ovt_verify_pkg_uninstall             |   Passed        | 00:03:21  |
+-------------------------------------------------------------------------+
```