### PR TITLE
Update online repo for opensuse-16.0

### DIFF
--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -131,7 +131,10 @@
   ansible.builtin.set_fact:
     guest_online_repos:
       - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_OSS"
-        baseurl: "http://download.opensuse.org/distribution/leap/$releasever/repo/oss"
+        baseurl: >-
+          {{ 'https://download.opensuse.org/distribution/leap/$releasever/repo/oss/' 
+             if (guest_os_ansible_distribution_ver is version('16.0', '==')) 
+             else 'http://download.opensuse.org/distribution/leap/$releasever/repo/oss' }}
   when: guest_os_ansible_distribution == "openSUSE Leap"
 
 - name: "Add VMware Photon OS online repositories"

--- a/linux/utils/enable_disable_repos.yml
+++ b/linux/utils/enable_disable_repos.yml
@@ -44,6 +44,28 @@
         rejectattr('status', 'equalto', repo_state)
       }}
 
+- name: "Standardize openSUSE Repositories to HTTPS"
+  delegate_to: "{{ vm_guest_ip }}"
+  when:
+    - repo_state == "enabled"
+    - guest_os_ansible_distribution is search('openSUSE')
+    - guest_os_ansible_distribution_ver is version('16.0','==')
+    - existing_repos | length > 0
+  block:
+    - name: "Find openSUSE repo files on target VM"
+      ansible.builtin.find:
+        paths: "/etc/zypp/repos.d"
+        patterns: "*.repo"
+      register: found_repo_files
+
+    - name: "Change 'http' to 'https' and add trailing slash in the repo URL"
+      ansible.builtin.replace:
+        path: "{{ item.path }}"
+        regexp: '^baseurl=http://(.*[^/])$'
+        replace: 'baseurl=https://\1/'
+      loop: "{{ found_repo_files.files | default([]) }}"
+      when: found_repo_files.matched > 0
+
 - name: "Set fact of repository ids need to be {{ repo_state }}"
   ansible.builtin.set_fact:
     existing_repo_ids: "{{ existing_repos | map(attribute='id') }}"


### PR DESCRIPTION
Intermittent Curl 56 (Connection Reset) and 302 Redirect errors occur in opensuse online repo updates because unencrypted HTTP traffic triggers firewall interference and inefficient redirect loops. This task fixes repository URLs to HTTPS to encrypt the data stream and ensures a trailing slash is present to hit directories directly, bypassing network resets and redundant redirect cycles.

Testing Done: yes. Regression passed in opensuse-16.0
```
Test Results (Total: 32, Passed: 26, Skipped: 6, Elapsed Time: 02:38:23)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_paravirtual_vmxnet3    |   Passed        | 00:18:35  |
| 02 | check_inbox_driver                   |   Passed        | 00:04:26  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:09:53  |
| 04 | ovt_verify_status                    |   Passed        | 00:03:33  |
| 05 | vgauth_check_service                 |   Passed        | 00:01:28  |
| 06 | host_verify_saml_token               |   Passed        | 00:03:03  |
| 07 | check_ip_address                     |   Passed        | 00:00:48  |
| 08 | check_os_fullname                    |   Passed        | 00:01:52  |
| 09 | stat_balloon                         |   Passed        | 00:00:41  |
| 10 | stat_hosttime                        |   Passed        | 00:00:41  |
| 11 | device_list                          |   Passed        | 00:02:35  |
| 12 | power_operation_scripts              |   Passed        | 00:16:21  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:08  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:05:22  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:05:04  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:08:09  |
| 17 | check_efi_firmware                   |   Passed        | 00:00:43  |
| 18 | secureboot_enable_disable            |   Passed        | 00:04:22  |
| 19 | pvrdma_network_device_ops            | * Not Supported | 00:00:41  |
| 20 | e1000e_network_device_ops            |   Passed        | 00:07:14  |
| 21 | vmxnet3_network_device_ops           |   Passed        | 00:06:19  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:00:49  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:00:38  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:00:38  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:00:38  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:07:13  |
| 27 | lsilogic_vhba_device_ops             |   Passed        | 00:15:53  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed        | 00:08:30  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:07:23  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:06:55  |
| 31 | nvdimm_cold_add_remove               | * Not Supported | 00:00:41  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:04:58  |
+-------------------------------------------------------------------------+
```