### PR TITLE
[Linux] Remove doxygen from open-vm-tools build denepencies on SLES 16

### DIFF
--- a/linux/open_vm_tools/templates/suse_ovt_build_config.tmpl
+++ b/linux/open_vm_tools/templates/suse_ovt_build_config.tmpl
@@ -10,9 +10,6 @@ dependencies:
   - pkg-config
   - rpm-build
 
-  # Documentation
-  - doxygen
-
   # Development libraries
   - fuse3
   - fuse3-devel
@@ -58,6 +55,7 @@ dependencies:
   - gtkmm3-devel
 
 {% if guest_os_ansible_distribution_major_ver | int < 16 %}
+  - doxygen
   - libdnet-devel
   - xorg-x11-devel
 {% else %}


### PR DESCRIPTION
The doxygen package has been removed from SLES 16 PublicRC. It is not a must-have package for building open-vm-tools source. So here removes it from OVT build dependencies.
```
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                             |
|                           | bitness='64'                                   |
|                           | cpeString='cpe:/o:suse:sles:16:16.0'           |
|                           | distroAddlVersion='16.0 PublicRC'              |
|                           | distroName='SLES'                              |
|                           | distroVersion='16.0'                           |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.12.0-160000.20-default'       |
|                           | prettyName='SUSE Linux Enterprise Server 16.0' |
+----------------------------------------------------------------------------+


Test Results (Total: 32, Passed: 27, Failed: 2, Skipped: 3, Elapsed Time: 03:54:11)
+--------------------------------------------------------------------------+
| ID | Name                                 |   Status         | Exec Time |
+--------------------------------------------------------------------------+
| 01 | deploy_vm_efi_nvme_e1000e            |   Passed         | 00:13:39  |
| 02 | check_inbox_driver                   |   Passed         | 00:02:11  |
| 03 | ovt_verify_src_install               |   Passed         | 00:33:56  |

....
```