### PR TITLE
Update autoinstall for opensuse-16

### DIFF
--- a/autoinstall/openSUSE/16.0/autoinst.jsonnet
+++ b/autoinstall/openSUSE/16.0/autoinst.jsonnet
@@ -35,8 +35,7 @@ local nicName = agama.findByID(agama.lshw, 'network').logicalname;
   user: {
     fullName: "{{ new_user }}",
     password: "{{ vm_password }}",
-    userName: "{{ new_user }}",
-    autologin: true
+    userName: "{{ new_user }}"
   },
 {% endif %}
   root: {
@@ -60,7 +59,7 @@ local nicName = agama.findByID(agama.lshw, 'network').logicalname;
            generate: "default"
           }
        ]
-     },
+     }
     ]
   },
   network: {


### PR DESCRIPTION
The warning "You need to fix any invalid settings before proceeding with the installation" occurs during autoinstall for opensuse-16.1-alpha-64bit. This fix removes "autologin:true" to make autoinstall proceed well.

Testing Done: yes.
```
VM information:
+----------------------------------------------------------------------+
| Guest OS Distribution     | openSUSE Leap 16.1 x86_64                |
+----------------------------------------------------------------------+
| GUI Installed             | True (GDM wayland)                       |
+----------------------------------------------------------------------+
| Firmware                  | EFI                                      |
+----------------------------------------------------------------------+
| Hardware Version          | vmx-22                                   |
+----------------------------------------------------------------------+
| Config Guest Id           | opensuse64Guest                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Id        | opensuse64Guest                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Full Name | SUSE openSUSE (64-bit)                   |
+----------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                               |
+----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                       |
|                           | bitness='64'                             |
|                           | cpeString='cpe:/o:opensuse:leap:16.1'    |
|                           | distroAddlVersion='16.1'                 |
|                           | distroName='openSUSE Leap'               |
|                           | distroVersion='16.1'                     |
|                           | familyName='Linux'                       |
|                           | kernelVersion='6.12.0-160099.37-default' |
|                           | prettyName='openSUSE Leap 16.1'          |
+----------------------------------------------------------------------+

Test Results (Total: 4, Passed: 4, Elapsed Time: 00:27:28)
+-------------------------------------------------------------+
| ID | Name                              | Status | Exec Time |
+-------------------------------------------------------------+
|  1 | deploy_vm_efi_paravirtual_vmxnet3 | Passed | 00:11:34  |
|  2 | check_inbox_driver                | Passed | 00:03:20  |
|  3 | ovt_verify_pkg_install            | Passed | 00:08:41  |
|  4 | ovt_verify_status                 | Passed | 00:03:25  |
+-------------------------------------------------------------+
```