### PR TITLE
[Photon 5] failure in file get_installed_packages.yml:12 for Photon 5 OVA and ISO

### DIFF
--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -54,6 +54,12 @@
       vars:
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
+    
+    # Fix issue: Failed to import the required Python library (rpm) on photon-autoinstall-machine's Python /usr/bin/python3.11
+    - name: "link rpm to /usr/lib/python3.11/site-packages/"
+      ansible.builtin.command: "ln -s /usr/lib/python3.14/site-packages/rpm /usr/lib/python3.11/site-packages/"
+      delegate_to: "{{ vm_guest_ip }}"
+      when: guest_os_ansible_distribution_major_ver | int == 5
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:
@@ -86,3 +92,5 @@
 
     - name: "Update /etc/fstab with partition UUID"
       include_tasks: ../utils/freebsd_update_fstab_with_uuid.yml
+
+  

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -55,8 +55,8 @@
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
     
-    # Fix issue in photon 5 GA ISO/OVA: Failed to import the required Python library (rpm) on bunleded Python /usr/bin/python3.11
-    - name: "Get path of package python3-rpm and link to /usr/lib/python3.11/site-packages/"
+    # Workaround for Photon OS 5.0 GA: Resolving 'python3-rpm' import failure in the default Python 3.11 environment.
+    - name: "Get path of package python3-rpm and create symbol link to it"
       when: 
         - guest_os_ansible_distribution_major_ver | int == 5
         - ansible_python_version == "3.11.0"
@@ -69,12 +69,11 @@
         - name: "Display the path of package python3-rpm"
           ansible.builtin.debug: var=rpm_package_result
 
-        - name: "link rpm to /usr/lib/python3.11/site-packages/"
+        - name: "Create symbol link '/usr/lib/python3.11/site-packages/rpm'"
           ansible.builtin.shell: "ln -s {{ rpm_package_result.stdout.strip() }} /usr/lib/python3.11/site-packages/"
           delegate_to: "{{ vm_guest_ip }}"
           ignore_errors: true
-          when: 
-            - not rpm_package_result.failed
+          when:
             - rpm_package_result.stdout is defined
             - rpm_package_result.stdout | length > 0
             - not rpm_package_result.stdout is search('python3\.11')

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -60,7 +60,7 @@
       when: guest_os_ansible_distribution_major_ver | int == 5
       block:
         - name: "Get path of package python3-rpm"
-          ansible.builtin.command: "rpm -ql python3-rpm | grep site-packages/rpm$"
+          ansible.builtin.shell: "rpm -ql python3-rpm | grep 'site-packages\/rpm$'"
           delegate_to: "{{ vm_guest_ip }}"
           register: rpm_package_result
 

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -57,7 +57,9 @@
     
     # Fix issue in photon 5 GA ISO/OVA: Failed to import the required Python library (rpm) on bunleded Python /usr/bin/python3.11
     - name: "Get path of package python3-rpm and link to /usr/lib/python3.11/site-packages/"
-      when: guest_os_ansible_distribution_major_ver | int == 5
+      when: 
+        - guest_os_ansible_distribution_major_ver | int == 5
+        - ansible_python_version == "3.11.0"
       block:
         - name: "Get path of package python3-rpm"
           ansible.builtin.shell: "rpm -ql python3-rpm | grep 'site-packages\/rpm$'"
@@ -75,7 +77,7 @@
             - not rpm_package_result.failed
             - rpm_package_result.stdout is defined
             - rpm_package_result.stdout | length > 0
-            - ansible_python_version == "3.11.0"
+            - not rpm_package_result.stdout is search('python3\.11')
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -31,7 +31,6 @@
   when:
     - guest_os_python_version is version('3.0.0', '>=')
     - guest_os_ansible_pkg_mgr is search('yum|dnf|zypper')
-    - not (guest_os_ansible_distribution == "VMware Photon OS" and guest_os_ansible_distribution_major_ver | int == 5)
 
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
@@ -56,19 +55,27 @@
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
     
-    # Fix issue in photon 5: Failed to import the required Python library (rpm) on bunleded Python /usr/bin/python3.11
-    - name: "Upgrade python3 to latest vesion and install package python3-rpm for Photon 5"
+    # Fix issue in photon 5 GA ISO/OVA: Failed to import the required Python library (rpm) on bunleded Python /usr/bin/python3.11
+    - name: "Get path of package python3-rpm and link to /usr/lib/python3.11/site-packages/"
       when: guest_os_ansible_distribution_major_ver | int == 5
       block:
-        - name: "Upgrade python3 to lastet version for Photon 5"
-          ansible.builtin.command: "tdnf update -y --nogpgcheck python3"
+        - name: "Get path of package python3-rpm"
+          ansible.builtin.shell: "rpm -ql python3-rpm | grep 'site-packages\/rpm$'"
           delegate_to: "{{ vm_guest_ip }}"
+          register: rpm_package_result
 
-        - name: "Install 'python3-rpm' on {{ vm_guest_os_distribution }}"
-          include_tasks: ../utils/install_uninstall_package.yml
-          vars:
-            package_list: ["python3*-rpm"]
-            package_state: "latest"
+        - name: "Display the path of package python3-rpm"
+          ansible.builtin.debug: var=rpm_package_result
+
+        - name: "link rpm to /usr/lib/python3.11/site-packages/"
+          ansible.builtin.shell: "ln -s {{ rpm_package_result.stdout.strip() }} /usr/lib/python3.11/site-packages/"
+          delegate_to: "{{ vm_guest_ip }}"
+          ignore_errors: true
+          when: 
+            - not rpm_package_result.failed
+            - rpm_package_result.stdout is defined
+            - rpm_package_result.stdout | length > 0
+            - ansible_python_version == "3.11.0"
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -68,12 +68,13 @@
           ansible.builtin.debug: var=rpm_package_result
 
         - name: "link rpm to /usr/lib/python3.11/site-packages/"
-          ansible.builtin.command: "ln -s {{ rpm_package_result.stdout.split() }} /usr/lib/python3.11/site-packages/"
+          ansible.builtin.command: "ln -s {{ rpm_package_result.stdout_lines[0].split() }} /usr/lib/python3.11/site-packages/"
           delegate_to: "{{ vm_guest_ip }}"
+          ignore_errors: true
           when: 
             - not rpm_package_result.failed
-            - rpm_package_result.stdout is defined
-            - rpm_package_result.stdout | length > 0
+            - rpm_package_result.stdout_lines is defined
+            - rpm_package_result.stdout_lines | length > 0
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -55,11 +55,25 @@
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
     
-    # Fix issue: Failed to import the required Python library (rpm) on photon-autoinstall-machine's Python /usr/bin/python3.11
-    - name: "link rpm to /usr/lib/python3.11/site-packages/"
-      ansible.builtin.command: "ln -s /usr/lib/python3.14/site-packages/rpm /usr/lib/python3.11/site-packages/"
-      delegate_to: "{{ vm_guest_ip }}"
+    # Fix issue in photon 5: Failed to import the required Python library (rpm) on photon-autoinstall-machine's Python /usr/bin/python3.11
+    - name: "Get path of package python3-rpm and link to /usr/lib/python3.11/site-packages/"
       when: guest_os_ansible_distribution_major_ver | int == 5
+      block:
+        - name: "Get path of package python3-rpm"
+          ansible.builtin.command: "rpm -ql python3-rpm | grep site-packages/rpm$"
+          delegate_to: "{{ vm_guest_ip }}"
+          register: rpm_package_result
+
+        - name: "Display the path of package python3-rpm"
+          ansible.builtin.debug: var=rpm_package_result
+
+        - name: "link rpm to /usr/lib/python3.11/site-packages/"
+          ansible.builtin.command: "ln -s {{ rpm_package_result.stdout.split() }} /usr/lib/python3.11/site-packages/"
+          delegate_to: "{{ vm_guest_ip }}"
+          when: 
+            - not rpm_package_result.failed
+            - rpm_package_result.stdout is defined
+            - rpm_package_result.stdout | length > 0
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -63,7 +63,7 @@
       block:
         - name: "Get latest 4.18 python3-rpm package"
           ansible.builtin.shell: >
-            curl -s https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/
+            curl -s https://packages.broadcom.com/photon/5.0/photon_release_5.0_x86_64/x86_64/
             | grep python3-rpm-4.18
             | sed 's/<[^>]*>//g'
             | awk '{print $1}'
@@ -76,7 +76,7 @@
           ansible.builtin.debug: var=python3_rpm_pkg
 
         - name: "Install the package python3-rpm-4.18.*"
-          ansible.builtin.shell: "tdnf install -y https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
+          ansible.builtin.shell: "tdnf install -y https://packages.broadcom.com/photon/5.0/photon_release_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
           delegate_to: "{{ vm_guest_ip }}"
           when:
             - python3_rpm_pkg.stdout is defined

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -31,6 +31,7 @@
   when:
     - guest_os_python_version is version('3.0.0', '>=')
     - guest_os_ansible_pkg_mgr is search('yum|dnf|zypper')
+    - not (guest_os_ansible_distribution == "VMware Photon OS" and guest_os_ansible_distribution_major_ver | int == 5)
 
 - name: "Reconfigure VMware Photon OS"
   when: guest_os_ansible_distribution == "VMware Photon OS"
@@ -55,11 +56,19 @@
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
     
-    # Fix issue in photon 5: Failed to import the required Python library (rpm) on photon-autoinstall-machine's Python /usr/bin/python3.11
-    - name: "Update pyhton3 to latest version for photon 5"
-      ansible.builtin.command: "tdnf update -y --nogpgcheck python3"
-      delegate_to: "{{ vm_guest_ip }}"
+    # Fix issue in photon 5: Failed to import the required Python library (rpm) on bunleded Python /usr/bin/python3.11
+    - name: "Upgrade python3 to latest vesion and install package python3-rpm for Photon 5"
       when: guest_os_ansible_distribution_major_ver | int == 5
+      block:
+        - name: "Upgrade python3 to lastet version for Photon 5"
+          ansible.builtin.command: "tdnf update -y --nogpgcheck python3"
+          delegate_to: "{{ vm_guest_ip }}"
+
+        - name: "Install 'python3-rpm' on {{ vm_guest_os_distribution }}"
+          include_tasks: ../utils/install_uninstall_package.yml
+          vars:
+            package_list: ["python3*-rpm"]
+            package_state: "latest"
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -56,7 +56,7 @@
         package_state: "latest"
     
     # Workaround for Photon OS 5.0 GA / update ISO / OVA: Resolving 'python3-rpm' import failure in the default Python 3.11 environment.
-    - name: "Reinstall latest python3-rpm-4.18.* for python 3.11.x"
+    - name: "Reinstall latest python3-rpm-4.18.* for python 3.11.x in Photon 5"
       when: 
         - guest_os_ansible_distribution_major_ver | int == 5
         - ansible_python_version is match("^3\.11")
@@ -76,7 +76,7 @@
           ansible.builtin.debug: var=python3_rpm_pkg
 
         - name: "Install the package python3-rpm-4.18.*"
-          ansible.builtin.shell: "tdnf install https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
+          ansible.builtin.shell: "tdnf install -y https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
           delegate_to: "{{ vm_guest_ip }}"
           when:
             - python3_rpm_pkg.stdout is defined

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -56,25 +56,10 @@
         package_state: "latest"
     
     # Fix issue in photon 5: Failed to import the required Python library (rpm) on photon-autoinstall-machine's Python /usr/bin/python3.11
-    - name: "Get path of package python3-rpm and link to /usr/lib/python3.11/site-packages/"
+    - name: "Update pyhton3 to latest version for photon 5"
+      ansible.builtin.command: "tdnf update -y --nogpgcheck python3"
+      delegate_to: "{{ vm_guest_ip }}"
       when: guest_os_ansible_distribution_major_ver | int == 5
-      block:
-        - name: "Get path of package python3-rpm"
-          ansible.builtin.shell: "rpm -ql python3-rpm | grep 'site-packages\/rpm$'"
-          delegate_to: "{{ vm_guest_ip }}"
-          register: rpm_package_result
-
-        - name: "Display the path of package python3-rpm"
-          ansible.builtin.debug: var=rpm_package_result
-
-        - name: "link rpm to /usr/lib/python3.11/site-packages/"
-          ansible.builtin.shell: "ln -s {{ rpm_package_result.stdout.strip() }} /usr/lib/python3.11/site-packages/"
-          delegate_to: "{{ vm_guest_ip }}"
-          ignore_errors: true
-          when: 
-            - not rpm_package_result.failed
-            - rpm_package_result.stdout is defined
-            - rpm_package_result.stdout | length > 0
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -92,5 +92,3 @@
 
     - name: "Update /etc/fstab with partition UUID"
       include_tasks: ../utils/freebsd_update_fstab_with_uuid.yml
-
-  

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -68,13 +68,13 @@
           ansible.builtin.debug: var=rpm_package_result
 
         - name: "link rpm to /usr/lib/python3.11/site-packages/"
-          ansible.builtin.command: "ln -s {{ rpm_package_result.stdout_lines[0].split() }} /usr/lib/python3.11/site-packages/"
+          ansible.builtin.shell: "ln -s {{ rpm_package_result.stdout.strip() }} /usr/lib/python3.11/site-packages/"
           delegate_to: "{{ vm_guest_ip }}"
           ignore_errors: true
           when: 
             - not rpm_package_result.failed
-            - rpm_package_result.stdout_lines is defined
-            - rpm_package_result.stdout_lines | length > 0
+            - rpm_package_result.stdout is defined
+            - rpm_package_result.stdout | length > 0
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -55,28 +55,32 @@
         package_list: ["sudo", "gawk", "tar", "wget", "curl"]
         package_state: "latest"
     
-    # Workaround for Photon OS 5.0 GA: Resolving 'python3-rpm' import failure in the default Python 3.11 environment.
-    - name: "Get path of package python3-rpm and create symbol link to it"
+    # Workaround for Photon OS 5.0 GA / update ISO / OVA: Resolving 'python3-rpm' import failure in the default Python 3.11 environment.
+    - name: "Reinstall latest python3-rpm-4.18.* for python 3.11.x"
       when: 
         - guest_os_ansible_distribution_major_ver | int == 5
-        - ansible_python_version == "3.11.0"
+        - ansible_python_version is match("^3\.11")
       block:
-        - name: "Get path of package python3-rpm"
-          ansible.builtin.shell: "rpm -ql python3-rpm | grep 'site-packages\/rpm$'"
+        - name: "Get latest 4.18 python3-rpm package"
+          ansible.builtin.shell: >
+            curl -s https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/
+            | grep python3-rpm-4.18
+            | sed 's/<[^>]*>//g'
+            | awk '{print $1}'
+            | sort -V
+            | tail -1
           delegate_to: "{{ vm_guest_ip }}"
-          register: rpm_package_result
+          register: python3_rpm_pkg
 
-        - name: "Display the path of package python3-rpm"
-          ansible.builtin.debug: var=rpm_package_result
+        - name: "Display the latest package python3-rpm-4.18.*"
+          ansible.builtin.debug: var=python3_rpm_pkg
 
-        - name: "Create symbol link '/usr/lib/python3.11/site-packages/rpm'"
-          ansible.builtin.shell: "ln -s {{ rpm_package_result.stdout.strip() }} /usr/lib/python3.11/site-packages/"
+        - name: "Install the package python3-rpm-4.18.*"
+          ansible.builtin.shell: "tdnf install https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
           delegate_to: "{{ vm_guest_ip }}"
-          ignore_errors: true
           when:
-            - rpm_package_result.stdout is defined
-            - rpm_package_result.stdout | length > 0
-            - not rpm_package_result.stdout is search('python3\.11')
+            - python3_rpm_pkg.stdout is defined
+            - python3_rpm_pkg.stdout | length > 0
 
 - name: "Reconfigure {{ guest_os_ansible_distribution }}"
   when:

--- a/linux/setup/reconfig_existing_guest.yml
+++ b/linux/setup/reconfig_existing_guest.yml
@@ -61,9 +61,16 @@
         - guest_os_ansible_distribution_major_ver | int == 5
         - ansible_python_version is match("^3\.11")
       block:
+        - name: "Set fact of package python3-rpm-4.18.x URL"
+          ansible.builtin.set_fact:
+            python3_rpm_url: |-
+              {%- if esxi_cpu_vendor == 'arm' -%}https://packages.broadcom.com/photon/5.0/photon_5.0_aarch64/aarch64/
+              {%- else -%}https://packages.broadcom.com/photon/5.0/photon_release_5.0_x86_64/x86_64/
+              {%- endif -%}
+        
         - name: "Get latest 4.18 python3-rpm package"
           ansible.builtin.shell: >
-            curl -s https://packages.broadcom.com/photon/5.0/photon_release_5.0_x86_64/x86_64/
+            curl -s {{ python3_rpm_url }}
             | grep python3-rpm-4.18
             | sed 's/<[^>]*>//g'
             | awk '{print $1}'
@@ -76,7 +83,7 @@
           ansible.builtin.debug: var=python3_rpm_pkg
 
         - name: "Install the package python3-rpm-4.18.*"
-          ansible.builtin.shell: "tdnf install -y https://packages.broadcom.com/photon/5.0/photon_release_5.0_x86_64/x86_64/{{ python3_rpm_pkg.stdout }} --nogpgcheck"
+          ansible.builtin.shell: "tdnf install -y {{ python3_rpm_url }}{{ python3_rpm_pkg.stdout }} --nogpgcheck"
           delegate_to: "{{ vm_guest_ip }}"
           when:
             - python3_rpm_pkg.stdout is defined

--- a/linux/utils/get_installed_packages.yml
+++ b/linux/utils/get_installed_packages.yml
@@ -14,7 +14,6 @@
     manager: auto
   delegate_to: "{{ vm_guest_ip }}"
   register: guest_package_facts
-  no_log: true
 
 - name: "Set fact of installed packages on {{ guest_os_ansible_distribution }}"
   ansible.builtin.set_fact:


### PR DESCRIPTION
GOSV-6154
failure in file get_installed_packages.yml:12 for Photon 5 OVA and ISO


Root cause:
The python3‑rpm package in Photon OS 5.0 incorrectly installs the rpm bindings into the Python 3.14 path, but the system does not provide Python 3.14.