### PR TITLE
Add waiting VM hostname before power operations on cloned VM when there is VMware Tools installed

### DIFF
--- a/common/vm_wait_guest_hostname.yml
+++ b/common/vm_wait_guest_hostname.yml
@@ -35,8 +35,8 @@
   register: vm_guest_facts
   until:
     - vm_guest_facts.instance.guest.toolsRunningStatus | default('') == "guestToolsRunning"
-    - vm_guest_facts.instance.guest.hostName | default('')
-    - (not wait_guest_hostname) or (wait_guest_hostname and wait_guest_hostname == vm_guest_facts.instance.guest.hostName)
+    - vm_guest_facts.instance.guest.hostName | default('') | length != 0
+    - (wait_guest_hostname | length == 0) or (wait_guest_hostname | length != 0 and wait_guest_hostname == vm_guest_facts.instance.guest.hostName)
   ignore_errors: true
 
 - name: "Display the retrieved guest info"
@@ -50,9 +50,9 @@
       - vm_guest_facts.instance.guest.toolsRunningStatus is defined
       - vm_guest_facts.instance.guest.toolsRunningStatus == "guestToolsRunning"
       - vm_guest_facts.instance.guest.hostName is defined
-      - vm_guest_facts.instance.guest.hostName
-      - ((not wait_guest_hostname) or
-        (wait_guest_hostname and wait_guest_hostname == vm_guest_facts.instance.guest.hostName))
+      - vm_guest_facts.instance.guest.hostName | length != 0
+      - ((wait_guest_hostname | length == 0) or
+        (wait_guest_hostname | length !=0 and wait_guest_hostname == vm_guest_facts.instance.guest.hostName))
     fail_msg: >-
       It's timed out for VMware Tools collecting guest OS hostname in {{ vm_get_hostname_timeout }} seconds.
       Current VMware Tools running status is '{{ vm_guest_facts.instance.guest.toolsRunningStatus | default("") }}'

--- a/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
+++ b/linux/deploy_vm/reconfigure_vm_with_cloudinit.yml
@@ -124,14 +124,6 @@
 - name: "Eject CDROM devices from guest OS"
   include_tasks: ../utils/eject_cdrom_in_guest.yml
 
-- name: "Delete uploaded cloud-init seed ISO from ESXi datastore"
-  include_tasks: ../../common/esxi_check_delete_datastore_file.yml
-  vars:
-    file_in_datastore: "{{ datastore }}"
-    file_in_datastore_path: "{{ vm_dir_name }}/{{ seed_iso_path | basename }}"
-    file_in_datastore_ops: "absent"
-    file_in_datastore_ignore_failed: true
-
 - name: "Get all CDROM devices on VM"
   include_tasks: ../../common/vm_get_cdrom_devices.yml
 
@@ -161,3 +153,11 @@
   when:
     - cdrom_device_list is defined
     - cdrom_device_list | length > 0
+
+- name: "Delete uploaded cloud-init seed ISO from ESXi datastore"
+  include_tasks: ../../common/esxi_check_delete_datastore_file.yml
+  vars:
+    file_in_datastore: "{{ datastore }}"
+    file_in_datastore_path: "{{ vm_dir_name }}/{{ seed_iso_path | basename }}"
+    file_in_datastore_ops: "absent"
+    file_in_datastore_ignore_failed: true

--- a/linux/network_device_ops/prepare_network_device_test.yml
+++ b/linux/network_device_ops/prepare_network_device_test.yml
@@ -71,11 +71,3 @@
     - name: "Set fact of client VM exists"
       ansible.builtin.set_fact:
         pvrdma_client_vm_exists: true
-
-    # The instant cloned VM has same IP address with parent VM.
-    # Resetting it to get a new DHCP IP address
-    - name: "Reset client VM '{{ pvrdma_client_vm_name }}' for getting DHCP IP address"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: 'restarted'
-        vm_name: "{{ pvrdma_client_vm_name }}"

--- a/linux/network_device_ops/prepare_network_device_test.yml
+++ b/linux/network_device_ops/prepare_network_device_test.yml
@@ -71,3 +71,17 @@
     - name: "Set fact of client VM exists"
       ansible.builtin.set_fact:
         pvrdma_client_vm_exists: true
+
+    - name: "Wait for guest OS hostname in guest info"
+      include_tasks: ../../common/vm_wait_guest_hostname.yml
+      vars:
+        vm_name: pvrdma_client_vm_name
+      when: vmtools_is_installed
+
+    # The instant cloned VM has the same IP address as the parent VM,
+    # reset it to get a new DHCP IP address
+    - name: "Reset client VM '{{ pvrdma_client_vm_name }}' for getting DHCP IP address"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: "{{ vmtools_is_running | ternary('reboot-guest', 'restarted') }}"
+        vm_name: "{{ pvrdma_client_vm_name }}"

--- a/linux/network_device_ops/prepare_network_device_test.yml
+++ b/linux/network_device_ops/prepare_network_device_test.yml
@@ -75,7 +75,7 @@
     - name: "Wait for guest OS hostname in guest info"
       include_tasks: ../../common/vm_wait_guest_hostname.yml
       vars:
-        vm_name: pvrdma_client_vm_name
+        vm_name: "{{ pvrdma_client_vm_name }}"
       when: vmtools_is_installed
 
     # The instant cloned VM has the same IP address as the parent VM,

--- a/linux/network_device_ops/pvrdma_client_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_client_network_device_ops.yml
@@ -59,14 +59,6 @@
         guest_file_ops_ignore_error: true
       when: vmtools_is_running
 
-    # The instant cloned VM has the same IP address as the parent VM,
-    # reset it to get a new DHCP IP address
-    - name: "Reset client VM '{{ pvrdma_client_vm_name }}' for getting DHCP IP address"
-      include_tasks: ../../common/vm_set_power_state.yml
-      vars:
-        vm_power_state_set: "{{ vmtools_is_running | ternary('reboot-guest', 'restarted') }}"
-        vm_name: "{{ pvrdma_client_vm_name }}"
-
     - name: "Refresh client VM's guest IP till it has different IP with server VM"
       include_tasks:
         file: refresh_pvrdma_client_vm_ip.yml

--- a/linux/network_device_ops/pvrdma_client_network_device_ops.yml
+++ b/linux/network_device_ops/pvrdma_client_network_device_ops.yml
@@ -57,7 +57,15 @@
         src_path: "{{ guest_primary_nic_config_path }}"
         dest_path: "{{ current_test_log_folder }}/{{ guest_primary_nic_config_path | ansible.builtin.basename }}_after_clone"
         guest_file_ops_ignore_error: true
-      when: vmtools_is_running is defined and vmtools_is_running | bool
+      when: vmtools_is_running
+
+    # The instant cloned VM has the same IP address as the parent VM,
+    # reset it to get a new DHCP IP address
+    - name: "Reset client VM '{{ pvrdma_client_vm_name }}' for getting DHCP IP address"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: "{{ vmtools_is_running | ternary('reboot-guest', 'restarted') }}"
+        vm_name: "{{ pvrdma_client_vm_name }}"
 
     - name: "Refresh client VM's guest IP till it has different IP with server VM"
       include_tasks:

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -10,7 +10,7 @@
 - name: "Set fact of the 'poweroff' command"
   ansible.builtin.set_fact:
     inhibitor_list_cmd: "systemd-inhibit --list"
-    poweroff_cmd: "systemctl stop packagekit && systemctl poweroff --check-inhibitors=no"
+    poweroff_cmd: "systemctl poweroff -f"
   when:
     - guest_os_family is defined
     - guest_os_family == 'RedHat'

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -7,8 +7,16 @@
   ansible.builtin.pause:
     seconds: 5
 
+- name: "Set fact of the 'poweroff' command"
+  ansible.builtin.set_fact:
+    poweroff_cmd: >-
+      {%- if (guest_os_family == 'RedHat') and (guest_os_ansible_distribution_major_ver | int >= 10) -%}
+      systemctl poweroff --check-inhibitors=no
+      {%- else -%}poweroff
+      {%- endif -%}
+
 - name: "Shutdown guest OS"
-  ansible.builtin.command: "poweroff"
+  ansible.builtin.command: "{{ poweroff_cmd }}"
   delegate_to: "{{ vm_guest_ip }}"
   become: true
   changed_when: false

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -3,6 +3,10 @@
 ---
 # Shutdown VM via executing 'poweroff' command in guest OS
 #
+- name: "Pause 5 seconds"
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: "Shutdown guest OS"
   ansible.builtin.command: "poweroff"
   delegate_to: "{{ vm_guest_ip }}"
@@ -15,4 +19,4 @@
   include_tasks: ../../common/vm_wait_power_state.yml
   vars:
     expected_power_status: 'poweredOff'
-    wait_power_state_timeout: 600
+    wait_power_state_timeout: 300

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -10,7 +10,7 @@
 - name: "Set fact of the 'poweroff' command"
   ansible.builtin.set_fact:
     inhibitor_list_cmd: "systemd-inhibit --list"
-    poweroff_cmd: "systemctl poweroff --check-inhibitors=no"
+    poweroff_cmd: "systemctl stop packagekit && systemctl poweroff --check-inhibitors=no"
   when:
     - guest_os_family is defined
     - guest_os_family == 'RedHat'

--- a/linux/utils/shutdown.yml
+++ b/linux/utils/shutdown.yml
@@ -9,14 +9,27 @@
 
 - name: "Set fact of the 'poweroff' command"
   ansible.builtin.set_fact:
-    poweroff_cmd: >-
-      {%- if (guest_os_family == 'RedHat') and (guest_os_ansible_distribution_major_ver | int >= 10) -%}
-      systemctl poweroff --check-inhibitors=no
-      {%- else -%}poweroff
-      {%- endif -%}
+    inhibitor_list_cmd: "systemd-inhibit --list"
+    poweroff_cmd: "systemctl poweroff --check-inhibitors=no"
+  when:
+    - guest_os_family is defined
+    - guest_os_family == 'RedHat'
+    - guest_os_ansible_distribution_major_ver is defined
+    - guest_os_ansible_distribution_major_ver | int >= 10
+
+- name: "Check for active inhibitors in guest OS"
+  ansible.builtin.command: "{{ inhibitor_list_cmd }}"
+  delegate_to: "{{ vm_guest_ip }}"
+  become: true
+  changed_when: false
+  ignore_errors: true
+  register: inhibitor_list
+  when:
+    - inhibitor_list_cmd is defined
+    - inhibitor_list_cmd | length != 0
 
 - name: "Shutdown guest OS"
-  ansible.builtin.command: "{{ poweroff_cmd }}"
+  ansible.builtin.command: "{{ poweroff_cmd | default('poweroff') }}"
   delegate_to: "{{ vm_guest_ip }}"
   become: true
   changed_when: false

--- a/linux/vtpm_cold_add_remove/vtpm_add_remove_test.yml
+++ b/linux/vtpm_cold_add_remove/vtpm_add_remove_test.yml
@@ -52,6 +52,7 @@
     vm_name_clone_to: "{{ vm_name }}_clone_{{ current_test_timestamp }}"
     vm_name_clone_from: "{{ vm_name }}"
     vm_nic_mac_clone_from: "{{ vm_primary_nic_mac }}"
+    vm_nic_mac_clone_to: ""
     vm_ip_clone_from: "{{ vm_guest_ip }}"
     vm_dir_name_clone_from: "{{ vm_dir_name }}"
 
@@ -75,6 +76,27 @@
   ansible.builtin.set_fact:
     vm_name: "{{ vm_name_clone_to }}"
 
+- name: "Get cloned VM primary network adapter MAC address"
+  include_tasks: ../../common/vm_get_network_facts.yml
+
+- name: "Set fact of cloned VM primary network adapter MAC address"
+  ansible.builtin.set_fact:
+    vm_nic_mac_clone_to: "{{ vm_network_adapters['0'].mac_addr }}"
+  when:
+    - vm_network_adapters is defined
+    - vm_network_adapters['0'] is defined
+    - vm_network_adapters['0'].mac_addr is defined
+
+- name: "Check the primary network adapter MAC address of cloned VM"
+  ansible.builtin.assert:
+    that:
+      - vm_nic_mac_clone_to | length != 0
+      - vm_nic_mac_clone_to != vm_nic_mac_clone_from
+    fail_msg: >-
+      The primary network adapter's MAC address of cloned VM '{{ vm_name_clone_to }}' is '{{ vm_nic_mac_clone_to }}',
+      which is empty or the same as the primary network adapter's MAC address of the original VM
+      VM '{{ vm_name_clone_from }}'.
+
 - name: "Get cloned VM file path"
   include_tasks: ../../common/vm_get_config.yml
   vars:
@@ -86,6 +108,12 @@
 
 - name: "Print the cloned VM file path"
   ansible.builtin.debug: var=vm_dir_name
+
+- name: "Get IP address of cloned VM before reset"
+  include_tasks: ../../common/vm_get_ip.yml
+  vars:
+    vm_primary_nic_mac: "{{ vm_nic_mac_clone_to }}"
+    vm_get_ip_timeout: 300
 
 - name: "Perform cold add vTPM device test"
   include_tasks: vtpm_cold_add.yml

--- a/linux/vtpm_cold_add_remove/vtpm_add_remove_test.yml
+++ b/linux/vtpm_cold_add_remove/vtpm_add_remove_test.yml
@@ -94,8 +94,7 @@
       - vm_nic_mac_clone_to != vm_nic_mac_clone_from
     fail_msg: >-
       The primary network adapter's MAC address of cloned VM '{{ vm_name_clone_to }}' is '{{ vm_nic_mac_clone_to }}',
-      which is empty or the same as the primary network adapter's MAC address of the original VM
-      VM '{{ vm_name_clone_from }}'.
+      which is empty or the same as the primary network adapter's MAC address of the original VM '{{ vm_name_clone_from }}'.
 
 - name: "Get cloned VM file path"
   include_tasks: ../../common/vm_get_config.yml

--- a/linux/vtpm_cold_add_remove/vtpm_cold_add.yml
+++ b/linux/vtpm_cold_add_remove/vtpm_cold_add.yml
@@ -8,6 +8,12 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-off'
+      when: not vmtools_is_running
+    - name: "Shutdown instant cloned VM"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: 'shutdown-guest'
+      when: vmtools_is_running
     - name: "Add key provider on vCenter server"
       include_tasks: ../../common/vcenter_add_key_provider.yml
       vars:
@@ -27,20 +33,6 @@
   include_tasks: ../../common/vm_set_power_state.yml
   vars:
     vm_power_state_set: 'powered-on'
-
-- name: "Get cloned VM primary MAC address"
-  include_tasks: ../../common/vm_wait_primary_nic_mac.yml
-
-- name: "Check cloned VM MAC is not the same as parent VM MAC address"
-  ansible.builtin.assert:
-    that:
-      - vm_primary_nic_mac != vm_nic_mac_clone_from
-    fail_msg: >-
-      Cloned VM '{{ vm_name_clone_to }}' MAC address is '{{ vm_primary_nic_mac }}',
-      which is the same as parent VM '{{ vm_name_clone_from }}' MAC address.
-    success_msg:
-      - "Parent VM '{{ vm_name_clone_from }}' MAC address is: {{ vm_nic_mac_clone_from }}."
-      - "Cloned VM '{{ vm_name_clone_to }}' MAC address is: {{ vm_primary_nic_mac }}."
 
 - name: "Initialize cloned VM IP address"
   ansible.builtin.set_fact:

--- a/windows/vtpm_cold_add_remove/cold_add_vtpm.yml
+++ b/windows/vtpm_cold_add_remove/cold_add_vtpm.yml
@@ -8,6 +8,12 @@
       include_tasks: ../../common/vm_set_power_state.yml
       vars:
         vm_power_state_set: 'powered-off'
+      when: not vmtools_is_running
+    - name: "Shutdown instant cloned VM"
+      include_tasks: ../../common/vm_set_power_state.yml
+      vars:
+        vm_power_state_set: 'shutdown-guest'
+      when: vmtools_is_running
     - name: "Add key provider on vCenter server"
       include_tasks: ../../common/vcenter_add_key_provider.yml
       vars:


### PR DESCRIPTION
Add `vm_wait_guest_hostname.yml` before cloned VM power operations to wait for the cloned VM is ready, also use VM shutdown instead of poweroff on cloned VM when there is VMware Tools installed. 