### PR TITLE
[Debian 13]lsilogicsas_vhba_device_ops failed on Debian 13.x

### DIFF
--- a/linux/vhba_hot_add_remove/handle_lsilogicsas_known_issue.yml
+++ b/linux/vhba_hot_add_remove/handle_lsilogicsas_known_issue.yml
@@ -7,7 +7,9 @@
   when: >-
     guest_os_ansible_distribution == "Ubuntu" or
     (guest_os_ansible_distribution == "SLES" and
-     guest_os_ansible_distribution_major_ver | int >= 16)
+     guest_os_ansible_distribution_major_ver | int >= 16) or
+    (guest_os_ansible_distribution == "Debian" and
+     guest_os_ansible_distribution_major_ver | int >= 13)
   block:
     - name: "Known issue - workaround of detecting LSI Logic SAS SCSI device changes"
       ansible.builtin.debug:


### PR DESCRIPTION
**Issue**
lsilogicsas_vhba_device_ops failed on Debian 13.x


**Resolution**
handle it as a known issue in 
https://github.com/vmware/ansible-vsphere-gos-validation/blob/main/linux/vhba_hot_add_remove/handle_lsilogicsas_known_issue.yml

Track Task: GOSV-5236
