### PR TITLE
[Pardus 25]perl GOSC is not supported in 90GA for pardus 25.0 XFCE and Server

### DIFF
--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -105,6 +105,7 @@ Pardus GNU/Linux XFCE:
 
 # Pardus 21.x Server support GOSC testing on vCenter Server 8.0U2 and on vCenter Server 7.0.3 from build 22585855(7.0.3P08), or higher vCenter Server versions.
 # Pardus 23.x Server support GOSC testing on vCenter Server 8.0U3 or higher vCenter Server versions.
+# Pardus 25.x Server support GOSC testing on vCenter Server 9.1.0.0 or higher vCenter Server versions.
 Pardus GNU/Linux Server:
   '21.2':
     vcenter:
@@ -115,6 +116,9 @@ Pardus GNU/Linux Server:
   '23.0':
     vcenter:
       8.0.3: 24022515
+  '25.0':
+    vcenter:
+      9.1.0: 25370922
 
 # Miracle Linux 8.4 and higher version support GOSC testing on vCenter Server 8.0.3 from build 24022515, or higher vCenter Server versions.
 MIRACLE:

--- a/linux/guest_customization/gosc_support_matrix.yml
+++ b/linux/guest_customization/gosc_support_matrix.yml
@@ -89,6 +89,7 @@ Ubuntu:
       7.0.1: 16858589
 
 # Pardus 21.x / 23.x XFCE support GOSC testing on vCenter Server 8.0U2 and on vCenter Server 7.0.3 from build 22585855(7.0.3P08), or higher vCenter Server versions.
+# Pardus 25.x XFCE support GOSC testing on vCenter Server 9.1.0.0 or higher vCenter Server versions.
 Pardus GNU/Linux XFCE:
   '21.2':
     vcenter:
@@ -102,6 +103,9 @@ Pardus GNU/Linux XFCE:
       8.0.0: N/A
       8.0.1: N/A
       8.0.2: 22385739
+  '25.0':
+    vcenter:
+      9.1.0: 25370922
 
 # Pardus 21.x Server support GOSC testing on vCenter Server 8.0U2 and on vCenter Server 7.0.3 from build 22585855(7.0.3P08), or higher vCenter Server versions.
 # Pardus 23.x Server support GOSC testing on vCenter Server 8.0U3 or higher vCenter Server versions.


### PR DESCRIPTION
perl GOSC is not supported in 90GA for pardus 25.0 XFCE and Server
pardus-64 is supported in 9.1.0 and later releases