### PR TITLE
Add "python" to the package list installed in FreeBSD in freebsd_post_config.sh

### DIFF
--- a/linux/deploy_vm/templates/post_install_scripts/freebsd_post_config.sh
+++ b/linux/deploy_vm/templates/post_install_scripts/freebsd_post_config.sh
@@ -67,7 +67,7 @@ env ASSUME_ALWAYS_YES=YES pkg bootstrap -y
 
 # Different packages between the 32bit image and 64bit image
 # The open-vm-tools is not installed by default
-packages_to_install="bash sudo wget curl e2fsprogs iozone lsblk open-vm-tools-nox11"
+packages_to_install="bash sudo wget curl e2fsprogs iozone lsblk python open-vm-tools-nox11"
 
 # Try to install package from CDROM repo. There is no default CDROM repo file FreeBSD_install_cdrom.conf on FreeBSD 15 or obove.
 failed_packages="$packages_to_install"


### PR DESCRIPTION
There is no links created when Python 3.12 is installed as the dependency of package "open-vm-tools-nox11", which causing installed Python is not auto discovered, so add python package in the list to be installed separately.