### PR TITLE
Update get_inbox_drivers.yml to ignore inbox drivers missing in RHEL …

### DIFF
--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -212,8 +212,8 @@
         (missing_mandatory_drivers | difference(['vmw_pvscsi', 'vmw_balloon']) | length == 0) and
         (
          (guest_os_ansible_distribution == 'RedHat' and
-          ((guest_os_ansible_distribution_major_ver == '10' and guest_os_ansible_distribution_ver is version('10.1', '<=')) or
-          (guest_os_ansible_distribution_major_ver == '9' and guest_os_ansible_distribution_ver is version('9.7', '<=')))) or
+          ((guest_os_ansible_distribution_major_ver == '10' and guest_os_ansible_distribution_ver is version('10.2', '<=')) or
+          (guest_os_ansible_distribution_major_ver == '9' and guest_os_ansible_distribution_ver is version('9.8', '<=')))) or
          (guest_os_ansible_distribution == 'SLES' and
           guest_os_ansible_distribution_ver is version('16.1', '<=')) or
          (guest_os_ansible_distribution == 'Ubuntu' and


### PR DESCRIPTION
Update get_inbox_drivers.yml to ignore inbox drivers missing in RHEL 10.2&9.8