### PR TITLE
[Linux] Handle SATA hot remove known issue for RHEL family OS

### DIFF
--- a/linux/vhba_hot_add_remove/handle_sata_known_issue.yml
+++ b/linux/vhba_hot_add_remove/handle_sata_known_issue.yml
@@ -3,14 +3,47 @@
 ---
 # Handle SATA known issues
 #
-# Pardus 21 XFCE can't detect SATA disk change after hot-remove
-# Work around it by updating the disk state
-- name: "Handle SATA known issue on {{ vm_guest_os_distribution }}"
+# Pardus 21 XFCE can't detect SATA disk change after hot remove
+- name: "Set fact of guest OS has SATA known issue on {{ vm_guest_os_distribution }}"
+  ansible.builtin.set_fact:
+    sata_known_issue_exists: true
   when:
     - guest_os_ansible_distribution == 'Pardus GNU/Linux'
     - guest_os_ansible_distribution_major_ver | int == 21
     - guest_os_edition == 'XFCE'
+
+# RHEL family OS of version 9.6, 10.0 or later, CentOS Stream 9 and 10 can't detect SATA disk change
+# after hot remove when 'alpmalpm=medium_power' exists in tuned config
+- name: "Check whether SATA known issue exists on {{ vm_guest_os_distribution }}"
+  when:
+    - guest_os_family == 'RedHat'
+    - guest_os_ansible_distribution_major_ver | int >= 9
+  block:
+    - name: "Check 'alpm=medium_power' in tuned config"
+      ansible.builtin.shell: "grep '^ *alpm=medium_power' '{{ tuned_conf_path }}'"
+      delegate_to: "{{ vm_guest_ip }}"
+      register: check_alpm_result
+      ignore_errors: true
+      vars:
+        tuned_conf_path: >-
+          {{
+            (guest_os_ansible_distribution_major_ver | int == 9) |
+            ternary('/usr/lib/tuned/balanced/tuned.conf',
+                    '/usr/lib/tuned/profiles/balanced/tuned.conf')
+          }}
+
+    - name: "Set fact of guest OS has SATA known issue on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        sata_known_issue_exists: true
+      when:
+        - check_alpm_result.stdout is defined
+        - check_alpm_result.stdout
+
+- name: "Handle SATA known issue on {{ vm_guest_os_distribution }}"
+  when:
     - wait_device_state | lower == 'absent'
+    - sata_known_issue_exists is defined
+    - sata_known_issue_exists
   block:
     - name: "Known issue - workaround of detecting SATA device changes on {{ vm_guest_os_distribution }}"
       ansible.builtin.debug:


### PR DESCRIPTION
On RHEL 9.6 and 10.0, there is a config `alpmalpm=medium_power` in its tuned config file, which leads to guest OS can still lists a SATA disk which has been hot removed.  Some other RHEL family OS like CentOS Stream, Oracle Linux, Rocky, AlmaLinux, MIRACLE LINUX, etc also have such issue. 

This fix added the tuned config check and handled this SATA hot remove issue on RHEL family OS.

```
| GuestInfo Detailed Data   | architecture='Arm'                                     |
|                           | bitness='64'                                           |
|                           | cpeString='cpe:/o:redhat:enterprise_linux:10::baseos'  |
|                           | distroAddlVersion='10.0 (Coughlan)'                    |
|                           | distroName='Red Hat Enterprise Linux'                  |
|                           | distroVersion='10.0'                                   |
|                           | familyName='Linux'                                     |
|                           | kernelVersion='6.12.0-55.9.1.el10_0.aarch64'           |
|                           | prettyName='Red Hat Enterprise Linux 10.0 (Coughlan)'  |
+------------------------------------------------------------------------------------+

Test Results (Total: 1, Passed: 1, Elapsed Time: 00:30:14)
+------------------------------------------------+
| ID | Name                 | Status | Exec Time |
+------------------------------------------------+
|  1 | sata_vhba_device_ops | Passed | 00:25:10  |
+------------------------------------------------+
```