### PR TITLE
Failed to rebuild autoinstall ISO for freebsd 14.x and 15.x with error: Failed adding duplicate name to parent

### DIFF
--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -26,8 +26,9 @@
       try:
           import pycdlib.dr
           _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
-          def _patched_add_child(self, child, logical_block_size, allow_duplicate=True, is_rr=False):
-              return _orig_add_child(self, child, logical_block_size, allow_duplicate=True, is_rr=is_rr)
+          def _patched_add_child(self, child, logical_block_size, allow_duplicate=False, *args, **kwargs):
+              kwargs.pop('allow_duplicate', None)
+              return _orig_add_child(self, child, logical_block_size, True, *args, **kwargs)
           pycdlib.dr.DirectoryRecord._add_child = _patched_add_child
       except Exception:
           pass

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -8,19 +8,29 @@
 #   src_iso_dir_path: Local path to the directory containing the source ISO image file.
 #
 
-- name: "Patch pycdlib for FreeBSD ISO duplicate name issue"
-  ansible.builtin.shell:
-    cmd: >-
-      {{ ansible_playbook_python }} -c "
-      import pycdlib.dr;
-      p = pycdlib.dr.__file__;
-      s = open(p).read();
-      s = s.replace('raise pycdlibexception.PyCdlibInvalidInput(\'Failed adding duplicate name to parent\')', 'pass');
-      s = s.replace('if not allow_duplicate:', 'if False:');
-      open(p, 'w').write(s)
-      "
-  changed_when: false
-  ignore_errors: true
+- name: "Set fact of pycdlib patch directory"
+  ansible.builtin.set_fact:
+    pycdlib_patch_dir: "{{ src_iso_dir_path }}/pycdlib_patch"
+
+- name: "Create directory for pycdlib patch"
+  ansible.builtin.file:
+    path: "{{ pycdlib_patch_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: "Create sitecustomize.py to patch pycdlib for FreeBSD ISO duplicate name issue"
+  ansible.builtin.copy:
+    dest: "{{ pycdlib_patch_dir }}/sitecustomize.py"
+    mode: '0644'
+    content: |
+      try:
+          import pycdlib.dr
+          _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
+          def _patched_add_child(self, child, logical_block_size, allow_duplicate=True, is_rr=False):
+              return _orig_add_child(self, child, logical_block_size, allow_duplicate=True, is_rr=is_rr)
+          pycdlib.dr.DirectoryRecord._add_child = _patched_add_child
+      except Exception:
+          pass
 
 - name: "Set fact of files to be updated in FreeBSD unattended install ISO"
   ansible.builtin.set_fact:
@@ -42,6 +52,8 @@
         dest: "{{ src_iso_dir_path }}"
         files:
           - "{{ dest_boot_loader_conf[1:] }}"
+      environment:
+        PYTHONPATH: "{{ pycdlib_patch_dir }}:{{ lookup('env', 'PYTHONPATH') }}"
 
     - name: "Add kern.kstack_pages option in FreeBSD boot loader"
       ansible.builtin.lineinfile:
@@ -64,3 +76,5 @@
     src_iso: "{{ src_iso_file_path }}"
     dest_iso: "{{ rebuilt_unattend_iso_path }}"
     add_files: "{{ freebsd_iso_files }}"
+  environment:
+    PYTHONPATH: "{{ pycdlib_patch_dir }}:{{ lookup('env', 'PYTHONPATH') }}"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -20,9 +20,9 @@
         state: directory
         mode: '0755'
 
-    - name: "Extract FreeBSD ISO using bsdtar"
+    - name: "Extract FreeBSD ISO using xorriso"
       ansible.builtin.command: >-
-        bsdtar -xf "{{ src_iso_file_path }}" -C "{{ extracted_freebsd_iso_dir }}"
+        xorriso -osirrox on -indev "{{ src_iso_file_path }}" -extract / "{{ extracted_freebsd_iso_dir }}"
       changed_when: true
 
     - name: "Ensure extracted files and directories are writable"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -8,15 +8,38 @@
 #   src_iso_dir_path: Local path to the directory containing the source ISO image file.
 #
 
-- name: "Set fact of pycdlib patch directory"
+# Extract FreeBSD version from source ISO file name
+- name: "Set fact of FreeBSD ISO version"
+  ansible.builtin.set_fact:
+    freebsd_iso_version: "{{ (src_iso_file_path | basename | regex_search('(\\d+\\.\\d+)', '\\1'))[0] | default('0.0') }}"
+
+# Determine if pycdlib patch is required:
+# - FreeBSD 14.x: < 14.6
+# - FreeBSD 15.x: < 15.2
+- name: "Set fact whether pycdlib patch is required for FreeBSD ISO"
+  ansible.builtin.set_fact:
+    need_pycdlib_patch: >-
+      {{
+        (freebsd_iso_version is version('14.0', '>=') and freebsd_iso_version is version('14.6', '<')) or
+        (freebsd_iso_version is version('15.0', '>=') and freebsd_iso_version is version('15.2', '<'))
+      }}
+
+- name: "Set fact of pycdlib patch directory and environment"
   ansible.builtin.set_fact:
     pycdlib_patch_dir: "{{ src_iso_dir_path }}/pycdlib_patch"
+    pycdlib_patch_env: >-
+      {{
+        {'PYTHONPATH': (src_iso_dir_path + '/pycdlib_patch:' + lookup('env', 'PYTHONPATH'))}
+        if need_pycdlib_patch
+        else {}
+      }}
 
 - name: "Create directory for pycdlib patch"
   ansible.builtin.file:
     path: "{{ pycdlib_patch_dir }}"
     state: directory
     mode: '0755'
+  when: need_pycdlib_patch
 
 - name: "Create sitecustomize.py to patch pycdlib for FreeBSD ISO duplicate name issue"
   ansible.builtin.copy:
@@ -32,6 +55,7 @@
           pycdlib.dr.DirectoryRecord._add_child = _patched_add_child
       except Exception:
           pass
+  when: need_pycdlib_patch
 
 - name: "Set fact of files to be updated in FreeBSD unattended install ISO"
   ansible.builtin.set_fact:
@@ -53,8 +77,7 @@
         dest: "{{ src_iso_dir_path }}"
         files:
           - "{{ dest_boot_loader_conf[1:] }}"
-      environment:
-        PYTHONPATH: "{{ pycdlib_patch_dir }}:{{ lookup('env', 'PYTHONPATH') }}"
+      environment: "{{ pycdlib_patch_env }}"
 
     - name: "Add kern.kstack_pages option in FreeBSD boot loader"
       ansible.builtin.lineinfile:
@@ -77,5 +100,4 @@
     src_iso: "{{ src_iso_file_path }}"
     dest_iso: "{{ rebuilt_unattend_iso_path }}"
     add_files: "{{ freebsd_iso_files }}"
-  environment:
-    PYTHONPATH: "{{ pycdlib_patch_dir }}:{{ lookup('env', 'PYTHONPATH') }}"
+  environment: "{{ pycdlib_patch_env }}"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -8,68 +8,17 @@
 #   src_iso_dir_path: Local path to the directory containing the source ISO image file.
 #
 
-- name: "Patch pycdlib and iso_customize for FreeBSD ISO duplicate name issue"
-  ansible.builtin.shell: |
-    {{ ansible_playbook_python }} -c "
-    import os, glob
-
-    try:
-        import pycdlib.dr
-        dr_paths = [pycdlib.dr.__file__]
-    except Exception:
-        dr_paths = []
-
-    dr_paths.extend(glob.glob('/usr/**/pycdlib/dr.py', recursive=True))
-    dr_paths.extend(glob.glob('/root/**/pycdlib/dr.py', recursive=True))
-    dr_paths.extend(glob.glob('/home/**/pycdlib/dr.py', recursive=True))
-
-    for path in set(dr_paths):
-        if path and os.path.exists(path):
-            try:
-                with open(path, 'r') as f:
-                    content = f.read()
-                content = content.replace(\"raise pycdlibexception.PyCdlibInvalidInput('Failed adding duplicate name to parent')\", 'pass')
-                content = content.replace('if not allow_duplicate:', 'if False:')
-                with open(path, 'w') as f:
-                    f.write(content)
-            except Exception:
-                pass
-
-    try:
-        import ansible_collections.community.general.plugins.modules.iso_customize as iso_mod
-        iso_paths = [iso_mod.__file__]
-    except Exception:
-        iso_paths = []
-
-    iso_paths.extend(glob.glob('/**/community/general/plugins/modules/iso_customize.py', recursive=True))
-
-    patch_code = '''
-try:
-    import pycdlib.dr
-    _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
-    def _tolerant_add_child(self, child, logical_block_size, allow_duplicate=True, *args, **kwargs):
-        try:
-            return _orig_add_child(self, child, logical_block_size, True, *args, **kwargs)
-        except Exception as e:
-            if \"duplicate name\" in str(e).lower():
-                return False
-            raise e
-    pycdlib.dr.DirectoryRecord._add_child = _tolerant_add_child
-except Exception:
-    pass
-'''
-    for path in set(iso_paths):
-        if path and os.path.exists(path):
-            try:
-                with open(path, 'r') as f:
-                    content = f.read()
-                if '_tolerant_add_child' not in content:
-                    content = content.replace('def iso_rebuild(', patch_code + '\ndef iso_rebuild(')
-                    with open(path, 'w') as f:
-                        f.write(content)
-            except Exception:
-                pass
-    "
+- name: "Patch pycdlib for FreeBSD ISO duplicate name issue"
+  ansible.builtin.shell:
+    cmd: >-
+      {{ ansible_playbook_python }} -c "
+      import pycdlib.dr;
+      p = pycdlib.dr.__file__;
+      s = open(p).read();
+      s = s.replace('raise pycdlibexception.PyCdlibInvalidInput(\'Failed adding duplicate name to parent\')', 'pass');
+      s = s.replace('if not allow_duplicate:', 'if False:');
+      open(p, 'w').write(s)
+      "
   changed_when: false
   ignore_errors: true
 

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -14,14 +14,14 @@
     freebsd_iso_version: "{{ (src_iso_file_path | basename | regex_search('(\\d+\\.\\d+)', '\\1'))[0] | default('0.0') }}"
 
 # Determine if pycdlib patch is required:
-# - FreeBSD 14.x: < 14.6
-# - FreeBSD 15.x: < 15.2
+# - FreeBSD 14.x: >= 14.0 and < 14.6
+# - FreeBSD 15.x: >= 15.1 and < 15.2 (FreeBSD 15.0 is excluded as it does not have duplicate directory record issue)
 - name: "Set fact whether pycdlib patch is required for FreeBSD ISO"
   ansible.builtin.set_fact:
     need_pycdlib_patch: >-
       {{
         (freebsd_iso_version is version('14.0', '>=') and freebsd_iso_version is version('14.6', '<')) or
-        (freebsd_iso_version is version('15.0', '>=') and freebsd_iso_version is version('15.2', '<'))
+        (freebsd_iso_version is version('15.1', '>=') and freebsd_iso_version is version('15.2', '<'))
       }}
 
 - name: "Set fact of pycdlib patch directory and environment"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -7,43 +7,63 @@
 #   src_iso_file_path: Local path to the source ISO image file
 #   src_iso_dir_path: Local path to the directory containing the source ISO image file.
 #
-- name: "Set fact of files to be updated in FreeBSD unattended install ISO"
+
+- name: "Set fact of temporary directory for extracted FreeBSD ISO contents"
   ansible.builtin.set_fact:
-    freebsd_iso_files:
-      - src_file: "{{ new_unattend_install_conf }}"
-        dest_file: "/etc/installerconfig"
+    extracted_freebsd_iso_dir: "{{ src_iso_dir_path }}/freebsd_iso_extracted"
 
-- name: "Update boot loader option for 32bit FreeBSD autoinstall"
-  when: "'64Guest' not in guest_id"
+- name: "Rebuild FreeBSD unattended install ISO block"
   block:
-    - name: "Set fact of boot loader config file path"
-      ansible.builtin.set_fact:
-        src_boot_loader_conf: "{{ src_iso_dir_path }}/loader.conf"
-        dest_boot_loader_conf: "/boot/loader.conf"
+    - name: "Create temporary directory for extracted FreeBSD ISO"
+      ansible.builtin.file:
+        path: "{{ extracted_freebsd_iso_dir }}"
+        state: directory
+        mode: '0755'
 
-    - name: "Extract boot loader config file in FreeBSD ISO"
-      community.general.iso_extract:
-        image: "{{ src_iso_file_path }}"
-        dest: "{{ src_iso_dir_path }}"
-        files:
-          - "{{ dest_boot_loader_conf[1:] }}"
+    - name: "Extract FreeBSD ISO using bsdtar"
+      ansible.builtin.command: >-
+        bsdtar -xf "{{ src_iso_file_path }}" -C "{{ extracted_freebsd_iso_dir }}"
+      changed_when: true
 
-    - name: "Add kern.kstack_pages option in FreeBSD boot loader"
+    - name: "Ensure extracted files and directories are writable"
+      ansible.builtin.command: >-
+        chmod -R u+w "{{ extracted_freebsd_iso_dir }}"
+      changed_when: true
+
+    - name: "Copy installerconfig to extracted FreeBSD ISO"
+      ansible.builtin.copy:
+        src: "{{ new_unattend_install_conf }}"
+        dest: "{{ extracted_freebsd_iso_dir }}/etc/installerconfig"
+        mode: '0644'
+
+    - name: "Update boot loader option for 32bit FreeBSD autoinstall"
       ansible.builtin.lineinfile:
-        path: "{{ src_boot_loader_conf }}"
+        path: "{{ extracted_freebsd_iso_dir }}/boot/loader.conf"
         line: 'kern.kstack_pages="8"'
+        create: true
+        mode: '0644'
+      when: "'64Guest' not in guest_id"
 
-    - name: "Update fact of files to be updated in FreeBSD unattended install ISO"
+    - name: "Check if EFI boot image exists in FreeBSD ISO"
+      ansible.builtin.stat:
+        path: "{{ extracted_freebsd_iso_dir }}/boot/efiboot.img"
+      register: freebsd_efiboot_img
+
+    - name: "Set xorriso boot options for FreeBSD ISO"
       ansible.builtin.set_fact:
-        freebsd_iso_files: >-
-          {{
-            freebsd_iso_files |
-            union([{'src_file': src_boot_loader_conf,
-                    'dest_file': dest_boot_loader_conf}])
-          }}
+        xorriso_boot_options: >-
+          -b boot/cdboot -no-emul-boot
+          {% if freebsd_efiboot_img.stat.exists %}-eltorito-alt-boot -e boot/efiboot.img -no-emul-boot{% endif %}
 
-- name: "Rebuild ISO image file for FreeBSD"
-  community.general.iso_customize:
-    src_iso: "{{ src_iso_file_path }}"
-    dest_iso: "{{ rebuilt_unattend_iso_path }}"
-    add_files: "{{ freebsd_iso_files }}"
+    - name: "Rebuild ISO image file for FreeBSD using xorriso"
+      ansible.builtin.command: >-
+        xorriso -as mkisofs -R -J -V "FREEBSD_INSTALL"
+        {{ xorriso_boot_options }}
+        -o "{{ rebuilt_unattend_iso_path }}"
+        "{{ extracted_freebsd_iso_dir }}"
+      changed_when: true
+  always:
+    - name: "Clean up extracted FreeBSD ISO directory"
+      ansible.builtin.file:
+        path: "{{ extracted_freebsd_iso_dir }}"
+        state: absent

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -8,62 +8,110 @@
 #   src_iso_dir_path: Local path to the directory containing the source ISO image file.
 #
 
-- name: "Set fact of temporary directory for extracted FreeBSD ISO contents"
+- name: "Patch pycdlib and iso_customize for FreeBSD ISO duplicate name issue"
+  ansible.builtin.shell: |
+    {{ ansible_playbook_python }} -c "
+    import os, glob
+
+    try:
+        import pycdlib.dr
+        dr_paths = [pycdlib.dr.__file__]
+    except Exception:
+        dr_paths = []
+
+    dr_paths.extend(glob.glob('/usr/**/pycdlib/dr.py', recursive=True))
+    dr_paths.extend(glob.glob('/root/**/pycdlib/dr.py', recursive=True))
+    dr_paths.extend(glob.glob('/home/**/pycdlib/dr.py', recursive=True))
+
+    for path in set(dr_paths):
+        if path and os.path.exists(path):
+            try:
+                with open(path, 'r') as f:
+                    content = f.read()
+                content = content.replace(\"raise pycdlibexception.PyCdlibInvalidInput('Failed adding duplicate name to parent')\", 'pass')
+                content = content.replace('if not allow_duplicate:', 'if False:')
+                with open(path, 'w') as f:
+                    f.write(content)
+            except Exception:
+                pass
+
+    try:
+        import ansible_collections.community.general.plugins.modules.iso_customize as iso_mod
+        iso_paths = [iso_mod.__file__]
+    except Exception:
+        iso_paths = []
+
+    iso_paths.extend(glob.glob('/**/community/general/plugins/modules/iso_customize.py', recursive=True))
+
+    patch_code = '''
+try:
+    import pycdlib.dr
+    _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
+    def _tolerant_add_child(self, child, logical_block_size, allow_duplicate=True, *args, **kwargs):
+        try:
+            return _orig_add_child(self, child, logical_block_size, True, *args, **kwargs)
+        except Exception as e:
+            if \"duplicate name\" in str(e).lower():
+                return False
+            raise e
+    pycdlib.dr.DirectoryRecord._add_child = _tolerant_add_child
+except Exception:
+    pass
+'''
+    for path in set(iso_paths):
+        if path and os.path.exists(path):
+            try:
+                with open(path, 'r') as f:
+                    content = f.read()
+                if '_tolerant_add_child' not in content:
+                    content = content.replace('def iso_rebuild(', patch_code + '\ndef iso_rebuild(')
+                    with open(path, 'w') as f:
+                        f.write(content)
+            except Exception:
+                pass
+    "
+  changed_when: false
+  ignore_errors: true
+
+- name: "Set fact of files to be updated in FreeBSD unattended install ISO"
   ansible.builtin.set_fact:
-    extracted_freebsd_iso_dir: "{{ src_iso_dir_path }}/freebsd_iso_extracted"
+    freebsd_iso_files:
+      - src_file: "{{ new_unattend_install_conf }}"
+        dest_file: "/etc/installerconfig"
 
-- name: "Rebuild FreeBSD unattended install ISO block"
+- name: "Update boot loader option for 32bit FreeBSD autoinstall"
+  when: "'64Guest' not in guest_id"
   block:
-    - name: "Create temporary directory for extracted FreeBSD ISO"
-      ansible.builtin.file:
-        path: "{{ extracted_freebsd_iso_dir }}"
-        state: directory
-        mode: '0755'
+    - name: "Set fact of boot loader config file path"
+      ansible.builtin.set_fact:
+        src_boot_loader_conf: "{{ src_iso_dir_path }}/loader.conf"
+        dest_boot_loader_conf: "/boot/loader.conf"
 
-    - name: "Extract FreeBSD ISO using xorriso"
-      ansible.builtin.command: >-
-        xorriso -osirrox on -indev "{{ src_iso_file_path }}" -extract / "{{ extracted_freebsd_iso_dir }}"
-      changed_when: true
+    - name: "Extract boot loader config file in FreeBSD ISO"
+      community.general.iso_extract:
+        image: "{{ src_iso_file_path }}"
+        dest: "{{ src_iso_dir_path }}"
+        files:
+          - "{{ dest_boot_loader_conf[1:] }}"
 
-    - name: "Ensure extracted files and directories are writable"
-      ansible.builtin.command: >-
-        chmod -R u+w "{{ extracted_freebsd_iso_dir }}"
-      changed_when: true
-
-    - name: "Copy installerconfig to extracted FreeBSD ISO"
-      ansible.builtin.copy:
-        src: "{{ new_unattend_install_conf }}"
-        dest: "{{ extracted_freebsd_iso_dir }}/etc/installerconfig"
-        mode: '0644'
-
-    - name: "Update boot loader option for 32bit FreeBSD autoinstall"
+    - name: "Add kern.kstack_pages option in FreeBSD boot loader"
       ansible.builtin.lineinfile:
-        path: "{{ extracted_freebsd_iso_dir }}/boot/loader.conf"
+        path: "{{ src_boot_loader_conf }}"
         line: 'kern.kstack_pages="8"'
         create: true
         mode: '0644'
-      when: "'64Guest' not in guest_id"
 
-    - name: "Check if EFI boot image exists in FreeBSD ISO"
-      ansible.builtin.stat:
-        path: "{{ extracted_freebsd_iso_dir }}/boot/efiboot.img"
-      register: freebsd_efiboot_img
-
-    - name: "Set xorriso boot options for FreeBSD ISO"
+    - name: "Update fact of files to be updated in FreeBSD unattended install ISO"
       ansible.builtin.set_fact:
-        xorriso_boot_options: >-
-          -b boot/cdboot -no-emul-boot
-          {% if freebsd_efiboot_img.stat.exists %}-eltorito-alt-boot -e boot/efiboot.img -no-emul-boot{% endif %}
+        freebsd_iso_files: >-
+          {{
+            freebsd_iso_files |
+            union([{'src_file': src_boot_loader_conf,
+                    'dest_file': dest_boot_loader_conf}])
+          }}
 
-    - name: "Rebuild ISO image file for FreeBSD using xorriso"
-      ansible.builtin.command: >-
-        xorriso -as mkisofs -R -J -V "FREEBSD_INSTALL"
-        {{ xorriso_boot_options }}
-        -o "{{ rebuilt_unattend_iso_path }}"
-        "{{ extracted_freebsd_iso_dir }}"
-      changed_when: true
-  always:
-    - name: "Clean up extracted FreeBSD ISO directory"
-      ansible.builtin.file:
-        path: "{{ extracted_freebsd_iso_dir }}"
-        state: absent
+- name: "Rebuild ISO image file for FreeBSD"
+  community.general.iso_customize:
+    src_iso: "{{ src_iso_file_path }}"
+    dest_iso: "{{ rebuilt_unattend_iso_path }}"
+    add_files: "{{ freebsd_iso_files }}"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -24,19 +24,15 @@
         (freebsd_iso_version is version('15.1', '>=') and freebsd_iso_version is version('15.2', '<'))
       }}
 
-- name: "Set fact of pycdlib patch directory and environment"
-  ansible.builtin.set_fact:
-    pycdlib_patch_dir: "{{ src_iso_dir_path }}/pycdlib_patch"
-    pycdlib_patch_env: >-
-      {{
-        {'PYTHONPATH': (src_iso_dir_path + '/pycdlib_patch:' + lookup('env', 'PYTHONPATH'))}
-        if need_pycdlib_patch
-        else {}
-      }}
-
 - name: "Create pycdlib patch for FreeBSD ISO duplicate name issue"
   when: need_pycdlib_patch
   block:
+    - name: "Set fact of pycdlib patch directory and environment"
+      ansible.builtin.set_fact:
+        pycdlib_patch_dir: "{{ src_iso_dir_path }}/pycdlib_patch"
+        pycdlib_patch_env:
+          PYTHONPATH: "{{ src_iso_dir_path }}/pycdlib_patch:{{ lookup('env', 'PYTHONPATH') }}"
+
     - name: "Create directory for pycdlib patch"
       ansible.builtin.file:
         path: "{{ pycdlib_patch_dir }}"
@@ -78,7 +74,7 @@
         dest: "{{ src_iso_dir_path }}"
         files:
           - "{{ dest_boot_loader_conf[1:] }}"
-      environment: "{{ pycdlib_patch_env }}"
+      environment: "{{ pycdlib_patch_env | default({}) }}"
 
     - name: "Add kern.kstack_pages option in FreeBSD boot loader"
       ansible.builtin.lineinfile:
@@ -101,4 +97,4 @@
     src_iso: "{{ src_iso_file_path }}"
     dest_iso: "{{ rebuilt_unattend_iso_path }}"
     add_files: "{{ freebsd_iso_files }}"
-  environment: "{{ pycdlib_patch_env }}"
+  environment: "{{ pycdlib_patch_env | default({}) }}"

--- a/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
+++ b/linux/deploy_vm/rebuild_freebsd_unattend_install_iso.yml
@@ -34,28 +34,29 @@
         else {}
       }}
 
-- name: "Create directory for pycdlib patch"
-  ansible.builtin.file:
-    path: "{{ pycdlib_patch_dir }}"
-    state: directory
-    mode: '0755'
+- name: "Create pycdlib patch for FreeBSD ISO duplicate name issue"
   when: need_pycdlib_patch
+  block:
+    - name: "Create directory for pycdlib patch"
+      ansible.builtin.file:
+        path: "{{ pycdlib_patch_dir }}"
+        state: directory
+        mode: '0755'
 
-- name: "Create sitecustomize.py to patch pycdlib for FreeBSD ISO duplicate name issue"
-  ansible.builtin.copy:
-    dest: "{{ pycdlib_patch_dir }}/sitecustomize.py"
-    mode: '0644'
-    content: |
-      try:
-          import pycdlib.dr
-          _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
-          def _patched_add_child(self, child, logical_block_size, allow_duplicate=False, *args, **kwargs):
-              kwargs.pop('allow_duplicate', None)
-              return _orig_add_child(self, child, logical_block_size, True, *args, **kwargs)
-          pycdlib.dr.DirectoryRecord._add_child = _patched_add_child
-      except Exception:
-          pass
-  when: need_pycdlib_patch
+    - name: "Create sitecustomize.py to patch pycdlib for FreeBSD ISO duplicate name issue"
+      ansible.builtin.copy:
+        dest: "{{ pycdlib_patch_dir }}/sitecustomize.py"
+        mode: '0644'
+        content: |
+          try:
+              import pycdlib.dr
+              _orig_add_child = pycdlib.dr.DirectoryRecord._add_child
+              def _patched_add_child(self, child, logical_block_size, allow_duplicate=False, *args, **kwargs):
+                  kwargs.pop('allow_duplicate', None)
+                  return _orig_add_child(self, child, logical_block_size, True, *args, **kwargs)
+              pycdlib.dr.DirectoryRecord._add_child = _patched_add_child
+          except Exception:
+              pass
 
 - name: "Set fact of files to be updated in FreeBSD unattended install ISO"
   ansible.builtin.set_fact:


### PR DESCRIPTION
Fixed FreeBSD 14.x and 15.x unattended ISO rebuild failures caused by pycdlib Rock Ridge duplicate directory record errors.

Test Done: yes