### PR TITLE
[Linux] Fix Ubuntu official APT sources on ARM

### DIFF
--- a/linux/utils/add_official_apt_sources.yml
+++ b/linux/utils/add_official_apt_sources.yml
@@ -9,11 +9,21 @@
     apt_sources: []
 
 - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
-  ansible.builtin.set_fact:
-    apt_sources:
-      - "deb http://archive.ubuntu.com/ubuntu {{ guest_os_ansible_distribution_release }} main restricted universe"
-      - "deb http://archive.ubuntu.com/ubuntu {{ guest_os_ansible_distribution_release }}-updates main restricted"
   when: guest_os_ansible_distribution == "Ubuntu"
+  block:
+    - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        apt_sources:
+          - "deb http://archive.ubuntu.com/ubuntu {{ guest_os_ansible_distribution_release }} main restricted universe"
+          - "deb http://archive.ubuntu.com/ubuntu {{ guest_os_ansible_distribution_release }}-updates main restricted"
+      when: esxi_cpu_vendor != 'arm'
+
+    - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
+      ansible.builtin.set_fact:
+        apt_sources:
+          - "deb http://ports.ubuntu.com/ubuntu-ports {{ guest_os_ansible_distribution_release }} main restricted universe"
+          - "deb http://ports.ubuntu.com/ubuntu-ports {{ guest_os_ansible_distribution_release }}-updates main restricted"
+      when: esxi_cpu_vendor == 'arm'
 
 - name: "Set fact of official APT sources on {{ vm_guest_os_distribution }}"
   when: guest_os_ansible_distribution == "Debian"


### PR DESCRIPTION

```
TASK [Install packages ['open-vm-tools', 'open-vm-tools-desktop']] *************
...
    "invocation": {
        "module_args": {
            "_raw_params": "apt-get install -y open-vm-tools open-vm-tools-desktop",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true
        }
    },
    "msg": "",
    "rc": 0,
    "start": "2025-08-13 07:35:48.526184",
    "stderr": "debconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline",
    "stderr_lines": [
        "debconf: unable to initialize frontend: Dialog",
        "debconf: (TERM is not set, so the dialog frontend is not usable.)",
        "debconf: falling back to frontend: Readline"
    ],
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSuggested packages:\n  open-vm-tools-containerinfo\nRecommended packages:\n  xserver-xorg-video-vmware\nThe following NEW packages will be installed:\n  open-vm-tools open-vm-tools-desktop\n0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.\nNeed to get 865 kB of archives.\nAfter this operation, 4,979 kB of additional disk space will be used.\nGet:1 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 open-vm-tools arm64 2:12.4.5-1~ubuntu0.24.04.2 [735 kB]\nGet:2 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 open-vm-tools-desktop arm64 2:12.4.5-1~ubuntu0.24.04.2 [130 kB]\nFetched 865 kB in 3s (324 kB/s)\nSelecting previously unselected package open-vm-tools.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 160313 files and directories currently installed.)\r\nPreparing to unpack .../open-vm-tools_2%3a12.4.5-1~ubuntu0.24.04.2_arm64.deb ...\r\nUnpacking open-vm-tools (2:12.4.5-1~ubuntu0.24.04.2) ...\r\nSelecting previously unselected package open-vm-tools-desktop.\r\nPreparing to unpack .../open-vm-tools-desktop_2%3a12.4.5-1~ubuntu0.24.04.2_arm64.deb ...\r\nUnpacking open-vm-tools-desktop (2:12.4.5-1~ubuntu0.24.04.2) ...\r\nSetting up open-vm-tools (2:12.4.5-1~ubuntu0.24.04.2) ...\r\nCreated symlink /etc/systemd/system/vmtoolsd.service → /usr/lib/systemd/system/open-vm-tools.service.\r\r\nCreated symlink /etc/systemd/system/multi-user.target.wants/open-vm-tools.service → /usr/lib/systemd/system/open-vm-tools.service.\r\r\nCreated symlink /etc/systemd/system/open-vm-tools.service.requires/vgauth.service → /usr/lib/systemd/system/vgauth.service.\r\r\nSetting up open-vm-tools-desktop (2:12.4.5-1~ubuntu0.24.04.2) ...\r\nCreated symlink /etc/systemd/system/multi-user.target.wants/run-vmblock\\x2dfuse.mount → /usr/lib/systemd/system/run-vmblock\\x2dfuse.mount.\r\r\nProcessing triggers for libc-bin (2.39-0ubuntu8.5) ...\r\nProcessing triggers for man-db (2.12.0-4build2) ...",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "Suggested packages:",
        "  open-vm-tools-containerinfo",
        "Recommended packages:",
        "  xserver-xorg-video-vmware",
        "The following NEW packages will be installed:",
        "  open-vm-tools open-vm-tools-desktop",
        "0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.",
        "Need to get 865 kB of archives.",
        "After this operation, 4,979 kB of additional disk space will be used.",
        "Get:1 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 open-vm-tools arm64 2:12.4.5-1~ubuntu0.24.04.2 [735 kB]",
        "Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 open-vm-tools-desktop arm64 2:12.4.5-1~ubuntu0.24.04.2 [130 kB]",
        "Fetched 865 kB in 3s (324 kB/s)",
        "Selecting previously unselected package open-vm-tools.",
        "(Reading database ... ",
        "(Reading database ... 5%",
        "(Reading database ... 10%",
        "(Reading database ... 15%",
        "(Reading database ... 20%",
        "(Reading database ... 25%",
        "(Reading database ... 30%",
        "(Reading database ... 35%",
        "(Reading database ... 40%",
        "(Reading database ... 45%",
        "(Reading database ... 50%",
        "(Reading database ... 55%",
        "(Reading database ... 60%",
        "(Reading database ... 65%",
        "(Reading database ... 70%",
        "(Reading database ... 75%",
        "(Reading database ... 80%",
        "(Reading database ... 85%",
        "(Reading database ... 90%",
        "(Reading database ... 95%",
        "(Reading database ... 100%",
        "(Reading database ... 160313 files and directories currently installed.)",
        "Preparing to unpack .../open-vm-tools_2%3a12.4.5-1~ubuntu0.24.04.2_arm64.deb ...",
        "Unpacking open-vm-tools (2:12.4.5-1~ubuntu0.24.04.2) ...",
        "Selecting previously unselected package open-vm-tools-desktop.",
        "Preparing to unpack .../open-vm-tools-desktop_2%3a12.4.5-1~ubuntu0.24.04.2_arm64.deb ...",
        "Unpacking open-vm-tools-desktop (2:12.4.5-1~ubuntu0.24.04.2) ...",
        "Setting up open-vm-tools (2:12.4.5-1~ubuntu0.24.04.2) ...",
        "Created symlink /etc/systemd/system/vmtoolsd.service → /usr/lib/systemd/system/open-vm-tools.service.",
        "",
        "Created symlink /etc/systemd/system/multi-user.target.wants/open-vm-tools.service → /usr/lib/systemd/system/open-vm-tools.service.",
        "",
        "Created symlink /etc/systemd/system/open-vm-tools.service.requires/vgauth.service → /usr/lib/systemd/system/vgauth.service.",
        "",
        "Setting up open-vm-tools-desktop (2:12.4.5-1~ubuntu0.24.04.2) ...",
        "Created symlink /etc/systemd/system/multi-user.target.wants/run-vmblock\\x2dfuse.mount → /usr/lib/systemd/system/run-vmblock\\x2dfuse.mount.",
        "",
        "Processing triggers for libc-bin (2.39-0ubuntu8.5) ...",
        "Processing triggers for man-db (2.12.0-4build2) ..."
    ]
}

```