### PR TITLE
[Windows] Add logic to clean up cached/temp Windows Updates packages in test case windows_update_install

### DIFF
--- a/windows/utils/win_remove_updates_package.yml
+++ b/windows/utils/win_remove_updates_package.yml
@@ -1,0 +1,23 @@
+# Copyright 2025 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+---
+# Description:
+#   Remove the cached or temp Windows Updates packages which may occupy a significant amount of disk space.
+# Parameters:
+#   restart_os_after_cleanup: if true, will restart OS after the cleanup. Default is false
+#
+- name: "Clean up the cached/temp Windows Updates packages"
+  include_tasks: win_execute_cmd.yml
+  vars:
+    win_powershell_cmd: >-
+      Stop-Service -Name wuauserv,bits,cryptsvc,msiserver -Force;
+      Remove-Item -Path "$env:windir\\SoftwareDistribution\\Download\\*" -Recurse -Force -ErrorAction SilentlyContinue;
+      Remove-Item -Path "$env:windir\\Temp\\*" -Recurse -Force -ErrorAction SilentlyContinue;
+      Remove-Item -Path "$env:TEMP\\*" -Recurse -Force -ErrorAction SilentlyContinue;
+    win_execute_cmd_ignore_error: true
+
+- name: "Restart the guest OS after cleanup of the cached/tmp Windows Updates packages"
+  include_tasks: win_shutdown_restart.yml
+  vars:
+    set_win_power_state: "restart"
+  when: restart_os_after_cleanup | default(false)

--- a/windows/windows_update_install/install_online_updates.yml
+++ b/windows/windows_update_install/install_online_updates.yml
@@ -49,19 +49,9 @@
       ignore_errors: true
 
 - name: "Clean up the cached/temp Windows Updates packages"
-  include_tasks: ../utils/win_execute_cmd.yml
+  include_tasks: ../utils/win_remove_updates_package.yml
   vars:
-    win_powershell_cmd: >-
-      Stop-Service -Name wuauserv,bits,cryptsvc,msiserver -Force;
-      Remove-Item -Path "$env:windir\\SoftwareDistribution\\Download\\*" -Recurse -Force -ErrorAction SilentlyContinue;
-      Remove-Item -Path "$env:windir\\Temp\\*" -Recurse -Force -ErrorAction SilentlyContinue;
-      Remove-Item -Path "$env:TEMP\\*" -Recurse -Force -ErrorAction SilentlyContinue;
-    win_execute_cmd_ignore_error: true
-
-- name: "Restart the guest OS after cleanup of the cached/tmp Windows Updates packages"
-  include_tasks: ../utils/win_shutdown_restart.yml
-  vars:
-    set_win_power_state: "restart"
+    restart_os_after_cleanup: true
 
 # For internal existing VM test scenario.
 # If guest OS has been updated, take a new base snapshot and remove the old one.


### PR DESCRIPTION
There may be a significant amount of cached/temp Windows Updates packages. Add logic to perform a cleanup to free up disk space. 