### PR TITLE
Update tmp partition in sles-16.1 autoinstall

### DIFF
--- a/autoinstall/SLE/16.1/SLES/autoinst.jsonnet
+++ b/autoinstall/SLE/16.1/SLES/autoinst.jsonnet
@@ -112,6 +112,11 @@ local nicName = agama.findByID(agama.lshw, 'network').logicalname;
         content: |||
           #!/bin/bash
           echo "Execute post-install script" >/dev/ttyS0
+          # Mask the systemd tmpfs mount service
+          echo "Configuring /tmp to use disk space instead of RAM..." >/dev/ttyS0
+          systemctl mask tmp.mount
+          # Remove any /tmp mount entries from /etc/fstab
+          sed -i '/[[:space:]]\/tmp[[:space:]]/d' /etc/fstab
           echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
         |||
       }


### PR DESCRIPTION
Fixed /tmp partion to use disk space instead of RAM in sles-16.1.
Testing Done: autoinstall and regression tests passed in sles-16.1-beta3.

```
+----------------------------------------------------------------------------+
| Guest OS Distribution     | SLES 16.1 x86_64                               |
+----------------------------------------------------------------------------+
| GUI Installed             | True (GDM wayland)                             |
+----------------------------------------------------------------------------+
| CloudInit Version         | 25.1.3-160099.2.37                             |
+----------------------------------------------------------------------------+
| Firmware                  | EFI                                            |
+----------------------------------------------------------------------------+
| Hardware Version          | vmx-22                                         |
+----------------------------------------------------------------------------+
| Config Guest Id           | sles16_64Guest                                 |
+----------------------------------------------------------------------------+
| GuestInfo Guest Id        | sles16_64Guest                                 |
+----------------------------------------------------------------------------+
| GuestInfo Guest Full Name | SUSE Linux Enterprise 16 (64-bit)              |
+----------------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                                     |
+----------------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                             |
|                           | bitness='64'                                   |
|                           | cpeString='cpe:/o:suse:sles:16:16.1'           |
|                           | distroAddlVersion='16.1 009-Beta3'             |
|                           | distroName='SLES'                              |
|                           | distroVersion='16.1'                           |
|                           | familyName='Linux'                             |
|                           | kernelVersion='6.12.0-160099.38-default'       |
|                           | prettyName='SUSE Linux Enterprise Server 16.1' |
+----------------------------------------------------------------------------+

Test Results (Total: 32, Passed: 29, Skipped: 3, Elapsed Time: 03:30:07)
+--------------------------------------------------------------------------+
| ID | Name                                 |   Status         | Exec Time |
+--------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed         | 00:13:08  |
| 02 | check_inbox_driver                   |   Passed         | 00:03:48  |
| 03 | ovt_verify_src_install               |   Passed         | 00:16:23  |
| 04 | ovt_verify_status                    | * Not Applicable | 00:00:58  |
| 05 | vgauth_check_service                 | * Not Applicable | 00:00:57  |
| 06 | host_verify_saml_token               |   Passed         | 00:03:30  |
| 07 | check_ip_address                     |   Passed         | 00:01:08  |
| 08 | check_os_fullname                    |   Passed         | 00:02:20  |
| 09 | stat_balloon                         |   Passed         | 00:01:03  |
| 10 | stat_hosttime                        |   Passed         | 00:01:02  |
| 11 | device_list                          |   Passed         | 00:02:56  |
| 12 | power_operation_scripts              |   Passed         | 00:17:18  |
| 13 | check_quiesce_snapshot_custom_script |   Passed         | 00:01:28  |
| 14 | memory_hot_add_basic                 |   Passed         | 00:06:21  |
| 15 | cpu_hot_add_basic                    |   Passed         | 00:05:27  |
| 16 | cpu_multicores_per_socket            |   Passed         | 00:08:21  |
| 17 | check_efi_firmware                   |   Passed         | 00:01:06  |
| 18 | secureboot_enable_disable            |   Passed         | 00:04:48  |
| 19 | pvrdma_network_device_ops            |   Passed         | 00:16:21  |
| 20 | e1000e_network_device_ops            |   Passed         | 00:07:31  |
| 21 | vmxnet3_network_device_ops           |   Passed         | 00:07:29  |
| 22 | gosc_perl_dhcp                       |   Passed         | 00:06:13  |
| 23 | gosc_perl_staticip                   |   Passed         | 00:05:42  |
| 24 | gosc_cloudinit_dhcp                  |   Passed         | 00:06:45  |
| 25 | gosc_cloudinit_staticip              |   Passed         | 00:06:38  |
| 26 | paravirtual_vhba_device_ops          |   Passed         | 00:08:13  |
| 27 | lsilogic_vhba_device_ops             |   Passed         | 00:16:30  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed         | 00:08:14  |
| 29 | sata_vhba_device_ops                 |   Passed         | 00:08:29  |
| 30 | nvme_vhba_device_ops                 |   Passed         | 00:08:03  |
| 31 | nvdimm_cold_add_remove               |   Passed         | 00:09:45  |
| 32 | ovt_verify_pkg_uninstall             | * Not Applicable | 00:00:58  |
+--------------------------------------------------------------------------+
```