### PR TITLE
[Linux] Fix Debian 13 autoinstall stuck at "Running preseed"

### DIFF
--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -157,7 +157,8 @@ d-i apt-setup/use_mirror boolean false
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
-d-i apt-setup/disable-cdrom-entries boolean true
+#d-i apt-setup/disable-cdrom-entries boolean true
+d-i apt-setup/disable-cdrom-entries boolean false
 
 # Don't add any security and updates repo to avoid an upgrade during installation
 d-i apt-setup/services-select multiselect
@@ -230,6 +231,8 @@ d-i preseed/early_command string \
 d-i preseed/late_command string \
     echo "Executing late command" >/dev/ttyS0; \
     cp -a /cdrom/{{ post_install_script_file }} /target/root/{{ post_install_script_file }}; \
+    echo "Bind the installer environment /cdrom to the target system /media/cdrom." >/dev/ttyS0; \
+    mount -o bind /cdrom /target/media/cdrom; \
     in-target /bin/bash /root/{{ post_install_script_file }}; \
     echo "Dump installer log:"; \
     cat /var/log/syslog >/dev/ttyS0; \

--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -231,6 +231,7 @@ d-i preseed/late_command string \
     echo "Executing late command" >/dev/ttyS0; \
     cp -a /cdrom/{{ post_install_script_file }} /target/root/{{ post_install_script_file }}; \
     echo "Bind the installer environment /cdrom to the target system /media/cdrom." >/dev/ttyS0; \
+    mkdir -p /target/media/cdrom; \
     mount -o bind /cdrom /target/media/cdrom; \
     in-target /bin/bash /root/{{ post_install_script_file }}; \
     echo "Dump installer log:"; \

--- a/autoinstall/Debian/10/preseed.cfg
+++ b/autoinstall/Debian/10/preseed.cfg
@@ -157,8 +157,7 @@ d-i apt-setup/use_mirror boolean false
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
-#d-i apt-setup/disable-cdrom-entries boolean true
-d-i apt-setup/disable-cdrom-entries boolean false
+d-i apt-setup/disable-cdrom-entries boolean true
 
 # Don't add any security and updates repo to avoid an upgrade during installation
 d-i apt-setup/services-select multiselect

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -1,24 +1,24 @@
 #Install open-vm-toools from CDROM if it exists
 cdrom_missing_pkgs=""
 for pkg in $required_pkgs; do
-    echo "Searching package $pkg in CDROM" >/dev/ttyS0
+    echo "Searching package $pkg in CDROM"
     apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
     pkg_in_cdrom=$?
     if [ $pkg_in_cdrom -eq 0 ]; then
         echo "Installing pacakge $pkg from CDROM"
         apt install -y $pkg 2>&1
         if [ $? -ne 0 ]; then
-            echo "ERROR: Failed to install package $pkg from CDROM" >/dev/ttyS0
+            echo "ERROR: Failed to install package $pkg from CDROM"
             cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
         fi
     else
-        echo "Package $pkg doesn't exist in CDROM" >/dev/ttyS0
+        echo "Package $pkg doesn't exist in CDROM"
         cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
     fi
 done
 
 if [ "X$cdrom_missing_pkgs" != "X" ]; then
-    echo "Adding $OS_NAME $VERSION_ID ($VERSION_CODENAME) offical online repo" >/dev/ttyS0
+    echo "Adding $OS_NAME $VERSION_ID ($VERSION_CODENAME) offical online repo"
 {% if unattend_installer == 'Debian' %}
     echo "deb http://deb.debian.org/debian/ $VERSION_CODENAME main contrib" >> /etc/apt/sources.list
 {% elif unattend_installer == 'Pardus' %}
@@ -36,13 +36,13 @@ if [ "X$cdrom_missing_pkgs" != "X" ]; then
         apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
         pkg_in_online_repo=$?
         if [ $pkg_in_online_repo -eq 0 ]; then
-            echo "Installing package $pkg from online repo" >/dev/ttyS0
+            echo "Installing package $pkg from online repo"
             apt install -y $pkg 2>&1
             if [ $? -ne 0 ]; then
-                echo "ERROR: Failed to install package $pkg from online repo" >/dev/ttyS0
+                echo "ERROR: Failed to install package $pkg from online repo"
             fi
         else
-            echo "ERROR: Failed to find package $pkg from CDROM and online repo" >/dev/ttyS0
+            echo "ERROR: Failed to find package $pkg from CDROM and online repo"
         fi
     done
 fi

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -1,24 +1,24 @@
 #Install open-vm-toools from CDROM if it exists
 cdrom_missing_pkgs=""
 for pkg in $required_pkgs; do
-    echo "Searching package $pkg in CDROM"
+    echo "Searching package $pkg in CDROM" >/dev/ttyS0
     apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
     pkg_in_cdrom=$?
     if [ $pkg_in_cdrom -eq 0 ]; then
         echo "Installing pacakge $pkg from CDROM"
         apt install -y $pkg 2>&1
         if [ $? -ne 0 ]; then
-            echo "ERROR: Failed to install package $pkg from CDROM"
+            echo "ERROR: Failed to install package $pkg from CDROM" >/dev/ttyS0
             cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
         fi
     else
-        echo "Package $pkg doesn't exist in CDROM"
+        echo "Package $pkg doesn't exist in CDROM" >/dev/ttyS0
         cdrom_missing_pkgs="$cdrom_missing_pkgs $pkg"
     fi
 done
 
 if [ "X$cdrom_missing_pkgs" != "X" ]; then
-    echo "Adding $OS_NAME $VERSION_ID ($VERSION_CODENAME) offical online repo"
+    echo "Adding $OS_NAME $VERSION_ID ($VERSION_CODENAME) offical online repo" >/dev/ttyS0
 {% if unattend_installer == 'Debian' %}
     echo "deb http://deb.debian.org/debian/ $VERSION_CODENAME main contrib" >> /etc/apt/sources.list
 {% elif unattend_installer == 'Pardus' %}
@@ -36,13 +36,13 @@ if [ "X$cdrom_missing_pkgs" != "X" ]; then
         apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg
         pkg_in_online_repo=$?
         if [ $pkg_in_online_repo -eq 0 ]; then
-            echo "Installing package $pkg from online repo"
+            echo "Installing package $pkg from online repo" >/dev/ttyS0
             apt install -y $pkg 2>&1
             if [ $? -ne 0 ]; then
-                echo "ERROR: Failed to install package $pkg from online repo"
+                echo "ERROR: Failed to install package $pkg from online repo" >/dev/ttyS0
             fi
         else
-            echo "ERROR: Failed to find package $pkg from CDROM and online repo"
+            echo "ERROR: Failed to find package $pkg from CDROM and online repo" >/dev/ttyS0
         fi
     done
 fi

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -31,11 +31,6 @@ if [ "X$cdrom_missing_pkgs" != "X" ]; then
     echo "Updating list of available packages"
     apt update -y 2>&1
 
-    # It gets stuck at searching / installing packages from online repo during autoinstall for Debian 13
-    # Skipping the installation of these packages during autoinstall will not affect the subsequent test cases.
-    if [[ "X$OS_NAME" == "XDebian GNU/Linux" ]] && [[ "X$VERSION_ID" == "X13" ]]; then
-        cdrom_missing_pkgs=""
-    fi
     for pkg in $cdrom_missing_pkgs; do
         echo "Searching package $pkg in online repo"
         apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg

--- a/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/apt_install_pkgs.sh
@@ -31,6 +31,11 @@ if [ "X$cdrom_missing_pkgs" != "X" ]; then
     echo "Updating list of available packages"
     apt update -y 2>&1
 
+    # It gets stuck at searching / installing packages from online repo during autoinstall for Debian 13
+    # Skipping the installation of these packages during autoinstall will not affect the subsequent test cases.
+    if [[ "X$OS_NAME" == "XDebian GNU/Linux" ]] && [[ "X$VERSION_ID" == "X13" ]]; then
+        cdrom_missing_pkgs=""
+    fi
     for pkg in $cdrom_missing_pkgs; do
         echo "Searching package $pkg in online repo"
         apt list $pkg 2>/dev/null | cut -d '/' -f 1 | grep $pkg


### PR DESCRIPTION
Debian 13 autoinstall stuck at "Running preseed"


**Two issues:**
1) During autoinstall, it should bind the installer environment’s /cdrom to the target system’s /media/cdrom, but the installer did not do so

   (if the ISO file is not mounted, the autoinstall will stuck)

2) CDROM APT source doesn't work even if manually mount an ISO file or use the mount command in a script to mount the ISO file.

**Resolution:**
   bind the installer environment’s /cdrom to the target system’s /media/cdrom
   Then, the autoinstall won't stuck.

   Note:
   For the issue 2, even if the CDROM APT source doesn't work, it won't 
affect the autoinstall. The packages will be installed from online repo.
   

**Test result:** 
   Passed. (check GOSV-5206)
  

  