### PR TITLE
Update get_inbox_drivers.yml to ignore missing pvscsi & balloon in RHEL

### DIFF
--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -212,8 +212,8 @@
         (missing_mandatory_drivers | difference(['vmw_pvscsi', 'vmw_balloon']) | length == 0) and
         (
          (guest_os_ansible_distribution == 'RedHat' and
-          ((guest_os_ansible_distribution_major_ver == '10' and guest_os_ansible_distribution_ver is version('10.2', '<=')) or
-          (guest_os_ansible_distribution_major_ver == '9' and guest_os_ansible_distribution_ver is version('9.8', '<=')))) or
+          ((guest_os_ansible_distribution_major_ver == '10' and guest_os_ansible_distribution_ver is version('10.3', '<=')) or
+          (guest_os_ansible_distribution_major_ver == '9'))) or
          (guest_os_ansible_distribution == 'SLES' and
           guest_os_ansible_distribution_ver is version('16.1', '<=')) or
          (guest_os_ansible_distribution == 'Ubuntu' and


### PR DESCRIPTION
RHEL 9.x & 10.3&earlier