### PR TITLE
[FreeBSD]FreeBSD 15.1 RC2 failed to recognize the new disk hot added to existing nvme controller

### DIFF
--- a/linux/vhba_hot_add_remove/handle_nvme_known_issue.yml
+++ b/linux/vhba_hot_add_remove/handle_nvme_known_issue.yml
@@ -46,7 +46,7 @@
 - name: "Handle NVMe known issue on FreeBSD"
   when:
     - guest_os_ansible_distribution == 'FreeBSD'
-    - guest_os_ansible_distribution_major_ver | int <= 13 or (guest_os_ansible_distribution_major_ver | int  == 15 and guest_os_ansible_distribution_minor_ver | int == 0)
+    - guest_os_ansible_distribution_major_ver | int <= 13 or (guest_os_ansible_distribution_major_ver | int  == 15 and guest_os_ansible_distribution_minor_ver in ['0', '1'])
   block:
     - name: "Reboot VM to detect NVMe device changes on {{ vm_guest_os_distribution }}"
       when: new_disk_ctrl_type == 'nvme'


### PR DESCRIPTION
GOSV-6341:
FreeBSD 15.1 RC2 failed to recognize the new disk hot added to existing nvme controller

This issue will be fixed in FreeBSD 15.2