### PR TITLE
[Photon]ovt_verify_pkg_install failed in photon-5.x-20260602-64bit due to fuse-2.9.9-2.ph5.x86_64 disabled

### DIFF
--- a/linux/utils/photon_config_repo.yml
+++ b/linux/utils/photon_config_repo.yml
@@ -46,10 +46,10 @@
       delegate_to: "{{ vm_guest_ip }}"
       when: ansible_kernel == '6.1.10-10.ph5-esx'
 
-    - name: "Disable current all other repositories and enable photon-snapshot.repo for Photon 5 Update image and later"
+    - name: "Disable current all other repositories and enable photon-snapshot.repo and photon-updates.repo for Photon 5 Update image and later"
       ansible.builtin.shell: |
         for f in $(ls /etc/yum.repos.d/*.repo); do
-          if [[ "$f" == *photon-snapshot.repo ]]; then
+          if [[ "$f" =~ (photon-snapshot|photon-updates)\.repo$ ]]; then
             sed -i 's/enabled=0/enabled=1/g' "$f";
           else
             sed -i 's/enabled=1/enabled=0/g' "$f";


### PR DESCRIPTION
Issue:
ovt_verify_pkg_install failed in photon-5.x-20260602-64bit due to fuse-2.9.9-2.ph5.x86_64 disabled

Resolution:
fuse-2.9.9-2.ph5.x86_64 is in photon-updates repo and enable the photon-updates repo for Photon 5