### PR TITLE
Add printing failed task call trace to failed_tasks.log in log plugin

### DIFF
--- a/env_setup/check_testing_vars.yml
+++ b/env_setup/check_testing_vars.yml
@@ -29,6 +29,10 @@
     - not new_vm
     - gosv_test_suite == "linux"
 
+- name: "Test code"
+  ansible.builtin.fail:
+    msg: "Test code failed"
+
 - name: "Check variables when testing on new VM"
   when: new_vm
   block:

--- a/env_setup/check_testing_vars.yml
+++ b/env_setup/check_testing_vars.yml
@@ -29,10 +29,6 @@
     - not new_vm
     - gosv_test_suite == "linux"
 
-- name: "Test code"
-  ansible.builtin.fail:
-    msg: "Test code failed"
-
 - name: "Check variables when testing on new VM"
   when: new_vm
   block:

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -537,10 +537,17 @@ class CallbackModule(CallbackBase):
         """
         trace = []
         current = task
+        base_dir = os.path.dirname(self.cwd)
+        if not base_dir.endswith(os.path.sep):
+            base_dir += os.path.sep
+
         while current is not None:
             if hasattr(current, 'get_path'):
                 path = current.get_path()
                 if path:
+                    if path.startswith(base_dir):
+                        path = path[len(base_dir):]
+
                     file_path = re.sub(r':\d+$', '', path)
                     if not trace:
                         trace.append(path)

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -537,7 +537,7 @@ class CallbackModule(CallbackBase):
         """
         trace = []
         current = task
-        base_dir = os.path.dirname(self.cwd)
+        base_dir = self.cwd
         if not base_dir.endswith(os.path.sep):
             base_dir += os.path.sep
 
@@ -549,16 +549,30 @@ class CallbackModule(CallbackBase):
                         path = path[len(base_dir):]
 
                     file_path = re.sub(r':\d+$', '', path)
+                    
+                    name = getattr(current, 'get_name', lambda: '')()
+                    action = getattr(current, 'action', '')
+                    
+                    details = []
+                    if name:
+                        details.append("name: {}".format(name))
+                    if action:
+                        details.append("module: {}".format(action))
+                    
+                    formatted_path = path
+                    if details:
+                        formatted_path += " ({})".format(", ".join(details))
+
                     if not trace:
-                        trace.append(path)
+                        trace.append((formatted_path, file_path))
                     else:
-                        prev_file_path = re.sub(r':\d+$', '', trace[-1])
+                        prev_file_path = trace[-1][1]
                         if file_path != prev_file_path:
-                            trace.append(path)
+                            trace.append((formatted_path, file_path))
             current = getattr(current, '_parent', None)
 
         trace.reverse()
-        return trace
+        return [t[0] for t in trace]
 
     def _print_task_details(self, result,
                             task_status=None,

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -540,8 +540,14 @@ class CallbackModule(CallbackBase):
         while current is not None:
             if hasattr(current, 'get_path'):
                 path = current.get_path()
-                if path and (not trace or trace[-1] != path):
-                    trace.append(path)
+                if path:
+                    file_path = re.sub(r':\d+$', '', path)
+                    if not trace:
+                        trace.append(path)
+                    else:
+                        prev_file_path = re.sub(r':\d+$', '', trace[-1])
+                        if file_path != prev_file_path:
+                            trace.append(path)
             current = getattr(current, '_parent', None)
 
         trace.reverse()

--- a/plugin/ansible_vsphere_gosv_log.py
+++ b/plugin/ansible_vsphere_gosv_log.py
@@ -531,6 +531,22 @@ class CallbackModule(CallbackBase):
 
         return formatted_msg
 
+    def _get_task_call_trace(self, task):
+        """
+        Get the call trace of a task by traversing its parent blocks
+        """
+        trace = []
+        current = task
+        while current is not None:
+            if hasattr(current, 'get_path'):
+                path = current.get_path()
+                if path and (not trace or trace[-1] != path):
+                    trace.append(path)
+            current = getattr(current, '_parent', None)
+
+        trace.reverse()
+        return trace
+
     def _print_task_details(self, result,
                             task_status=None,
                             delegated_vars=None,
@@ -649,6 +665,12 @@ class CallbackModule(CallbackBase):
             result_in_json = json.loads(self._dump_results(result._result, indent=4))
             error_msg = extract_error_msg(result_in_json)
             task_details += "\nerror message:\n" + error_msg
+
+            call_trace = self._get_task_call_trace(task)
+            if call_trace and len(call_trace) > 1:
+                task_details += "call trace:\n"
+                for trace_path in call_trace:
+                    task_details += "  - {}\n".format(trace_path)
 
             self.add_logger_file_handler(self.failed_tasks_log)
 


### PR DESCRIPTION
The 1st version of call trace printed is as below:
```
call trace:
  - linux/check_inbox_driver/check_inbox_driver.yml:15 (name: Test setup, module: include_tasks)
  - linux/setup/test_setup.yml:55 (name: Get VM guest IP, module: include_tasks)
  - common/update_inventory.yml:18 (name: Wait for VM connectable, module: include_tasks)
  - common/vm_wait_connection.yml:26 (name: include_tasks, module: include_tasks)
  - common/vm_wait_ssh.yml:19 (name: Wait for port 22 to become open or contain specific keyword, module: ansible.builtin.wait_for)
```