### PR TITLE
Move check snapshot existence status in "vm_revert_snapshot.yml"

### DIFF
--- a/common/base_snapshot_check_revert.yml
+++ b/common/base_snapshot_check_revert.yml
@@ -9,15 +9,13 @@
       include_tasks: vm_check_snapshot_exist.yml
       vars:
         snapshot_name: "{{ base_snapshot_name }}"
-      when: not new_vm
 
     - name: "Set fact of base snapshot existence"
       ansible.builtin.set_fact:
-        base_snapshot_exists: "{{ snapshot_exist | default(false) }}"
+        base_snapshot_exists: "{{ snapshot_exist }}"
 
 - name: "Revert to snapshot {{ base_snapshot_name }}"
   include_tasks: vm_revert_snapshot.yml
   vars:
     snapshot_name: "{{ base_snapshot_name }}"
-  when:
-    - base_snapshot_exists | bool
+  when: base_snapshot_exists

--- a/common/vm_check_snapshot_exist.yml
+++ b/common/vm_check_snapshot_exist.yml
@@ -7,13 +7,14 @@
 # Return:
 #   snapshot_exist: the flag of snapshot exist
 #
-- include_tasks: vm_get_snapshot_facts.yml
-
-- name: Initialize snapshot existence result
+- name: "Initialize snapshot existence result"
   ansible.builtin.set_fact:
     snapshot_exist: false
 
-- name: Loop snapshot list to find specified snapshot
+- name: "Get VM snapshot info"
+  include_tasks: vm_get_snapshot_facts.yml
+
+- name: "Loop snapshot list to find specified snapshot"
   ansible.builtin.set_fact:
     snapshot_exist: "{{ vm_snapshot_facts.guest_snapshots.snapshots | selectattr('name', 'equalto', snapshot_name) | length == 1 }}"
   when:
@@ -21,6 +22,6 @@
     - vm_snapshot_facts.guest_snapshots is defined
     - vm_snapshot_facts.guest_snapshots.snapshots is defined
 
-- name: "Snapshot {{ snapshot_name }} exist: {{ snapshot_exist }}"
+- name: "Display snapshot existence status"
   ansible.builtin.debug:
-    msg: "Snapshot '{{ snapshot_name }}' exist: {{ snapshot_exist }}"
+    msg: "Snapshot '{{ snapshot_name }}' exists: {{ snapshot_exist }}"

--- a/common/vm_revert_snapshot.yml
+++ b/common/vm_revert_snapshot.yml
@@ -1,17 +1,11 @@
 # Copyright 2021-2026 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-# Revert to snapshot of VM
+# Revert to the specified snapshot of VM. Please get VM snapshots info
+# and check if specified snapshot exists firstly before using this task file.
 # Parameters:
-#   snapshot_name: the name of snapshot to revert
-#   skip_if_not_exist: if set to true, revert snapshot task will not fail when snapshot doesn't exist.
-#   Default value is false.
+#   snapshot_name: the name of snapshot to revert.
 #
-- name: "Set fact of skipping not existing snapshot to false"
-  ansible.builtin.set_fact:
-    skip_if_not_exist: false
-  when: skip_if_not_exist is undefined
-
 - name: "Check snapshot name is not empty"
   ansible.builtin.assert:
     that:
@@ -19,46 +13,23 @@
       - snapshot_name | length > 0
     fail_msg: "The parameter 'snapshot_name' is not defined or is empty."
 
-- name: "Check if snapshot {{ snapshot_name }} exists"
-  include_tasks: vm_check_snapshot_exist.yml
+- name: "Revert to snapshot {{ snapshot_name }}"
+  vmware.vmware.vm_snapshot_revert:
+    hostname: "{{ vsphere_host_name }}"
+    username: "{{ vsphere_host_user }}"
+    password: "{{ vsphere_host_user_password }}"
+    validate_certs: "{{ validate_certs | default(false) }}"
+    datacenter: "{{ vsphere_host_datacenter }}"
+    folder: "{{ vm_folder }}"
+    name: "{{ vm_name }}"
+    snapshot_name: "{{ snapshot_name }}"
+  register: revert_result
 
-- name: "Ensure snapshot exists when skip_if_not_exist is set to false"
-  ansible.builtin.assert:
-    that:
-      - snapshot_exist
-    fail_msg: "The snapshot '{{ snapshot_name }}' does not exist on VM '{{ vm_name }}'."
-  when: not (skip_if_not_exist | bool)
+- name: "Display revert snapshot result"
+  ansible.builtin.debug: var=revert_result
+  when: enable_debug
 
-- name: "Skip reverting snapshot when it does not exist"
-  ansible.builtin.debug:
-    msg: "Snapshot '{{ snapshot_name }}' does not exist on VM '{{ vm_name }}'. Skipping revert task as 'skip_if_not_exist' is true."
-  when:
-    - not snapshot_exist
-    - skip_if_not_exist | bool
-
-- name: "Revert to the existing snapshot {{ snapshot_name }}"
-  when: snapshot_exist
-  block:
-    - name: "Revert to snapshot {{ snapshot_name }}"
-      vmware.vmware.vm_snapshot_revert:
-        hostname: "{{ vsphere_host_name }}"
-        username: "{{ vsphere_host_user }}"
-        password: "{{ vsphere_host_user_password }}"
-        validate_certs: "{{ validate_certs | default(false) }}"
-        datacenter: "{{ vsphere_host_datacenter }}"
-        folder: "{{ vm_folder }}"
-        name: "{{ vm_name }}"
-        snapshot_name: "{{ snapshot_name }}"
-      register: revert_result
-
-    - name: "Display revert snapshot result"
-      ansible.builtin.debug: var=revert_result
-      when: enable_debug
-
-    - name: "Wait for VM current snapshot is the expected one after revert to snapshot"
-      include_tasks: vm_wait_expected_snapshot.yml
-      vars:
-        expected_snapshot_name: "{{ snapshot_name }}"
-      when:
-        - revert_result.changed is defined
-        - revert_result.changed
+- name: "Wait for VM current snapshot is as expected after reverting"
+  include_tasks: vm_wait_expected_snapshot.yml
+  vars:
+    expected_snapshot_name: "{{ snapshot_name }}"

--- a/common/vm_take_snapshot.yml
+++ b/common/vm_take_snapshot.yml
@@ -18,9 +18,9 @@
   ignore_errors: "{{ vm_take_snapshot_ignore_err | default(false) }}"
   register: vm_take_snapshot_result
 
-- name: Display the result of taking snapshot
+- name: "Display the result of taking snapshot"
   ansible.builtin.debug: var=vm_take_snapshot_result
-  when: enable_debug is defined and enable_debug
+  when: enable_debug
 
 - name: "Check if snapshot is created successfully"
   when:

--- a/env_setup/env_cleanup.yml
+++ b/env_setup/env_cleanup.yml
@@ -15,15 +15,18 @@
     # Revert to VM base snapshot firstly, or the network testbed cleanup tasks may fail.
     # Parameter 'vm_not_revert_base' is used internally, and please be aware that if it's
     # set to true, the following tasks may be affected.
+    - name: "Check whether base snapshot exists or not"
+      include_tasks: ../common/vm_check_snapshot_exist.yml
+      vars:
+        snapshot_name: "{{ base_snapshot_name }}"
+
     - name: "Revert to snapshot {{ base_snapshot_name }}"
       include_tasks: ../common/vm_revert_snapshot.yml
       vars:
         snapshot_name: "{{ base_snapshot_name }}"
-        skip_if_not_exist: true
       when:
         - not vm_not_revert_base | default(false)
-        - base_snapshot_exists is defined
-        - base_snapshot_exists | bool
+        - snapshot_exist
 
     - name: "Cleanup network environment"
       include_tasks: ../common/network_testbed_cleanup.yml

--- a/linux/deploy_vm/deploy_vm_from_ova.yml
+++ b/linux/deploy_vm/deploy_vm_from_ova.yml
@@ -26,6 +26,7 @@
       ansible.builtin.set_fact:
         vm_ova_path: "{{ nfs_mount_dir }}/{{ ova_path }}"
         vm_ova_name: "{{ ova_path | basename }}"
+
 # Check OVA file exists
 - name: "Check for {{ vm_ova_path }} existence"
   ansible.builtin.stat:

--- a/linux/setup/create_base_snapshot.yml
+++ b/linux/setup/create_base_snapshot.yml
@@ -7,6 +7,16 @@
 - name: "Do configurations on VM prior to testing"
   include_tasks: reconfig_existing_vm.yml
 
+- name: "Get VM info before creating base snapshot"
+  when: vm_info_retrieved is undefined or not vm_info_retrieved
+  block:
+    - name: "Get VM info at base snapshot"
+      include_tasks: ../../common/vm_get_vm_info.yml
+
+    - name: "Set fact that VM info at base snapshot retrieved"
+      ansible.builtin.set_fact:
+        vm_info_retrieved: true
+
 - name: "Take a baseline snapshot on VM for testing"
   include_tasks: ../../common/vm_take_snapshot.yml
   vars:

--- a/linux/setup/test_setup.yml
+++ b/linux/setup/test_setup.yml
@@ -17,8 +17,7 @@
 
 - name: "Get VM info after reverting to base snapshot"
   when:
-    - not new_vm
-    - base_snapshot_exists | bool
+    - base_snapshot_exists
     - vm_info_retrieved is undefined or not vm_info_retrieved
   block:
     - name: "Get VM info at base snapshot"
@@ -77,7 +76,7 @@
 
 - name: "Take a base snapshot if it does not exist"
   include_tasks: create_base_snapshot.yml
-  when: not (base_snapshot_exists | bool)
+  when: not base_snapshot_exists
 
 - name: "Get VMware Tools version and build"
   include_tasks: ../utils/get_guest_ovt_version_build.yml

--- a/windows/setup/create_base_snapshot.yml
+++ b/windows/setup/create_base_snapshot.yml
@@ -1,11 +1,24 @@
 # Copyright 2021-2026 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 ---
-- include_tasks: win_guest_reconfig.yml
+- name: "In guest configure before taking base snapshot"
+  include_tasks: win_guest_reconfig.yml
 
-- include_tasks: ../../common/vm_take_snapshot.yml
+- name: "Get VM info before taking base snapshot"
+  when: vm_info_retrieved is undefined or not vm_info_retrieved
+  block:
+    - name: "Get VM info at base snapshot"
+      include_tasks: ../../common/vm_get_vm_info.yml
+
+    - name: "Set fact that VM info at base snapshot retrieved"
+      ansible.builtin.set_fact:
+        vm_info_retrieved: true
+
+- name: "Take base snapshot"
+  include_tasks: ../../common/vm_take_snapshot.yml
   vars:
     snapshot_name: "{{ base_snapshot_name }}"
-- name: Set fact of base snapshot existence
+
+- name: "Set fact of base snapshot exists"
   ansible.builtin.set_fact:
     base_snapshot_exists: true

--- a/windows/setup/test_setup.yml
+++ b/windows/setup/test_setup.yml
@@ -19,8 +19,7 @@
 
 - name: "Get VM info after reverting to base snapshot"
   when:
-    - not new_vm
-    - base_snapshot_exists | bool
+    - base_snapshot_exists
     - vm_info_retrieved is undefined or not vm_info_retrieved
   block:
     - name: "Get VM info at base snapshot"


### PR DESCRIPTION
"vm_revert_snapshot.yml" is only used to revert to specified snapshot on VM, not containing snapshot existence status get and check, and remove "skip_if_not_exist" parameter. Please use get and check snapshot info task files for this purpose before calling this task file.