### PR TITLE
Fix autoinstall issue for opensuse-16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | AlmaLinux 8.x, 9.x, 10.x                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | SUSE Linux Enterprise Desktop 15 SP3 and later         | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | SUSE Linux Enterprise Server 15 SP3 and later          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| SUSE Linux Enterprise Server 16.0                      | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| SUSE Linux Enterprise Server 16.0 and later            | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | VMware Photon OS 4.0, 5.0                              | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Ubuntu 20.04 and later                                 | :heavy_check_mark:               | :heavy_check_mark:       | :heavy_check_mark:                 |
 | Flatcar 2592.0.0 and later                             |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
@@ -86,7 +86,7 @@ This project supports below scenarios for end-to-end guest operating system vali
 | ProLinux Server 7.9, 8.5                               | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | FreeBSD 13 and later                                   | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Pardus 21.2 and later, 23.x, 25.0 Server/XFCE          | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
-| openSUSE Leap 15.3 and later, 16.0                     | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
+| openSUSE Leap 15.3 and later, 16.0 and later           | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Red Hat Enterprise Linux CoreOS (RHCOS) 4.13 and later |                                  | :heavy_check_mark:       | :heavy_check_mark:                 |
 | FusionOS 22, 23                                        | :heavy_check_mark:               |                          | :heavy_check_mark:                 |
 | Miracle Linux 8.x, 9.x                                 | :heavy_check_mark:               |                          | :heavy_check_mark:                 |

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -26,6 +26,7 @@
 - For Pardus 23.x Server and XFCE Desktop unattend auto-install, please use file Pardus/preseed.cfg.
 - For openSUSE Leap 15.3 or later unattend auto-install, please use file openSUSE/15/autoinst.xml.
 - For openSUSE Leap 16.0 unattend auto-install, please use file openSUSE/16.0/autoinst.jsonnet.
+- For openSUSE Leap 16.1 unattend auto-install, please use file openSUSE/16.1/autoinst.jsonnet.
 - For BCLinux 8.x unattend auto-install, please use file BCLinux/8/ks.cfg.
 - For BCLinux-for-Euler 21.10 unattend auto-install, please use file BCLinux-for-Euler/21.10/ks.cfg.
 - For FusionOS 22 unattend auto-install, please use files under Fusion.

--- a/autoinstall/openSUSE/16.1/autoinst.jsonnet
+++ b/autoinstall/openSUSE/16.1/autoinst.jsonnet
@@ -1,0 +1,126 @@
+// This is a Jsonnet file referring to
+// https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/examples/profile.jsonnet.
+// Please, check https://jsonnet.org/ for more information about the language.
+// For the schema, see
+// https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/profile.schema.json
+
+// The "hw.libsonnet" file contains hardware information from the "lshw" tool.
+// Agama generates this file at runtime by running (with root privileges):
+//
+//   lshw -json
+//
+// There are included also helpers to search this hardware tree. To see helpers check
+// "/usr/share/agama-cli/agama.libsonnet"
+local agama = import 'hw.libsonnet';
+
+// Find the biggest disk which is suitable for installing the system.
+local findBiggestDisk(disks) =
+  local sizedDisks = std.filter(function(d) std.objectHas(d, 'size'), disks);
+  local sorted = std.sort(sizedDisks, function(x) -x.size);
+  sorted[0].logicalname;
+
+// Find the network interface name
+local nicName = agama.findByID(agama.lshw, 'network').logicalname;
+
+{
+  product: {
+    id: "openSUSE_Leap"
+  },
+  software: {
+    patterns: {
+      add: ["gnome"]
+    }
+  },
+{% if new_user is defined and new_user %}
+  user: {
+    fullName: "{{ new_user }}",
+    password: "{{ vm_password }}",
+    userName: "{{ new_user }}"
+  },
+{% endif %}
+  root: {
+    password: "{{ vm_password }}",
+    sshPublicKey: "{{ ssh_public_key }}"
+  },
+  localization: {
+    language: "en_US",
+    keyboard: "us",
+    timezone: "America/New_York"
+  },
+  storage: {
+    boot: {
+      configure: true
+    },
+    drives: [
+      {
+        search: findBiggestDisk(agama.selectByClass(agama.lshw, 'disk')),
+        partitions: [
+          { 
+           generate: "default"
+          }
+       ]
+     }
+    ]
+  },
+  network: {
+    connections: [
+      {
+        id: nicName,
+        interface: nicName,
+        method4: "auto",
+        method6: "disabled",
+        ignoreAutoDns: false,
+        status: "up",
+        autoconnect: true
+      }
+    ]
+  },
+  scripts: {
+    pre: [
+      {
+        name: "pre_install_script",
+        content: |||
+          #!/bin/bash
+          echo "Execute pre-install script" >/dev/ttyS0
+          echo "{{ autoinstall_start_msg }}" >/dev/ttyS0
+
+          echo "Installer environment variables:" >/dev/ttyS0
+          env | sort >/dev/ttyS0
+
+          echo "Installer filesystems:" >/dev/ttyS0
+          mount >/dev/ttyS0
+
+          ip_addr=$(ip -br -f inet addr show | grep -v 127.0.0.1 | awk '{print $3}')
+          echo "{{ autoinstall_ipv4_msg }}$ip_addr" >/dev/ttyS0
+
+          echo "Boot command:" >/dev/ttyS0
+          cat /proc/cmdline >/dev/ttyS0
+        |||
+      }
+    ],
+     post: [
+      {
+        name: 'post_install_script',
+        content: |||
+          #!/bin/bash
+          echo "Execute post-install script" >/dev/ttyS0
+          echo "Config SSHd to permit root login" >/dev/ttyS0
+          echo "PermitRootLogin yes" >/etc/ssh/sshd_config.d/10_root_login.conf
+          echo "{{ autoinstall_complete_msg }}" >/dev/ttyS0
+        |||
+      }
+    ],
+    init: [
+      {
+        name: "init_script",
+        content: |||
+          #!/bin/bash
+          echo "Archive Agama installation logs" >/dev/ttyS0
+          cd /var/log
+          tar -czvf agama-installation.tar.gz agama-installation >/dev/ttyS0
+          echo "Agama installation logs can be found in /var/log/agama-installation.tar.gz" >/dev/ttyS0
+        |||
+      }
+    ]
+  }
+}

--- a/linux/utils/add_official_online_repo.yml
+++ b/linux/utils/add_official_online_repo.yml
@@ -133,7 +133,7 @@
       - name: "{{ guest_os_ansible_distribution }}_{{ guest_os_ansible_distribution_ver }}_OSS"
         baseurl: >-
           {{ 'https://download.opensuse.org/distribution/leap/$releasever/repo/oss/' 
-             if (guest_os_ansible_distribution_ver is version('16.0', '==')) 
+             if (guest_os_ansible_distribution_ver is version('16.0', '>=')) 
              else 'http://download.opensuse.org/distribution/leap/$releasever/repo/oss' }}
   when: guest_os_ansible_distribution == "openSUSE Leap"
 

--- a/linux/utils/enable_disable_repos.yml
+++ b/linux/utils/enable_disable_repos.yml
@@ -49,7 +49,7 @@
   when:
     - repo_state == "enabled"
     - guest_os_ansible_distribution is search('openSUSE')
-    - guest_os_ansible_distribution_ver is version('16.0','==')
+    - guest_os_ansible_distribution_ver is version('16.0','>=')
     - existing_repos | length > 0
   block:
     - name: "Find openSUSE repo files on target VM"


### PR DESCRIPTION
Added autoinstall/openSUSE/16.1/autoinst.jsonnet due to UI change and updated online repo for opensuse-16.1.

Testing Done: yes. Autoinstall passed in both efi and bios modes with different configurations.
```
VM information:
+----------------------------------------------------------------------+
| Guest OS Distribution     | openSUSE Leap 16.1 x86_64                |
+----------------------------------------------------------------------+
| GUI Installed             | True (GDM wayland)                       |
+----------------------------------------------------------------------+
| Firmware                  | EFI                                      |
+----------------------------------------------------------------------+
| Hardware Version          | vmx-19                                   |
+----------------------------------------------------------------------+
| VMTools Version           | 13.1.0 (build-25218885)                  |
+----------------------------------------------------------------------+
| Config Guest Id           | opensuse64Guest                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Id        | opensuse64Guest                          |
+----------------------------------------------------------------------+
| GuestInfo Guest Full Name | SUSE openSUSE (64-bit)                   |
+----------------------------------------------------------------------+
| GuestInfo Guest Family    | linuxGuest                               |
+----------------------------------------------------------------------+
| GuestInfo Detailed Data   | architecture='X86'                       |
|                           | bitness='64'                             |
|                           | cpeString='cpe:/o:opensuse:leap:16.1'    |
|                           | distroAddlVersion='16.1'                 |
|                           | distroName='openSUSE Leap'               |
|                           | distroVersion='16.1'                     |
|                           | familyName='Linux'                       |
|                           | kernelVersion='6.12.0-160099.43-default' |
|                           | prettyName='openSUSE Leap 16.1'          |
+----------------------------------------------------------------------+

Test Results (Total: 33, Passed: 27, Skipped: 6, Elapsed Time: 03:17:42)
+-------------------------------------------------------------------------+
| ID | Name                                 |   Status        | Exec Time |
+-------------------------------------------------------------------------+
| 01 | deploy_vm_efi_nvme_e1000e            |   Passed        | 00:14:36  |
| 02 | check_inbox_driver                   |   Passed        | 00:04:44  |
| 03 | ovt_verify_pkg_install               |   Passed        | 00:10:22  |
| 04 | ovt_verify_status                    |   Passed        | 00:04:13  |
| 05 | vgauth_check_service                 |   Passed        | 00:01:53  |
| 06 | host_verify_saml_token               |   Passed        | 00:03:33  |
| 07 | check_ip_address                     |   Passed        | 00:01:07  |
| 08 | check_os_fullname                    |   Passed        | 00:10:39  |
| 09 | stat_balloon                         |   Passed        | 00:00:58  |
| 10 | stat_hosttime                        |   Passed        | 00:01:01  |
| 11 | device_list                          |   Passed        | 00:03:15  |
| 12 | power_operation_scripts              |   Passed        | 00:17:17  |
| 13 | check_quiesce_snapshot_custom_script |   Passed        | 00:01:34  |
| 14 | memory_hot_add_basic                 |   Passed        | 00:06:22  |
| 15 | cpu_hot_add_basic                    |   Passed        | 00:05:54  |
| 16 | cpu_multicores_per_socket            |   Passed        | 00:08:56  |
| 17 | check_efi_firmware                   |   Passed        | 00:01:01  |
| 18 | secureboot_enable_disable            |   Passed        | 00:05:04  |
| 19 | pvrdma_network_device_ops            | * Not Supported | 00:01:03  |
| 20 | e1000e_network_device_ops            |   Passed        | 00:08:00  |
| 21 | vmxnet3_network_device_ops           |   Passed        | 00:07:10  |
| 22 | gosc_perl_dhcp                       | * Not Supported | 00:01:13  |
| 23 | gosc_perl_staticip                   | * Not Supported | 00:01:06  |
| 24 | gosc_cloudinit_dhcp                  | * Not Supported | 00:01:10  |
| 25 | gosc_cloudinit_staticip              | * Not Supported | 00:01:10  |
| 26 | paravirtual_vhba_device_ops          |   Passed        | 00:08:01  |
| 27 | lsilogic_vhba_device_ops             |   Passed        | 00:16:37  |
| 28 | lsilogicsas_vhba_device_ops          |   Passed        | 00:08:23  |
| 29 | sata_vhba_device_ops                 |   Passed        | 00:08:34  |
| 30 | nvme_vhba_device_ops                 |   Passed        | 00:08:15  |
| 31 | nvdimm_cold_add_remove               | * Not Supported | 00:01:00  |
| 32 | ovt_verify_pkg_uninstall             |   Passed        | 00:05:47  |
| 33 | vtpm_cold_add_remove                 |   Passed        | 00:16:22  |
+-------------------------------------------------------------------------+
```