### PR TITLE
Fix package install failure on openSUSE Leap 16.1 due to glib2-devel dependency conflict

### DIFF
--- a/linux/utils/install_uninstall_package.yml
+++ b/linux/utils/install_uninstall_package.yml
@@ -134,6 +134,7 @@
       community.general.zypper:
         name: "{{ package_manage_list }}"
         state: "{{ package_state }}"
+        force_resolution: "{{ (guest_os_ansible_distribution == 'openSUSE Leap' and guest_os_ansible_distribution_ver == '16.1') | bool }}"
       delegate_to: "{{ vm_guest_ip }}"
       when: guest_os_family == "Suse"
 


### PR DESCRIPTION
The base installation image of openSUSE Leap 16.1 has `glib2-tools 2.88.0` pre-installed, whereas the online OSS repository currently provides `glib2-devel 2.84.4`, which strictly requires `glib2-tools = 2.84.4`. In non-interactive mode (`--non-interactive`), Zypper aborts with return code `4` because it lacks permission to automatically downgrade `glib2-tools` to resolve the conflict.

Solutions:
 - Conditionally enable `force_resolution: true` in the `community.general.zypper` task under `linux/utils/install_uninstall_package.yml` specifically for `openSUSE Leap 16.1`.
- This allows Zypper to automatically accept the solver's downgrade recommendation and complete the dependency installation.

Testing Done: yes