### PR TITLE
'vmtools_conf_path' is undefined in test case 'power_operation_scripts' in rescue block

### DIFF
--- a/windows/power_operation_scripts/power_operation_scripts.yml
+++ b/windows/power_operation_scripts/power_operation_scripts.yml
@@ -54,6 +54,7 @@
           vars:
             win_get_file_src_path: "{{ vmtools_conf_path }}"
             win_get_file_dst_path: "{{ current_test_log_folder }}"
+          when: vmtools_conf_path is defined and vmtools_conf_path
 
         - name: "Test case failure"
           include_tasks: ../../common/test_rescue.yml


### PR DESCRIPTION
Issue:
'vmtools_conf_path' is undefined in test case 'power_operation_scripts' in rescue block

Jira task: GOSV-4987

