### PR TITLE
Fix "check_inbox_driver" failed in SLES16.1 on ARM server

### DIFF
--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -215,7 +215,7 @@
           ((guest_os_ansible_distribution_major_ver == '10' and guest_os_ansible_distribution_ver is version('10.1', '<=')) or
           (guest_os_ansible_distribution_major_ver == '9' and guest_os_ansible_distribution_ver is version('9.7', '<=')))) or
          (guest_os_ansible_distribution == 'SLES' and
-          guest_os_ansible_distribution_ver is version('16.0', '<=')) or
+          guest_os_ansible_distribution_ver is version('16.1', '<=')) or
          (guest_os_ansible_distribution == 'Ubuntu' and
           guest_os_ansible_distribution_ver is version('26.04', '<='))
         )


### PR DESCRIPTION
Fix check_inbox_driver issue in SLES 16.1 on ARM server.

Testing Done: yes

