### PR TITLE
Fault-tolerant for Ubuntu 26.04.x check_inbox_driver on ARM ESXi

### DIFF
--- a/linux/check_inbox_driver/get_inbox_drivers.yml
+++ b/linux/check_inbox_driver/get_inbox_drivers.yml
@@ -217,7 +217,7 @@
          (guest_os_ansible_distribution == 'SLES' and
           guest_os_ansible_distribution_ver is version('16.1', '<=')) or
          (guest_os_ansible_distribution == 'Ubuntu' and
-          guest_os_ansible_distribution_ver is version('26.04', '<='))
+          guest_os_ansible_distribution_ver is version('27.04', '<='))
         )
       }}
 


### PR DESCRIPTION
Fault-tolerant for Ubuntu 26.04.x check_inbox_driver on ARM ESXi