### PR TITLE
[Linux] Check Ubuntu cloud-image for minimal-vmware is using EFI firmware

### DIFF
--- a/linux/check_efi_firmware/check_efi_firmware.yml
+++ b/linux/check_efi_firmware/check_efi_firmware.yml
@@ -24,7 +24,7 @@
           when:
             - guest_os_ansible_distribution == "Ubuntu"
             - guest_os_edition == "CloudImage"
-            - cloud_image_build_name | default('') == "minimal-vmware"
+            - cloud_image_build_name == "minimal-vmware"
 
         - name: "Skip testcase '{{ ansible_play_name }}' for {{ vm_firmware | upper }} VM"
           include_tasks: ../../common/skip_test_case.yml

--- a/linux/check_efi_firmware/check_efi_firmware.yml
+++ b/linux/check_efi_firmware/check_efi_firmware.yml
@@ -11,17 +11,27 @@
   tasks:
     - name: "Test case block"
       block:
+        - name: "Test setup"
+          include_tasks: ../setup/test_setup.yml
+          vars:
+            create_test_log_folder: true
+
+        - name: "Check Ubuntu cloud image firmware"
+          ansible.builtin.assert:
+            that:
+              - vm_firmware == "efi"
+            fail_msg: "The Ubuntu cloud image for minimal-vmware is not using EFI firmware"
+          when:
+            - guest_os_ansible_distribution == "Ubuntu"
+            - guest_os_edition == "CloudImage"
+            - cloud_image_build_name | default('') == "minimal-vmware"
+
         - name: "Skip testcase '{{ ansible_play_name }}' for {{ vm_firmware | upper }} VM"
           include_tasks: ../../common/skip_test_case.yml
           vars:
             skip_msg: "Skip test case due to VM's firmware is {{ vm_firmware }}"
             skip_reason: "Not Applicable"
           when: vm_firmware != "efi"
-
-        - name: "Test setup"
-          include_tasks: ../setup/test_setup.yml
-          vars:
-            create_test_log_folder: true
 
         - name: "Check EFI ROM in vmware.log"
           include_tasks: ../../common/vm_wait_log_msg.yml


### PR DESCRIPTION
EFI is a mandatory requirement for Ubuntu cloud images for minimal-vmware. So this case adds an assertion to check the firmware.

```
+--------------------------------------------------------------------------+
| Name                      | ansible_ubuntu24.04_ova                      |
+--------------------------------------------------------------------------+
| Guest OS Distribution     | Ubuntu 24.04-20240423 CloudImage x86_64      |
+--------------------------------------------------------------------------+
| Cloud Image Build         | server (serial: 20240423)                    |
+--------------------------------------------------------------------------+
| GUI Installed             | False                                        |
+--------------------------------------------------------------------------+
| CloudInit Version         | 24.1.3-0ubuntu3                              |
+--------------------------------------------------------------------------+
| Firmware                  | BIOS                                         |
+--------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                       |
+--------------------------------------------------------------------------+
| VMTools Version           | 12.3.5 (build-22544099)                      |
+--------------------------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                                |
+--------------------------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                                |
+--------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)                        |
+--------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                   |
+--------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                           |
|                           | bitness='64'                                 |
|                           | distroAddlVersion='24.04 LTS (Noble Numbat)' |
|                           | distroName='Ubuntu'                          |
|                           | distroVersion='24.04'                        |
|                           | familyName='Linux'                           |
|                           | kernelVersion='6.8.0-31-generic'             |
|                           | prettyName='Ubuntu 24.04 LTS'                |
+--------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 1, Skipped: 1, Elapsed Time: 00:12:46)
+--------------------------------------------------------+
| ID | Name               |   Status         | Exec Time |
+--------------------------------------------------------+
|  1 | deploy_vm_ova      |   Passed         | 00:09:12  |
|  2 | check_efi_firmware | * Not Applicable | 00:03:02  |
+--------------------------------------------------------+
```

```
VM information:
+---------------------------------------------------------------------------------------+
| Name                      | ansible_canonical_26.04_efi                               |
+---------------------------------------------------------------------------------------+
| Guest OS Distribution     | Ubuntu 26.04-20260310 CloudImage x86_64                   |
+---------------------------------------------------------------------------------------+
| Cloud Image Build         | minimal-vmware (serial: 20260310)                         |
+---------------------------------------------------------------------------------------+
| GUI Installed             | False                                                     |
+---------------------------------------------------------------------------------------+
| CloudInit Version         | 26.1-0ubuntu1                                             |
+---------------------------------------------------------------------------------------+
| Firmware                  | EFI                                                       |
+---------------------------------------------------------------------------------------+
| Hardware Version          | vmx-20                                                    |
+---------------------------------------------------------------------------------------+
| VMTools Version           | 13.0.10 (build-25056151)                                  |
+---------------------------------------------------------------------------------------+
| Config Guest Id           | ubuntu64Guest                                             |
+---------------------------------------------------------------------------------------+
| GuestInfo Guest Id        | ubuntu64Guest                                             |
+---------------------------------------------------------------------------------------+
| GuestInfo Guest Full Name | Ubuntu Linux (64-bit)                                     |
+---------------------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                                |
+---------------------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                                        |
|                           | bitness='64'                                              |
|                           | distroAddlVersion='26.04 (Resolute Raccoon)'              |
|                           | distroName='Ubuntu'                                       |
|                           | distroVersion='26.04'                                     |
|                           | familyName='Linux'                                        |
|                           | kernelVersion='6.19.0-9-generic'                          |
|                           | prettyName='Ubuntu Resolute Raccoon (development branch)' |
+---------------------------------------------------------------------------------------+


Test Results (Total: 2, Passed: 2, Elapsed Time: 00:10:02)
+----------------------------------------------+
| ID | Name               | Status | Exec Time |
+----------------------------------------------+
|  1 | deploy_vm_ova      | Passed | 00:08:58  |
|  2 | check_efi_firmware | Passed | 00:00:48  |
+----------------------------------------------+
```